### PR TITLE
Fix excessive EF invocations: add MCP config templates with mcp-remote recommendation

### DIFF
--- a/docs/guides/connect-agents.md
+++ b/docs/guides/connect-agents.md
@@ -42,6 +42,10 @@ client; you can also run both in parallel.
 
 > **Perplexity** does not support MCP and has no integration path at this time.
 
+> **Quick start with templates:** Copy-pasteable `.mcp.json` templates for each client are
+> available in [`examples/mcp-configs/`](../../examples/mcp-configs/). Pick the one for your
+> client, replace the placeholders, and you're connected.
+
 ---
 
 ## Prerequisites
@@ -278,7 +282,37 @@ npx supabase functions deploy cerefox-mcp
 
 ### Path A-Remote: Claude Code
 
-Claude Code supports Streamable HTTP MCP natively — no proxy needed.
+> **Recommended: use `mcp-remote` stdio bridge.** Claude Code's native Streamable HTTP
+> transport maintains an SSE connection that polls the Edge Function at ~5 GET requests/second
+> even when idle — burning ~130-198K invocations/day against your Supabase quota. Using
+> `mcp-remote` as a stdio bridge eliminates this overhead while keeping all functionality
+> intact. See [#7](https://github.com/tdebasis/cerefox/issues/7) for details.
+
+**Option 1 — `mcp-remote` (recommended):**
+
+Add to your project's `.mcp.json` (or copy
+[`examples/mcp-configs/claude-code-remote.json`](../../examples/mcp-configs/claude-code-remote.json)):
+
+```json
+{
+  "mcpServers": {
+    "cerefox": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://<your-project-ref>.supabase.co/functions/v1/cerefox-mcp",
+        "--header",
+        "Authorization: Bearer <your-anon-key>"
+      ]
+    }
+  }
+}
+```
+
+**Option 2 — native HTTP (higher Edge Function cost):**
+
+Claude Code also supports Streamable HTTP natively. This works but incurs significant idle
+invocation overhead (see warning above).
 
 ```bash
 claude mcp add --transport http cerefox \

--- a/examples/mcp-configs/README.md
+++ b/examples/mcp-configs/README.md
@@ -1,0 +1,53 @@
+# MCP Client Configuration Templates
+
+Copy the appropriate template into your project root as `.mcp.json` and replace the
+placeholders with your Supabase project values.
+
+## Which template to use
+
+| Template | Client | Transport | Notes |
+|----------|--------|-----------|-------|
+| `claude-code-remote.json` | Claude Code | stdio via `mcp-remote` | **Recommended for Claude Code.** Avoids SSE polling overhead (see below). |
+| `claude-desktop-remote.json` | Claude Desktop | stdio via `supergateway` | Required — Claude Desktop needs a local subprocess. |
+| `cursor-remote.json` | Cursor | native HTTP | Cursor supports remote MCP natively. |
+| `local-stdio.json` | Any stdio client | stdio via `uv` | Runs the MCP server locally. Zero Edge Function cost. Requires Python + uv + local clone. |
+
+## Setup
+
+1. Copy the template for your client:
+   ```bash
+   cp examples/mcp-configs/claude-code-remote.json /path/to/your/project/.mcp.json
+   ```
+
+2. Replace the placeholders:
+   - `<your-project-ref>` — your Supabase project reference (from Project Settings > General)
+   - `<your-anon-key>` — your Supabase anon/public key (from Project Settings > API)
+   - `/path/to/cerefox` — (local-stdio only) absolute path to your cerefox clone
+
+3. Restart your MCP client.
+
+## Why `mcp-remote` for Claude Code?
+
+Claude Code's native Streamable HTTP transport maintains an SSE (Server-Sent Events)
+connection that generates continuous GET polling at ~5 requests/second — even when idle.
+This burns through Supabase Edge Function invocations at ~130-198K/day, quickly exhausting
+the 2M/month Pro Plan quota.
+
+The `mcp-remote` stdio bridge wraps the HTTP endpoint in a local process, eliminating the
+SSE polling entirely. Actual tool calls still reach the Edge Function as expected — only the
+idle overhead is removed.
+
+See [#7](https://github.com/tdebasis/cerefox/issues/7) for the full investigation and
+verification results.
+
+### Why not `mcp-remote` for Claude Desktop?
+
+`mcp-remote` 0.1.x performs OAuth discovery at the Supabase root domain, which fails when
+Supabase's built-in auth (GoTrue) rejects dynamic client registration. `supergateway` does
+not attempt OAuth — it connects directly with the Bearer token. This issue does not affect
+Claude Code, where `mcp-remote --header` works correctly.
+
+## More information
+
+See [docs/guides/connect-agents.md](../../docs/guides/connect-agents.md) for the full
+integration guide covering all access paths, prerequisites, and troubleshooting.

--- a/examples/mcp-configs/claude-code-remote.json
+++ b/examples/mcp-configs/claude-code-remote.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "cerefox": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://<your-project-ref>.supabase.co/functions/v1/cerefox-mcp",
+        "--header",
+        "Authorization: Bearer <your-anon-key>"
+      ]
+    }
+  }
+}

--- a/examples/mcp-configs/claude-desktop-remote.json
+++ b/examples/mcp-configs/claude-desktop-remote.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "cerefox": {
+      "command": "npx",
+      "args": [
+        "-y", "supergateway",
+        "--streamableHttp", "https://<your-project-ref>.supabase.co/functions/v1/cerefox-mcp",
+        "--oauth2Bearer", "<your-anon-key>"
+      ]
+    }
+  }
+}

--- a/examples/mcp-configs/cursor-remote.json
+++ b/examples/mcp-configs/cursor-remote.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "cerefox": {
+      "url": "https://<your-project-ref>.supabase.co/functions/v1/cerefox-mcp",
+      "headers": {
+        "Authorization": "Bearer <your-anon-key>"
+      }
+    }
+  }
+}

--- a/examples/mcp-configs/local-stdio.json
+++ b/examples/mcp-configs/local-stdio.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "cerefox": {
+      "command": "uv",
+      "args": ["--directory", "/path/to/cerefox", "run", "cerefox", "mcp"]
+    }
+  }
+}


### PR DESCRIPTION
## Problem

Claude Code's native Streamable HTTP MCP transport maintains an SSE (Server-Sent Events) connection to the `cerefox-mcp` Edge Function. This connection generates continuous HTTP GET polling at **~5 requests/second** — even when idle. With multiple agents connected, this burns **~130-198K Edge Function invocations/day** against Supabase's 2M/month Pro Plan quota.

Our `cerefox_usage_log` showed only 58 actual tool calls vs ~180K Supabase-counted invocations on the same day — an overhead ratio of ~3,000:1. 100% of invocations were GETs.

## Solution

Using `mcp-remote` as a stdio bridge instead of direct HTTP eliminates the polling entirely. After switching, idle invocations dropped from ~5/sec to zero. All MCP functionality remains intact.

This PR adds:
- `examples/mcp-configs/` with copy-pasteable `.mcp.json` templates for Claude Code, Claude Desktop, Cursor, and local stdio
- A README explaining which template to use, how to customize, and why `mcp-remote` matters
- Updates to `docs/guides/connect-agents.md` recommending `mcp-remote` for Claude Code with SSE polling warning

## Templates

| File | Client | Transport |
|------|--------|-----------|
| `claude-code-remote.json` | Claude Code | `mcp-remote` stdio (recommended) |
| `claude-desktop-remote.json` | Claude Desktop | `supergateway` stdio |
| `cursor-remote.json` | Cursor | native HTTP |
| `local-stdio.json` | Any client | local `uv run` stdio |

Related issue: #17