### PR TITLE
docs: Supabase 2026 key migration, connection pooling, Path C agents

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,25 +2,45 @@
 # Copy this file to .env and fill in your values.
 
 # ── Supabase (required for web UI and CLI) ────────────────────────────────────
+# See docs/guides/setup-supabase.md for screenshots and full walkthrough.
 CEREFOX_SUPABASE_URL=https://your-project-ref.supabase.co
-CEREFOX_SUPABASE_KEY=your-service-role-key
-# Anon key (JWT format, starts with eyJ...) — needed for Edge Function e2e tests.
-# Find it in: Supabase Dashboard → Settings → API → anon / public key
-# CEREFOX_SUPABASE_ANON_KEY=eyJ...your-anon-key...
 
-# ── Direct Postgres (required for db_deploy.py) ───────────────────────────────
-# Copy from: Supabase Dashboard → Settings → Database → Connection string
-# Two options depending on your network — uncomment the one that applies:
+# CEREFOX_SUPABASE_KEY — the key used by the Python web app and CLI to reach the
+# Supabase Data API (PostgREST). Two formats both work:
+#   - New "secret key" (recommended, starts with `sb_secret_`): Supabase Dashboard
+#     → Project Settings → API Keys → Secret key.
+#   - Legacy "service_role" JWT (starts with `eyJ...`): same panel, "Legacy" section.
+# Keep this value secret — it bypasses Row Level Security.
+CEREFOX_SUPABASE_KEY=sb_secret_...your-supabase-secret-key...
+
+# CEREFOX_SUPABASE_ANON_KEY — the key used as a Bearer token when calling Edge
+# Functions (MCP, GPT Actions, e2e tests, direct curl).
+# IMPORTANT: must currently be the **legacy anon JWT** (starts with `eyJ...`).
+# The new `sb_publishable_...` key is rejected by the Edge Function gateway with
+# `UNAUTHORIZED_INVALID_JWT_FORMAT`. This is a Supabase platform constraint, not
+# a Cerefox choice. Supabase has not announced an EOL for legacy keys.
+# Find it in: Supabase Dashboard → Project Settings → API Keys → Legacy → anon.
+# See docs/guides/setup-supabase.md → "Supabase API keys (2026)" for context.
+# CEREFOX_SUPABASE_ANON_KEY=eyJ...your-legacy-anon-jwt...
+
+# ── Direct Postgres (required for db_deploy.py / db_migrate.py / db_status.py) ─
+# This is for the Python deployment & status scripts only. The web app and CLI
+# do NOT use this connection — they go through the Data API above.
 #
-# Option A — Session pooler (IPv4, most home/office networks):
-#   Username must include the project ref (postgres.your-project-ref).
-#   If you omit it you will get "Tenant or user not found".
-#   Avoid the Transaction pooler (port 6543) — it does not support DDL.
-CEREFOX_DATABASE_URL=postgresql://postgres.your-project-ref:password@aws-0-region.pooler.supabase.com:5432/postgres
+# Use the **Session Pooler** (port 5432). The Transaction Pooler (port 6543)
+# does NOT support DDL and will fail mid-schema during `db_deploy.py`.
+# The Direct Connection is IPv6-only on the free tier and unusable on most
+# home/office networks.
 #
-# Option B — Direct connection (IPv6 networks only):
-#   If you get "nodename nor servname provided" use Option A instead.
-# CEREFOX_DATABASE_URL=postgresql://postgres:password@db.your-project-ref.supabase.co:5432/postgres
+# Finding the Session Pooler URI in 2026:
+#   - The new Supabase "Connect" dialog often surfaces only the Direct Connection
+#     and the Transaction Pooler. The Session Pooler may not be a first-class tab.
+#   - Either: take the Transaction Pooler URI and change `:6543` → `:5432`.
+#   - Or: open Project Settings → Database → Connection pooling.
+#   - The username must include the project-ref suffix (`postgres.<project-ref>`).
+#     Without the suffix you will get "Tenant or user not found".
+#   - Append `?sslmode=require` to enforce TLS explicitly.
+CEREFOX_DATABASE_URL=postgresql://postgres.your-project-ref:your-db-password@aws-N-region.pooler.supabase.com:5432/postgres?sslmode=require
 
 # ── Embeddings ────────────────────────────────────────────────────────────────
 # Embedder provider: "openai" (default) or "fireworks"

--- a/AGENT_GUIDE.md
+++ b/AGENT_GUIDE.md
@@ -1,6 +1,6 @@
 # How AI Agents Use Cerefox
 
-Reference guide for AI agents interacting with the Cerefox knowledge base via MCP tools.
+Reference guide for AI agents interacting with the Cerefox knowledge base.
 Read this before your first interaction. For a minimal quick reference, see `AGENT_QUICK_REFERENCE.md`.
 
 ---
@@ -11,7 +11,16 @@ Cerefox is a persistent, shared knowledge base that multiple AI agents can read 
 Knowledge written by one agent (or a human) is immediately searchable by any other agent.
 It is not a message bus -- it is curated, versioned, searchable memory backed by Postgres + pgvector.
 
-You interact with Cerefox through 8 MCP tools described below.
+## Two ways to interact with Cerefox
+
+You'll be using **one** of these — whichever your user (or the harness) has configured:
+
+1. **MCP tools (default)** — eight named tools (`cerefox_search`, `cerefox_ingest`, …) exposed by either a local MCP server (`cerefox mcp`) or the remote `cerefox-mcp` Edge Function. Tool names and parameters are documented in **The 8 Tools** below. This is the recommended path for purpose-built agent clients.
+2. **Shell CLI (Bash tool)** — the same operations exposed as a local `uv run cerefox …` command, invoked via your Bash tool. Used when your user prefers not to install/configure an MCP server. The semantics are identical; only the surface differs. See **Using Cerefox via the CLI** near the bottom of this guide for the MCP-tool → CLI-command mapping and the small list of behavioural differences.
+
+If you're not sure which mode you're in: check whether `cerefox_search` shows up in your tool list. If yes, use MCP. If no, ask your user where the Cerefox checkout lives — they'll have told you, typically in `CLAUDE.md`, `AGENTS.md`, or an equivalent project memory file.
+
+The rest of this guide is written around the MCP tool names, since those are stable across both modes. The CLI section maps each tool name to its CLI command.
 
 ---
 
@@ -228,3 +237,70 @@ Call `cerefox_list_metadata_keys` for the current list -- conventions evolve.
 - **Audit log**: all write operations are recorded with author, timestamp, and size changes.
 
 This is a human-on-the-loop model: agents write freely, humans monitor and correct.
+
+---
+
+## Using Cerefox via the CLI
+
+Read this section only if you do **not** have MCP tools available (no `cerefox_search` in your tool list) and your user has pointed you at a local Cerefox checkout. The semantics of every operation are identical to MCP — only the calling surface differs. The conventions above (when to search, when to ingest, metadata rules, ID-based update workflow, governance) all still apply.
+
+### Setup
+
+Your user will have told you where their Cerefox checkout lives (commonly `/Users/<name>/src/cerefox`, but check `CLAUDE.md` / `AGENTS.md` / project memory for the exact path). Run every command from that directory, or use `cd /path/to/cerefox && uv run cerefox …` in your Bash tool call.
+
+If a command fails with `command not found: cerefox`, run it as `uv run cerefox <subcommand>` (the project's `uv` environment provides the binary).
+
+### MCP tool ↔ CLI command mapping
+
+| MCP tool | CLI command |
+|---|---|
+| `cerefox_search(query, ...)` | `uv run cerefox search "<query>"`  (flags: `--mode hybrid\|fts\|semantic`, `--count N`, `--project <name>`, `--filter '<json>'`, `--min-score 0.X`) |
+| `cerefox_ingest(title, content, ...)` from a file | `uv run cerefox ingest <path>` (flags: `--title`, `--project <name>`, `--metadata '<json>'`, `--update`) |
+| `cerefox_ingest(title, content, ...)` from a string | `printf '%s' "<content>" \| uv run cerefox ingest --paste --title "<title>"` (same flags) |
+| `cerefox_get_document(document_id)` | `uv run cerefox get-doc <document-id>` |
+| `cerefox_list_versions(document_id)` | `uv run cerefox list-versions <document-id>` |
+| `cerefox_list_projects()` | `uv run cerefox list-projects` |
+| `cerefox_list_metadata_keys()` | `uv run cerefox list-metadata-keys` |
+| `cerefox_metadata_search(metadata_filter, ...)` | `uv run cerefox metadata-search --filter '<json>'` (flags: `--project <name>`, `--updated-since <iso>`, `--created-since <iso>`, `--limit N`, `--include-content`) |
+| `cerefox_get_audit_log(...)` | **No CLI equivalent today.** If you need audit-log data, tell your user — they can query via the web UI, the JSON API, or by installing the MCP server. |
+
+### Behavioural differences worth knowing
+
+1. **Author / requestor attribution is currently lossy.** Every CLI write today lands in the audit log with `author = "unknown"`, `author_type = "user"` regardless of what value you would set on an MCP `cerefox_ingest` call. Read commands record `requestor = "user"`. There is no `--author` / `--author-type` / `--requestor` flag yet — the work is tracked in [cerefox#28](https://github.com/fstamatelopoulos/cerefox/issues/28). Once that lands, agents on the CLI path should set `--author "<your-agent-name>" --author-type "agent"` on every write and `--requestor "<your-agent-name>"` on every read, exactly mirroring the MCP `author` / `requestor` rule. Until then, **mention this in your response to the user when ingesting** — they may want to manually attribute the write later, or use the MCP path for governance-sensitive entries.
+
+2. **CLI output is human-formatted, not JSON.** `cerefox search` returns a numbered, indented text block with title, score, and a 300-char preview per result. To extract document IDs reliably, parse the `Doc: <title>  (<source>)` lines or fall back to `cerefox list-docs` for a clean tabular listing. `cerefox get-doc <id>` prints raw Markdown to stdout, which you can read back like any other file.
+
+3. **No automatic `requestor` propagation.** With MCP, your tool framework passes `requestor` once per tool call. With the CLI, every invocation is independent — if `--requestor` ever lands (per #28), you'd pass it on every command. Until then, no action is possible.
+
+4. **Errors come back on stderr with a non-zero exit code.** Check both — a successful command prints results on stdout and exits 0; a failure prints to stderr and exits non-zero. Some CLI commands (notably `cerefox search`) currently have a known cosmetic bug where a Python traceback prints *after* successful results — the results themselves are correct, but exit code is non-zero. Tracked in [cerefox#27](https://github.com/fstamatelopoulos/cerefox/issues/27); when scripting against `cerefox search`, treat any results-shaped stdout as success even if exit code is non-zero, until the fix lands.
+
+### Quick patterns
+
+**Search before answering:**
+```bash
+uv run cerefox search "OAuth design notes" --count 5
+```
+
+**Search then read full content of a hit:**
+```bash
+uv run cerefox search "OAuth design" --count 3
+# Note the [n] entries. Pick one and grab the doc id from `list-docs` or the result preview.
+uv run cerefox get-doc <document-id>
+```
+
+**Ingest a note:**
+```bash
+printf '# Title\n\nBody markdown with H2s for chunking.\n' \
+  | uv run cerefox ingest --paste \
+      --title "Stable Title" \
+      --project "Cerefox" \
+      --metadata '{"type":"decision-log","status":"active"}'
+```
+
+**Update an existing document (title-based, fallback):**
+```bash
+printf '...new content...' \
+  | uv run cerefox ingest --paste --title "Exact Same Title" --update
+```
+
+**ID-based update is not yet exposed on the CLI** — `cerefox ingest` does not currently accept a `--document-id` flag the way `cerefox_ingest` accepts `document_id`. Use title-based update (with `--update`) for revisions, or use the MCP path when ID-based determinism matters.

--- a/AGENT_QUICK_REFERENCE.md
+++ b/AGENT_QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Cerefox Knowledge Base -- Agent Quick Reference
 
-Cerefox is a persistent, shared knowledge base. You have 8 MCP tools.
+Cerefox is a persistent, shared knowledge base. You have 8 MCP tools (or, if MCP isn't configured, the same 8 operations via the local CLI — see CLI section at the bottom).
 For the full guide, search Cerefox for "How AI Agents Use Cerefox".
 
 ## Tools
@@ -44,3 +44,20 @@ ingest(title="Same Title", content="...", update_if_exists=true, author="my-agen
 ```
 metadata_search(metadata_filter={"type": "decision-log"}, updated_since="2026-03-28T00:00:00Z")
 ```
+
+## CLI fallback (when MCP is unavailable)
+
+If `cerefox_search` is not in your tool list, your user has likely pointed you at a local Cerefox checkout. Use `uv run cerefox <subcommand>` via your Bash tool. Same operations, same conventions.
+
+| MCP tool | CLI |
+|---|---|
+| `cerefox_search` | `uv run cerefox search "<q>"` |
+| `cerefox_ingest` (paste) | `printf '...' \| uv run cerefox ingest --paste --title "<t>"` |
+| `cerefox_get_document` | `uv run cerefox get-doc <id>` |
+| `cerefox_list_versions` | `uv run cerefox list-versions <id>` |
+| `cerefox_list_projects` | `uv run cerefox list-projects` |
+| `cerefox_list_metadata_keys` | `uv run cerefox list-metadata-keys` |
+| `cerefox_metadata_search` | `uv run cerefox metadata-search --filter '<json>'` |
+| `cerefox_get_audit_log` | _no CLI equivalent yet_ |
+
+Caveats today (pending [cerefox#28](https://github.com/fstamatelopoulos/cerefox/issues/28)): CLI writes log `author = "unknown"`, reads log `requestor = "user"` — agent attribution is not yet pluggable on the CLI. See `AGENT_GUIDE.md` → "Using Cerefox via the CLI" for full details.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,112 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ---
 
+## [Unreleased]
+
+Documentation and process work to support the Supabase 2026 API key migration, the new
+"Path C" CLI-for-local-agents access pattern, and a set of follow-up tickets that will
+land code changes in subsequent releases.
+
+### Added
+- **Path C — Shell CLI for local coding agents** as a documented access path. Local
+  coding agents (Claude Code, OpenAI Codex CLI, opencode, OpenClaw, Hermes, etc.) can
+  read and write Cerefox by invoking `uv run cerefox …` via their Bash tool, instead of
+  configuring an MCP server. New top-level section in [`docs/guides/connect-agents.md`](docs/guides/connect-agents.md)
+  covering setup, system-prompt template, MCP-tool ↔ CLI-command mapping, verification
+  prompts, caveats (privilege level, audit attribution gap pending #28), and a per-agent
+  footprint table.
+- **AGENT_GUIDE.md** now opens with a "Two ways to interact with Cerefox" section
+  (MCP vs CLI) and ends with a "Using Cerefox via the CLI" section: full MCP-tool ↔
+  CLI-command mapping, behavioural differences (lossy attribution pending #28,
+  human-formatted output, exit-code quirks with #27), and quick-pattern recipes.
+- **AGENT_QUICK_REFERENCE.md** gains a "CLI fallback" section pointing at the new
+  mapping when MCP is not available.
+- **README.md** gains "Option 4 — Shell CLI for local coding agents" in the
+  "Connecting AI agents" section.
+- **[`docs/guides/setup-supabase.md`](docs/guides/setup-supabase.md)** gains two new canonical reference sections:
+  - "Supabase API keys (2026)" — explains the asymmetric Supabase key migration: the
+    new `sb_secret_…` key works for the Data API (`CEREFOX_SUPABASE_KEY`), but the
+    Edge Function gateway still requires the **legacy anon JWT** for Bearer auth
+    (`CEREFOX_SUPABASE_ANON_KEY`). The new `sb_publishable_…` key cannot replace
+    the legacy anon JWT today. Sources linked.
+  - "Connection pooling (2026)" — full reference for finding the Session Pooler URI
+    in the redesigned Supabase dashboard, the port-change shortcut from Transaction
+    Pooler to Session Pooler, username/sslmode requirements, and a common-errors
+    table.
+  All other Supabase-related docs (README, quickstart, configuration, access-paths,
+  connect-agents, e2e-use-cases, response-limits, upgrading, mcp-configs example,
+  CLAUDE.md, solution-design, research notes) link back to these two anchors instead
+  of repeating the explanation.
+
+### Changed
+- **All Supabase setup docs** updated for the 2026 key migration:
+  - `CEREFOX_SUPABASE_KEY` examples now use the new secret key (`sb_secret_…`);
+    legacy `service_role` JWT documented as still working.
+  - `CEREFOX_SUPABASE_ANON_KEY` instructions explicitly call for the **legacy anon
+    JWT** (`eyJ…`); explain that `sb_publishable_…` is rejected by the Edge Function
+    gateway with `UNAUTHORIZED_INVALID_JWT_FORMAT`.
+  - Files touched: [`.env.example`](.env.example), [`README.md`](README.md), [`CLAUDE.md`](CLAUDE.md), [`docs/guides/quickstart.md`](docs/guides/quickstart.md),
+    [`docs/guides/setup-supabase.md`](docs/guides/setup-supabase.md), [`docs/guides/configuration.md`](docs/guides/configuration.md),
+    [`docs/guides/access-paths.md`](docs/guides/access-paths.md), [`docs/guides/connect-agents.md`](docs/guides/connect-agents.md),
+    [`docs/guides/response-limits.md`](docs/guides/response-limits.md), [`docs/guides/upgrading.md`](docs/guides/upgrading.md),
+    [`docs/e2e-use-cases.md`](docs/e2e-use-cases.md), [`docs/examples/mcp-configs/README.md`](docs/examples/mcp-configs/README.md),
+    [`docs/solution-design.md`](docs/solution-design.md), `docs/research/gemini-integration.md`,
+    `docs/research/oauth-mcp-auth.md`.
+- **Connection pooling guidance** rewritten across all setup docs to reflect the
+  redesigned Supabase Connect dashboard: explicitly mandate the **Session Pooler**
+  (port `5432`), warn against the Transaction Pooler (`6543`, breaks DDL), document
+  the port-change shortcut from the Transaction Pooler URI, require the
+  `postgres.<project-ref>` username suffix, and recommend appending `?sslmode=require`.
+
+### Filed (pending implementation)
+The following tickets capture work that did **not** ship in this docs-only PR — they
+will be picked up one by one in subsequent releases. Each ticket includes a
+"Documentation to update when this ships" section so doc drift is prevented as the
+work lands.
+
+- [cerefox#26](https://github.com/fstamatelopoulos/cerefox/issues/26) — Add explicit
+  `GRANT` block to `schema.sql` for the Supabase Data API role-grants change rolling
+  out on 2026-05-30 (new projects) and 2026-10-30 (existing projects). Also tightens
+  `cerefox_audit_log` and `cerefox_document_versions` to `INSERT, SELECT` only at the
+  privilege level, enforcing the existing "append-only" comment as a real
+  immutability boundary.
+- [cerefox#27](https://github.com/fstamatelopoulos/cerefox/issues/27) — `cerefox
+  search` CLI raises `NameError: name 'project_id' is not defined` after rendering
+  results. One-word fix at [`src/cerefox/cli.py:400`](src/cerefox/cli.py:400). Note:
+  contributor [@reggaeguitar](https://github.com/reggaeguitar) independently caught
+  the same bug in PR #25 (which also fixes an `rpcs.sql` ordering issue that blocks
+  fresh deploys); if PR #25 merges, #27 can be closed as resolved.
+- [cerefox#28](https://github.com/fstamatelopoulos/cerefox/issues/28) — Add
+  `--author`, `--author-type`, and `--requestor` flags to the CLI for caller-identity
+  parity with the MCP and Edge Function paths. Amends the 2026-03-23
+  access-path-as-trust-signal decision for ambiguous channels (CLI, Edge Functions).
+- [cerefox#29](https://github.com/fstamatelopoulos/cerefox/issues/29) — CLI parity
+  with MCP for `ingest`: add `--document-id` (enables the *preferred* ID-based update
+  workflow), `--source`, and `--metadata` on `ingest-dir`.
+- [cerefox#30](https://github.com/fstamatelopoulos/cerefox/issues/30) — Add
+  `cerefox get-audit-log` CLI command. Last remaining MCP-tool ↔ CLI-command
+  parity gap.
+- [cerefox#31](https://github.com/fstamatelopoulos/cerefox/issues/31) — Add
+  [`docs/guides/cli.md`](docs/guides/cli.md) — comprehensive CLI reference. Scheduled
+  intentionally **after** #28/#29/#30 so it documents the final CLI surface.
+
+### Decision-log entries (in Cerefox knowledge base, not the repo)
+- 2026-05-18 — "CLI gains caller-set author / author_type / requestor; amend the
+  2026-03-23 access-path principle for ambiguous channels". Captures the rationale
+  for #28.
+- 2026-05-18 — "Supabase API key migration is asymmetric: Data API yes, Edge
+  Functions no". Captures the empirical findings behind the Supabase API key docs
+  updates, the deprecation timeline (none announced), the future plan for replacing
+  the legacy anon JWT (`verify_jwt = false` + in-function validation), and the
+  trigger conditions for that future work.
+- 2026-05-18 — "Supabase removing implicit role grants on public-schema tables".
+  Captures the rationale for #26.
+- Plus lessons-learned entries: install `uv` outside any venv; "Legacy" dashboard
+  label is misleading; Session Pooler vs Transaction Pooler; OpenAI keys per
+  machine.
+
+---
+
 ## [v0.1.16] -- 2026-05-03
 
 Documentation fixes and security fix for metadata search.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,8 +204,8 @@ Note: `cerefox-mcp` calls RPCs directly (no delegation to primitive Edge Functio
 
 Cerefox has three distinct access layers, each with its own credential:
 
-1. **AI agents / Edge Functions** — callers (MCP clients, GPT Actions, curl) use the **anon key** (JWT). The Supabase gateway validates it; Edge Functions then use `SUPABASE_SERVICE_ROLE_KEY` internally to call RPCs. Callers never see the service-role key.
-2. **Python web app & CLI** — `CerefoxClient` authenticates with the **service-role key** via the Supabase REST API. This bypasses RLS and gives unrestricted read/write access. Never expose this key to clients.
+1. **AI agents / Edge Functions** — callers (MCP clients, GPT Actions, curl) use the **legacy anon JWT** (`eyJ…`). The Supabase gateway validates it as a JWT; Edge Functions then use `SUPABASE_SERVICE_ROLE_KEY` internally to call RPCs. Callers never see the service-role key. **Important (2026):** the new `sb_publishable_…` API key cannot be used here — the Edge Function gateway rejects non-JWT keys. The Data API (Layer 2) accepts the new key system; the Edge Function gateway does not. See `docs/guides/setup-supabase.md` → "Supabase API keys (2026)" and the Decision Log 2026 Q2 entry for context.
+2. **Python web app & CLI** — `CerefoxClient` authenticates via the Supabase REST API using either the new **secret key** (`sb_secret_…`) or the legacy **service_role** JWT. Both are accepted and bypass RLS to grant unrestricted read/write access. Never expose this key to clients.
 3. **Deployment scripts only** — `db_deploy.py` / `db_migrate.py` connect directly to Postgres via psycopg2 using the **database password** (`CEREFOX_DATABASE_URL`). No application code uses this path at runtime.
 
 See `docs/guides/access-paths.md` for a full breakdown with credential sources and a summary table.
@@ -248,7 +248,7 @@ Business logic lives **only in Postgres RPCs** wherever feasible. If you need to
 
 | Client | How to connect | Notes |
 |---|---|---|
-| Claude Code | `claude mcp add --transport http cerefox <url> --header "Authorization: Bearer <anon-key>"` | Direct Streamable HTTP |
+| Claude Code | `claude mcp add --transport http cerefox <url> --header "Authorization: Bearer <legacy-anon-jwt>"` (legacy `eyJ…` only — see Layer 1 note above) | Direct Streamable HTTP |
 | Cursor | `url` + `headers.Authorization` in mcp.json | Same as Claude Code |
 | OpenAI Codex CLI | `url` + `bearer_token_env_var` in `~/.codex/config.toml` | Direct Streamable HTTP; TOML config; **tested, working** |
 | Gemini CLI | `httpUrl` + `headers` in `~/.gemini/settings.json` | Direct Streamable HTTP; **untested, expected to work** |

--- a/README.md
+++ b/README.md
@@ -89,16 +89,18 @@ Open `.env` and fill in these values:
 
 | Variable | Where to find it |
 |---|---|
-| `CEREFOX_SUPABASE_URL` | Supabase → Settings → API → Project URL |
-| `CEREFOX_SUPABASE_KEY` | Supabase → Settings → API → Secret keys → `default` |
-| `CEREFOX_DATABASE_URL` | Supabase → Settings → Database → Connection string → **Session pooler** (port 5432) |
+| `CEREFOX_SUPABASE_URL` | Supabase → Project Settings → API → Project URL |
+| `CEREFOX_SUPABASE_KEY` | Supabase → Project Settings → API Keys → **Secret key** (`sb_secret_…`). Legacy `service_role` JWT also works. |
+| `CEREFOX_DATABASE_URL` | Supabase → Project Settings → Database → **Connection pooling → Session Pooler** (port `5432`). See notes below. |
 | `OPENAI_API_KEY` | [platform.openai.com/api-keys](https://platform.openai.com/api-keys) |
+| `CEREFOX_SUPABASE_ANON_KEY` (only for Edge Functions / MCP / GPT Actions) | Supabase → Project Settings → API Keys → **Legacy → anon** (JWT, `eyJ…`). The new `sb_publishable_…` does **not** work for Edge Function Bearer auth. See [`docs/guides/setup-supabase.md` → Supabase API keys (2026)](docs/guides/setup-supabase.md#supabase-api-keys-2026). |
 
 **`CEREFOX_DATABASE_URL` notes:**
-- Use the **Session pooler** string (port 5432), not the Direct connection or Transaction pooler.
-- The username must include your project ref: `postgres.your-project-ref` — not just `postgres`.
-- Direct connection is IPv6 only on the free tier. If you get `nodename nor servname provided`, you are on IPv4 — use the Session pooler.
-- See `.env.example` for both URL formats with full explanations.
+- Use the **Session Pooler** (port `5432`), not the Transaction Pooler (`6543`, no DDL) or the Direct Connection (IPv6-only on free tier).
+- The Session Pooler may not be a first-class option in the new "Connect" dialog; either find it under **Connection pooling**, or take the Transaction Pooler URI and change `:6543` → `:5432`.
+- The username must include your project ref: `postgres.your-project-ref` — not just `postgres`. Without the suffix Supabase returns "Tenant or user not found".
+- Append `?sslmode=require` to enforce TLS.
+- Full reference: [`docs/guides/setup-supabase.md` → Connection pooling (2026)](docs/guides/setup-supabase.md#connection-pooling-2026).
 
 ### 4. Deploy the schema
 
@@ -168,7 +170,7 @@ Search RPCs (MCP tools): `cerefox_hybrid_search`, `cerefox_fts_search`,
 
 ## Connecting AI agents
 
-**Option 1 — Remote MCP (recommended)** — just a URL, an anon key, and `npx`:
+**Option 1 — Remote MCP (recommended)** — just a URL, a legacy anon JWT (Supabase → Project Settings → API Keys → **Legacy → anon**, not the new `sb_publishable_…` key — see [setup-supabase.md](docs/guides/setup-supabase.md#supabase-api-keys-2026)), and `npx`:
 
 The `cerefox-mcp` Supabase Edge Function speaks MCP Streamable HTTP. No Python, no local
 repo clone — works from any machine with Node.js installed.
@@ -218,6 +220,16 @@ as Bearer auth.
   }
 }
 ```
+
+**Option 4 — Shell CLI for local coding agents** — no MCP setup at all:
+
+Modern local coding agents (Claude Code, OpenAI Codex CLI, opencode, OpenClaw, Hermes, …)
+have a Bash tool. If you've already got Cerefox checked out and your `.env` configured for
+the CLI, you can simply point the agent at the repo path in its system prompt / project
+memory, and tell it to read `AGENT_GUIDE.md`. The agent reads and writes Cerefox by
+running `uv run cerefox …`. No `.mcp.json`, no `claude mcp add`, no Claude Desktop edit.
+Useful when you want one Cerefox checkout to serve any number of local agents in the
+same project with zero per-agent configuration.
 
 Full setup for all options: `docs/guides/connect-agents.md`
 

--- a/docs/e2e-use-cases.md
+++ b/docs/e2e-use-cases.md
@@ -22,7 +22,7 @@ after each run, even on failure.
 ## Configuration
 
 - **Supabase REST API tests**: Use credentials from `.env` (`CEREFOX_SUPABASE_URL`, `CEREFOX_SUPABASE_KEY`)
-- **Edge Function tests**: Need a JWT-format key. Set `CEREFOX_SUPABASE_ANON_KEY` in `.env` (the Supabase anon key from Dashboard > Settings > API). Skipped if not available.
+- **Edge Function tests**: Need a JWT-format key. Set `CEREFOX_SUPABASE_ANON_KEY` in `.env` — use the **legacy anon JWT** (Project Settings → API Keys → Legacy → anon). The new `sb_publishable_…` key fails at the Edge Function gateway. See [`docs/guides/setup-supabase.md` → Supabase API keys (2026)](guides/setup-supabase.md#supabase-api-keys-2026). Tests are skipped if `CEREFOX_SUPABASE_ANON_KEY` is not set.
 - **UI tests**: Require the web app running (`uv run uvicorn cerefox.api.app:app`) and frontend built (`cd frontend && npm run build`). Tests target the React SPA at `http://127.0.0.1:8000/app/`.
 
 ---

--- a/docs/examples/mcp-configs/README.md
+++ b/docs/examples/mcp-configs/README.md
@@ -21,7 +21,7 @@ placeholders with your Supabase project values.
 
 2. Replace the placeholders:
    - `<your-project-ref>` -- your Supabase project reference (from Project Settings > General)
-   - `<your-anon-key>` -- your Supabase anon/public key (from Project Settings > API)
+   - `<your-anon-key>` -- your Supabase **legacy anon JWT** (Project Settings > API Keys > Legacy > anon). Do **not** use the new `sb_publishable_…` key — Edge Function gateway rejects it. See [`docs/guides/setup-supabase.md` → Supabase API keys (2026)](../../guides/setup-supabase.md#supabase-api-keys-2026).
    - `/path/to/cerefox` -- (local-stdio only) absolute path to your cerefox clone
 
 3. Restart your MCP client.

--- a/docs/guides/access-paths.md
+++ b/docs/guides/access-paths.md
@@ -3,15 +3,27 @@
 Cerefox is built in three distinct layers. Understanding them tells you which credentials to
 configure, what can reach the database, and which path is right for your integration.
 
+> **A note on Supabase keys (2026):** Cerefox needs two API keys for two different transport
+> layers. Layer 1 (Edge Functions) uses the **legacy anon JWT** as a Bearer token — the new
+> `sb_publishable_…` key is rejected by the Edge Function gateway. Layer 2 (Python REST)
+> uses the new **secret key** (`sb_secret_…`) or the legacy `service_role` JWT — either
+> works. See [`setup-supabase.md` → Supabase API keys (2026)](setup-supabase.md#supabase-api-keys-2026)
+> for the full picture and why this asymmetry exists.
+
 ---
 
 ## Layer 1 — AI Agents via Edge Functions (HTTPS)
 
 This is the primary integration layer for AI clients. Six Supabase Edge Functions are
 deployed on the Supabase platform and are reachable over HTTPS with nothing more than the
-**anon key** (a public-facing JWT). The Supabase gateway validates the key before any
-request reaches a function; individual functions then use the service-role key internally to
-call Postgres RPCs. Your anon key is never elevated to database-level access.
+**legacy anon JWT** (a public-facing JWT, `eyJ…`). The Supabase gateway validates the key
+before any request reaches a function; individual functions then use the service-role key
+internally to call Postgres RPCs. Your anon key is never elevated to database-level access.
+
+> ⚠️ Use the **legacy anon JWT** here, not the new `sb_publishable_…` key. The Edge
+> Function gateway rejects non-JWT keys with `UNAUTHORIZED_INVALID_JWT_FORMAT`. See
+> [`setup-supabase.md` → Supabase API keys (2026)](setup-supabase.md#supabase-api-keys-2026)
+> for why.
 
 ### The six Edge Functions
 
@@ -54,7 +66,7 @@ same anon key as a Bearer token.
 ### Credentials needed
 
 - `CEREFOX_SUPABASE_URL` — your Supabase project URL
-- Anon key — found in your Supabase dashboard under **Project Settings → API → anon public**
+- **Legacy anon JWT** — found in your Supabase dashboard under **Project Settings → API Keys → Legacy → anon**. (Do not use the new `sb_publishable_…` key — gateway constraint.)
 
 See `docs/guides/connect-agents.md` for step-by-step setup per client.
 
@@ -65,12 +77,21 @@ See `docs/guides/connect-agents.md` for step-by-step setup per client.
 The FastAPI web app and all `cerefox` CLI commands (`ingest`, `search`, `reindex`,
 `backup`, etc.) use `CerefoxClient` (`src/cerefox/db/client.py`), a thin wrapper around
 `supabase-py`. This library talks to Supabase over its REST API (PostgREST), but
-authenticates with the **service-role key** rather than the anon key.
+authenticates with a **service-role-equivalent key** rather than the anon key — either
+the new **secret key** (`sb_secret_…`) or the legacy `service_role` JWT. Both are
+accepted by the Data API gateway.
 
 The service-role key bypasses Supabase Row Level Security (RLS) policies and grants
 unrestricted read and write access. This is intentional — the CLI and web app are trusted,
 local tools that need to insert, update, and delete freely. Keep this key out of any
 public-facing configuration.
+
+> **Local coding agents (Claude Code, Codex CLI, opencode, OpenClaw, Hermes, …) also reach
+> Cerefox through this layer**, when the user authorises the agent to invoke `uv run cerefox …`
+> via its Bash tool. This is "Path C" in `connect-agents.md`. The agent runs with the same
+> service-role privileges as the user — same trust assumption as letting the agent edit
+> source code in your repo. See `docs/guides/connect-agents.md` → "Path C — Shell CLI for
+> local coding agents" for the setup and caveats.
 
 ```
 Python web app / CLI (service-role key)
@@ -88,8 +109,7 @@ lives in one place (Postgres) and is shared across all callers.
 ### Credentials needed
 
 - `CEREFOX_SUPABASE_URL` — your Supabase project URL
-- `CEREFOX_SUPABASE_KEY` — the **service-role** key (not the anon key)
-  Found in **Project Settings → API → service_role secret**
+- `CEREFOX_SUPABASE_KEY` — the new **secret key** (`sb_secret_…`) from **Project Settings → API Keys → Secret key**, or the legacy `service_role` JWT from the "Legacy" section of the same panel. **Not** the anon / publishable key.
 
 ---
 
@@ -112,9 +132,12 @@ exclusively for schema deployment and data restore operations.
 
 ### Credentials needed
 
-- `CEREFOX_DATABASE_URL` — the direct Postgres connection string
-  Found in **Project Settings → Database → Connection string → URI** (use the
-  "Connection pooling" URI for Supabase; the direct URI for local Docker)
+- `CEREFOX_DATABASE_URL` — the direct Postgres connection string. **Use the Session
+  Pooler** (port `5432`) from **Project Settings → Database → Connection pooling**, with
+  username `postgres.<project-ref>` and `?sslmode=require` appended. Do not use the
+  Transaction Pooler (`6543`) — it does not support DDL. See [`setup-supabase.md` →
+  Connection pooling (2026)](setup-supabase.md#connection-pooling-2026) for the full
+  reference.
 
 ---
 
@@ -122,17 +145,19 @@ exclusively for schema deployment and data restore operations.
 
 | Caller | Transport | Auth credential | Typical use |
 |---|---|---|---|
-| Claude Code / Cursor | HTTPS → `cerefox-mcp` | Anon key | Daily AI assistant access |
-| Claude Desktop | HTTPS → `cerefox-mcp` (via `supergateway`) | Anon key | Daily AI assistant access |
-| ChatGPT Custom GPT | HTTPS → primitive Edge Functions | Anon key | AI assistant via GPT Actions |
-| curl / HTTP scripts | HTTPS → primitive Edge Functions | Anon key | Ad-hoc queries, automation |
-| Python web app | Supabase REST API | Service-role key | Web UI backend |
-| `cerefox` CLI | Supabase REST API | Service-role key | Ingestion, search, reindex, backup |
+| Claude Code / Cursor | HTTPS → `cerefox-mcp` | Legacy anon JWT | Daily AI assistant access |
+| Claude Desktop | HTTPS → `cerefox-mcp` (via `supergateway`) | Legacy anon JWT | Daily AI assistant access |
+| ChatGPT Custom GPT | HTTPS → primitive Edge Functions | Legacy anon JWT | AI assistant via GPT Actions |
+| curl / HTTP scripts | HTTPS → primitive Edge Functions | Legacy anon JWT | Ad-hoc queries, automation |
+| Python web app | Supabase REST API | Secret key (or legacy service_role) | Web UI backend |
+| `cerefox` CLI (human) | Supabase REST API | Secret key (or legacy service_role) | Ingestion, search, reindex, backup |
+| Local coding agent via `cerefox` CLI | Supabase REST API | Secret key (or legacy service_role) | User-authorised agent (Claude Code, Codex CLI, opencode, OpenClaw, Hermes, …) acting on user's behalf via Bash tool |
 | Deployment scripts | Direct TCP (psycopg2) | DB password | Schema deploy, data restore |
 
 ### Key security principle
 
-The anon key is safe to share with AI agents and client applications — it can only call
-the five operations exposed by the Edge Functions, and the Supabase gateway rate-limits
-and validates it. The service-role key and the database password must never be embedded
-in client-facing configuration or committed to the repository.
+The (legacy) anon JWT is safe to share with AI agents and client applications — it can
+only call the operations exposed by the Edge Functions, and the Supabase gateway
+rate-limits and validates it. The secret key / `service_role` JWT and the database
+password must never be embedded in client-facing configuration or committed to the
+repository.

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -14,8 +14,9 @@ cp .env.example .env
 | Variable | Default | Required | Description |
 |----------|---------|----------|-------------|
 | `CEREFOX_SUPABASE_URL` | `""` | For app | Supabase project URL. Found in: Project Settings → API → Project URL |
-| `CEREFOX_SUPABASE_KEY` | `""` | For app | Service role key. Found in: Project Settings → API → service_role key. **Keep secret.** |
-| `CEREFOX_DATABASE_URL` | `""` | For scripts | Direct Postgres connection URL. Found in: Project Settings → Database → Connection string (URI). Required for `db_deploy.py` and `db_status.py`. |
+| `CEREFOX_SUPABASE_KEY` | `""` | For app | New **secret key** (`sb_secret_…`) from Project Settings → API Keys → Secret key. Legacy `service_role` JWT also works. **Keep secret.** See [`setup-supabase.md` → Supabase API keys (2026)](setup-supabase.md#supabase-api-keys-2026). |
+| `CEREFOX_SUPABASE_ANON_KEY` | `""` | For Edge Functions / e2e | **Legacy anon JWT** (`eyJ…`), under "Legacy" in Project Settings → API Keys. Used as Bearer token for Edge Function / MCP / GPT Action calls. The new `sb_publishable_…` key fails at the Edge Function gateway and cannot replace this. See [`setup-supabase.md`](setup-supabase.md#supabase-api-keys-2026). |
+| `CEREFOX_DATABASE_URL` | `""` | For scripts | Direct Postgres URL for deployment scripts. **Use the Session Pooler** (port `5432`) — Transaction Pooler (`6543`) does not support DDL. Username must include the project-ref suffix (`postgres.<project-ref>`). Append `?sslmode=require`. See [`setup-supabase.md` → Connection pooling (2026)](setup-supabase.md#connection-pooling-2026). |
 
 **When each is needed:**
 - `CEREFOX_SUPABASE_URL` + `CEREFOX_SUPABASE_KEY` — used by the Python app (ingestion, search, CLI, web UI) via supabase-py
@@ -224,7 +225,7 @@ CEREFOX_SUPABASE_URL=https://abcdefghijkl.supabase.co
 CEREFOX_SUPABASE_KEY=eyJhbGciOiJIUzI1NiIs...
 
 # Required for scripts only
-CEREFOX_DATABASE_URL=postgresql://postgres.abcdefghijkl:MyPassword@aws-0-us-east-1.pooler.supabase.com:5432/postgres
+CEREFOX_DATABASE_URL=postgresql://postgres.abcdefghijkl:MyPassword@aws-1-us-east-1.pooler.supabase.com:5432/postgres?sslmode=require
 
 # Embeddings — OpenAI (default)
 OPENAI_API_KEY=sk-...

--- a/docs/guides/connect-agents.md
+++ b/docs/guides/connect-agents.md
@@ -21,6 +21,12 @@ client; you can also run both in parallel.
 
 ## Access paths at a glance
 
+Three top-level paths plus a few special cases:
+
+- **Path A** — MCP server (local subprocess or remote Edge Function). Best for purpose-built agent clients like Claude Desktop, Cursor, and Claude Code's MCP integration.
+- **Path B** — direct Edge Function HTTP. Best for ChatGPT Custom GPTs and any HTTP caller (curl, scripts).
+- **Path C** — local shell CLI invoked by a coding agent's Bash tool. Best for Claude Code, Codex CLI, opencode, OpenClaw, Hermes, and similar local-agent CLIs **when the user prefers not to configure MCP** but still wants the agent to read and write Cerefox.
+
 | Client | Path | Search | Requirements / caveats |
 |--------|------|--------|-----------------------|
 | Claude Desktop (remote) | Path A-Remote — `cerefox-mcp` Edge Function | Hybrid | Node.js for `npx supergateway` or `npx mcp-remote`; no Python needed |
@@ -33,6 +39,7 @@ client; you can also run both in parallel.
 | Cursor (local) | Path A-Local — `cerefox mcp` | Hybrid | Local alternative; Python + uv + local clone; zero Edge Function invocations |
 | Cloud Claude (claude.ai web) | Remote Supabase MCP | FTS only | No install; search quality limited |
 | Gemini CLI (remote) | Path A-Remote — `cerefox-mcp` Edge Function | Hybrid | URL + anon key only; no local install |
+| Local coding agents (Claude Code, Codex CLI, opencode, OpenClaw, Hermes, …) | Path C — Shell CLI (Bash tool) | Hybrid | Local clone + `uv`; agent runs `uv run cerefox …` as a shell command. Useful when MCP setup is friction. |
 | curl / scripts | Path B — Edge Functions directly | Hybrid | Direct HTTP; no client needed |
 | Custom Python agents | Python SDK directly | Hybrid | Local Python required |
 
@@ -66,9 +73,17 @@ client; you can also run both in parallel.
 - `.env` file configured with `CEREFOX_SUPABASE_URL`, `CEREFOX_SUPABASE_KEY`,
   and your embedding API key (`OPENAI_API_KEY`)
 
+> **Important — which anon key to use (2026):** Path A-Remote and Path B both require an
+> "anon key" as a Bearer token. As of 2026, you **must** use the **legacy anon JWT**
+> (`eyJ…`) — the new `sb_publishable_…` key is rejected by the Supabase Edge Function
+> gateway with `UNAUTHORIZED_INVALID_JWT_FORMAT`. Find the legacy key in **Project
+> Settings → API Keys → Legacy → anon**. This is a Supabase platform constraint;
+> see [`setup-supabase.md` → Supabase API keys (2026)](setup-supabase.md#supabase-api-keys-2026)
+> for the full story.
+
 **For Path A-Remote (remote MCP Edge Function) — recommended:**
 - `cerefox-mcp` Edge Function deployed (`npx supabase functions deploy cerefox-mcp`)
-- Your **anon key**: Supabase Dashboard → Project Settings → API → `anon public`
+- Your **legacy anon JWT** (see callout above): Supabase Dashboard → Project Settings → API Keys → Legacy → anon
 - For Claude Desktop: [Node.js](https://nodejs.org) installed (for `npx supergateway` or `npx mcp-remote`)
 - For Claude Code: [Node.js](https://nodejs.org) for `npx mcp-remote` (recommended), or no extra deps for native HTTP
 
@@ -77,7 +92,7 @@ client; you can also run both in parallel.
   `cerefox-get-document`, `cerefox-list-versions`, `cerefox-get-audit-log`,
   `cerefox-metadata-search`, `cerefox-list-projects` --
   see `setup-supabase.md` for the deploy procedure (`npx supabase functions deploy`)
-- Your **anon key**: Supabase Dashboard → Project Settings → API → `anon public`
+- Your **legacy anon JWT** (see callout above): Supabase Dashboard → Project Settings → API Keys → Legacy → anon
 - Your **project ref**: visible in the Supabase Dashboard URL
   (`app.supabase.com/project/<project-ref>`)
 
@@ -517,7 +532,7 @@ Authorization: Bearer <your-anon-key>
 Content-Type: application/json
 ```
 
-Find your anon key: **Supabase Dashboard → Project Settings → API → `anon public`**
+Find your anon key: **Supabase Dashboard → Project Settings → API Keys → Legacy → anon** (use the legacy JWT, not the new `sb_publishable_…` — see the API keys callout in the Prerequisites section).
 
 ### Path B system prompt
 
@@ -972,6 +987,118 @@ Claude.ai web can connect to the Supabase-hosted remote MCP (no local install):
 > **Limitation**: The cloud Supabase MCP only supports **FTS keyword search** — no hybrid or
 > semantic search. For full hybrid search from the web, deploy the MCP server to Cloud Run
 > (see `docs/TODO.md` → "Remote HTTP MCP server").
+
+---
+
+## Path C — Shell CLI for local coding agents
+
+### What it is
+
+Modern local coding agents — Claude Code, OpenAI Codex CLI, opencode, OpenClaw, Hermes, and many others — all expose a **Bash tool** (or similar shell-execution tool) to their underlying model. If the agent's user grants the agent access to a checked-out Cerefox repo, the agent can read and write the knowledge base by running `uv run cerefox …` exactly the same way a human would.
+
+This is **not a separate Cerefox installation path** — it's the same Layer 2 access (Python REST + service-role key) that you already use as a human via the CLI. What's new is the *usage model*: the user authorizes a local agent to use that CLI on their behalf, instead of (or alongside) configuring MCP.
+
+When to choose Path C over Path A:
+
+- **No MCP setup friction** — the agent already has a Bash tool; no `.mcp.json`, no `claude mcp add`, no Claude Desktop config edits.
+- **One Cerefox checkout serves any number of local agents** — Claude Code, Codex CLI, opencode, etc. running in the same project all use the same `uv run cerefox …` commands.
+- **Best for power users who already use the CLI themselves** — the agent and the user share one mental model and one set of conventions.
+
+When Path A is still better:
+
+- Cleaner agent UX — named tool calls (`cerefox_search(...)`) read better in agent transcripts than `Bash("uv run cerefox search 'foo'")`.
+- Some agents may rate-limit or budget Bash calls separately from MCP calls.
+- Cloud-only agents (claude.ai, chatgpt.com) cannot use Path C at all — they have no Bash tool.
+
+### Prerequisites
+
+Same as **Path A-Local**:
+
+- [`uv`](https://docs.astral.sh/uv/getting-started/installation/) installed on your machine
+- Cerefox repository cloned locally (e.g. `/Users/yourname/src/cerefox`)
+- `.env` configured with `CEREFOX_SUPABASE_URL`, `CEREFOX_SUPABASE_KEY` (service-role / new secret key), and your embedding API key (`OPENAI_API_KEY`)
+
+Quick sanity check before pointing an agent at it:
+
+```bash
+cd /path/to/cerefox
+uv run cerefox search "any query"
+uv run cerefox list-projects
+```
+
+If both work for you, they'll work for the agent.
+
+### How to enable it for an agent
+
+The pattern is the same across Claude Code, Codex CLI, opencode, OpenClaw, Hermes, and similar tools:
+
+1. **Tell the agent the Cerefox checkout path** (e.g. via system prompt, project memory, or your agent's equivalent of `CLAUDE.md`).
+2. **Point the agent at the agent docs** in that checkout: `AGENT_GUIDE.md` and `AGENT_QUICK_REFERENCE.md`. These already describe what to read, what to write, and the audit/metadata conventions. They cover MCP usage; the CLI mapping is in `AGENT_GUIDE.md` ("Using Cerefox via the CLI").
+3. **Optionally**: add a one-line reminder in the agent's system prompt so the model defaults to using Cerefox proactively.
+
+Example system-prompt snippet (adapt for your agent — Claude Code's `CLAUDE.md`, Codex's `AGENTS.md`, opencode's project config, etc.):
+
+```
+You have access to a personal Cerefox knowledge base via a local CLI.
+
+- Path: /path/to/cerefox  (cd here before running commands)
+- Run any command with: uv run cerefox <subcommand>
+- Read AGENT_GUIDE.md and AGENT_QUICK_REFERENCE.md in that directory for
+  conventions, metadata rules, and the MCP-tool → CLI-command mapping.
+
+When answering questions, search Cerefox first. When the user asks you to
+remember something, ingest it. Cite document titles for every claim drawn
+from the knowledge base.
+```
+
+### MCP tool ↔ CLI command mapping
+
+The agent docs are written around MCP tool names. Here is how each maps to a CLI command:
+
+| MCP tool | CLI command |
+|---|---|
+| `cerefox_search` | `uv run cerefox search "<query>"`  (flags: `--mode`, `--count`, `--project`, `--filter`, `--min-score`) |
+| `cerefox_ingest` (file) | `uv run cerefox ingest <path>` (flags: `--title`, `--project`, `--metadata`, `--update`) |
+| `cerefox_ingest` (paste) | `printf '...' \| uv run cerefox ingest --paste --title "<title>"` |
+| `cerefox_get_document` | `uv run cerefox get-doc <document-id>` |
+| `cerefox_list_versions` | `uv run cerefox list-versions <document-id>` |
+| `cerefox_list_projects` | `uv run cerefox list-projects` |
+| `cerefox_list_metadata_keys` | `uv run cerefox list-metadata-keys` |
+| `cerefox_metadata_search` | `uv run cerefox metadata-search --filter '<json>'` |
+| `cerefox_get_audit_log` | **No CLI equivalent today** — use MCP (Path A) or query the web UI / API |
+
+> The audit-log CLI gap is the only feature where Path C is strictly worse than Path A. If you need scripted audit-log access, use Path A or the JSON API.
+
+### Path C verification prompts
+
+After pointing your agent at the repo, ask it:
+
+> "Run a Cerefox search for 'second brain'. What did you find?"
+> Expected: agent runs `uv run cerefox search "second brain"` via its Bash tool and reports results.
+
+> "Save a note titled 'Test Note' to Cerefox with the content '# Test\nThis is a Path C test.'"
+> Expected: agent runs `cerefox ingest --paste --title "Test Note"` (or equivalent) and reports the new document ID.
+
+> "List my Cerefox projects."
+> Expected: agent runs `uv run cerefox list-projects`.
+
+### Caveats
+
+- **Privilege level**: the CLI uses the **service-role key** (`CEREFOX_SUPABASE_KEY`), which bypasses Row Level Security. An agent with Bash access has the same full read/write power you do. Only enable Path C for agents you trust to act on your behalf — the same trust level you'd grant Cursor/Claude Code for editing your source code.
+- **Audit attribution is currently limited**: today, every CLI write lands in the audit log with `author = "unknown"`, `author_type = "user"`, regardless of which agent issued the command. Read commands log `requestor = "user"`. Proper attribution flags (`--author`, `--author-type`, `--requestor`) are tracked in [cerefox#28](https://github.com/fstamatelopoulos/cerefox/issues/28). Until that lands, you cannot tell from the audit log whether a Path C entry came from you or from an agent acting on your behalf. The Decision Log (`2026 Q2`) records this gap and the planned fix.
+- **One repo per machine**: the agent needs your checkout — there's no "Path C without a local clone". If you skip the local install entirely, Path A-Remote or Path B is the only option.
+- **No sandboxing beyond the agent's existing Bash sandbox**: the CLI is just shell. If your agent's tool framework restricts which commands run, allowlist `uv run cerefox …` explicitly.
+
+### Path C is configuration-free, but here's the per-agent footprint
+
+| Agent | Where to mention the Cerefox path |
+|---|---|
+| Claude Code | `CLAUDE.md` in the project, or `~/.claude/CLAUDE.md` globally. No MCP entry needed. |
+| OpenAI Codex CLI | `AGENTS.md` or the project's instructions file. |
+| opencode | Project config / agent system prompt. |
+| OpenClaw, Hermes, custom local agents | Whatever the tool's system-prompt / memory mechanism is. |
+
+There is nothing Cerefox-specific to install for the agent itself — just the repo + your `.env`.
 
 ---
 

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -31,19 +31,20 @@ uv sync
 ## 3. Set up Supabase (5 min)
 
 1. Create a new Supabase project at [app.supabase.com](https://app.supabase.com).
-2. Go to **Settings > API** and copy:
-   - **Project URL** (looks like `https://abcd1234.supabase.co`)
-   - **service_role** key (under "Project API keys" -- use service_role, not anon)
-3. Go to **Settings > Database** and copy the **Connection string** (URI format).
+2. Go to **Project Settings → API → Project URL** and copy it. Also note your project ref (the slug in the URL, e.g. `abcd1234`).
+3. Go to **Project Settings → API Keys** and copy the **Secret key** (`sb_secret_…`). The legacy `service_role` JWT also works if you prefer; either goes into `CEREFOX_SUPABASE_KEY`. See [`setup-supabase.md` → Supabase API keys (2026)](setup-supabase.md#supabase-api-keys-2026) for the full key story (including why the anon key, if you ever need it, must currently stay as the legacy JWT — `sb_publishable_…` does not work for Edge Functions).
+4. Go to **Project Settings → Database → Connection pooling** and copy the **Session Pooler** URI (host ends `.pooler.supabase.com`, port `5432`). If you only see the Transaction Pooler in the dashboard, take that URI and change `:6543` → `:5432`. **Do not use port 6543** — Transaction Pooler does not support DDL. See [`setup-supabase.md` → Connection pooling (2026)](setup-supabase.md#connection-pooling-2026) for context.
 
 Create a `.env` file:
 
 ```env
 CEREFOX_SUPABASE_URL=https://your-project-ref.supabase.co
-CEREFOX_SUPABASE_KEY=your-service-role-key
-CEREFOX_DATABASE_URL=postgresql://postgres:password@db.your-project-ref.supabase.co:5432/postgres
+CEREFOX_SUPABASE_KEY=sb_secret_...your-supabase-secret-key...
+CEREFOX_DATABASE_URL=postgresql://postgres.your-project-ref:your-db-password@aws-N-region.pooler.supabase.com:5432/postgres?sslmode=require
 OPENAI_API_KEY=sk-...your-openai-key...
 ```
+
+The username must include the `.<project-ref>` suffix (e.g. `postgres.abcd1234`) — without it, Supabase returns "Tenant or user not found".
 
 ---
 

--- a/docs/guides/response-limits.md
+++ b/docs/guides/response-limits.md
@@ -95,7 +95,7 @@ JSON body field:
 
 ```http
 POST https://<project>.supabase.co/functions/v1/cerefox-search
-Authorization: Bearer <anon-key>
+Authorization: Bearer <legacy-anon-jwt>   # see docs/guides/setup-supabase.md#supabase-api-keys-2026
 Content-Type: application/json
 
 {

--- a/docs/guides/setup-supabase.md
+++ b/docs/guides/setup-supabase.md
@@ -36,24 +36,32 @@ The deploy script also runs `CREATE EXTENSION IF NOT EXISTS vector` automaticall
 
 ## Step 3 — Collect Your Credentials
 
-You need three values from Supabase. Find them as follows:
+You need three values from Supabase: a URL, an API key, and a direct Postgres connection string. The API-key panel and the connection-string panel both went through significant changes in 2026 — read the two reference sections below for the up-to-date guidance.
 
-### API URL and Service Role Key
-1. Go to **Project Settings → API**
-2. Copy:
-   - **Project URL** → `CEREFOX_SUPABASE_URL`
-   - **service_role** key (under "Project API keys") → `CEREFOX_SUPABASE_KEY`
+### 3a. API URL
+- **Project Settings → API → Project URL** → `CEREFOX_SUPABASE_URL`
 
-> ⚠️ Use the **service_role** key (not the anon key). The service role key bypasses Row Level Security and is needed for schema-level operations. Keep it secret — never commit it to git.
+### 3b. API key — `CEREFOX_SUPABASE_KEY`
 
-### Direct Database URL (for deployment scripts)
-1. Go to **Project Settings → Database**
-2. Under **Connection string**, select the **URI** tab
-3. Copy the connection string — it looks like:
-   ```
-   postgresql://postgres.PROJECTREF:PASSWORD@aws-0-REGION.pooler.supabase.com:5432/postgres
-   ```
-   Replace `[YOUR-PASSWORD]` with the password you set in Step 1.
+See the **[Supabase API keys (2026)](#supabase-api-keys-2026)** section near the end of this guide for the full picture. The short version:
+
+- For `CEREFOX_SUPABASE_KEY` (this guide, Python web app, CLI): use the new **secret key** (`sb_secret_…`) from **Project Settings → API Keys → Secret key**. The legacy `service_role` JWT also still works during the transition.
+- For `CEREFOX_SUPABASE_ANON_KEY` (only if you'll use Edge Functions / MCP / GPT Actions; not needed for this guide's deployment step): you must use the **legacy anon JWT** (`eyJ…`). The new `sb_publishable_…` key fails at the Edge Function gateway. See the reference section for why.
+
+Either way: keep this key secret — it bypasses Row Level Security and grants full database access.
+
+### 3c. Direct database URL — `CEREFOX_DATABASE_URL`
+
+This is used by `db_deploy.py`, `db_migrate.py`, and `db_status.py`. See the **[Connection pooling in 2026](#connection-pooling-2026)** reference section near the end of this guide for context. The short version:
+
+1. Open **Project Settings → Database → Connection pooling** (not the "Connect" dialog — that one usually omits the Session Pooler in the new UI).
+2. Copy the **Session Pooler** URI (host ends in `.pooler.supabase.com`, port `5432`).
+3. Confirm the username has the form `postgres.<project-ref>` — without that suffix you'll get "Tenant or user not found".
+4. Append `?sslmode=require` to enforce TLS explicitly.
+
+If you only see Direct Connection and Transaction Pooler in your dashboard, take the Transaction Pooler URI and change `:6543` → `:5432`. That gives you the Session Pooler. **Do not use port 6543** — Transaction Pooler does not support DDL and `db_deploy.py` will fail mid-schema.
+
+The Direct Connection (`db.<project-ref>.supabase.co:5432`) is IPv6-only on the free tier and unusable on most home/office networks. The dashboard now warns about this directly.
 
 ---
 
@@ -64,12 +72,15 @@ You need three values from Supabase. Find them as follows:
 cp .env.example .env
 ```
 
-Edit `.env` and fill in your three values:
+Edit `.env` and fill in your values. A minimal working configuration looks like:
 
 ```bash
 CEREFOX_SUPABASE_URL=https://your-project-ref.supabase.co
-CEREFOX_SUPABASE_KEY=eyJhbGc...your-service-role-key
-CEREFOX_DATABASE_URL=postgresql://postgres.yourref:yourpassword@aws-0-us-east-1.pooler.supabase.com:5432/postgres
+CEREFOX_SUPABASE_KEY=sb_secret_...your-secret-key...
+CEREFOX_DATABASE_URL=postgresql://postgres.yourref:yourpassword@aws-N-region.pooler.supabase.com:5432/postgres?sslmode=require
+# CEREFOX_SUPABASE_ANON_KEY only needed if you'll deploy Edge Functions (Step 8)
+# Must be the legacy anon JWT, NOT sb_publishable_... — see "Supabase API keys (2026)" below
+# CEREFOX_SUPABASE_ANON_KEY=eyJ...your-legacy-anon-jwt...
 ```
 
 Leave all other settings at their defaults for now.
@@ -272,8 +283,88 @@ architecture explanation, and ChatGPT GPT Actions setup.
 - Then re-run `python scripts/db_deploy.py`
 
 ### "permission denied for table"
-- Make sure you're using the **service_role** key, not the anon key
+- Make sure `CEREFOX_SUPABASE_KEY` is your secret key (`sb_secret_…`) or legacy `service_role` JWT — not the publishable / anon key. See [Supabase API keys (2026)](#supabase-api-keys-2026) below.
 
 ### Schema already exists (re-deploying)
 - All schema objects use `CREATE ... IF NOT EXISTS` / `CREATE OR REPLACE`, so re-running is safe
 - To start completely fresh: `python scripts/db_deploy.py --reset` (⚠️ deletes all data)
+
+---
+
+## Supabase API keys (2026) <a id="supabase-api-keys-2026"></a>
+
+In 2026 Supabase rolled out a new API key system. The dashboard now shows two key types side by side, and the migration is **asymmetric** — one half is fully migrated, the other is not. Cerefox needs values from both halves.
+
+### The two key families
+
+| Family | What you'll see in the dashboard | Use it for |
+|---|---|---|
+| **New (recommended)** | "Publishable key" (`sb_publishable_…`) and "Secret key" (`sb_secret_…`) | `CEREFOX_SUPABASE_KEY` — works end-to-end through the Data API. |
+| **Legacy** | "anon" and "service_role" JWTs (`eyJ…`), filed under a "Legacy" section | `CEREFOX_SUPABASE_ANON_KEY` — **still required** for any Edge Function call (MCP, GPT Actions, e2e tests, direct curl). |
+
+### What goes where in `.env`
+
+| Variable | Recommended value | Why |
+|---|---|---|
+| `CEREFOX_SUPABASE_KEY` | New **secret key** (`sb_secret_…`). Legacy `service_role` JWT also works. | Used by `db/client.py` to reach the Data API (PostgREST). Both formats are accepted by the gateway. |
+| `CEREFOX_SUPABASE_ANON_KEY` | **Legacy anon JWT** (`eyJ…`). | Used as the `Authorization: Bearer …` header for Edge Function calls. The Supabase Edge Function gateway still validates this token as a JWT — it parses `header.payload.signature` and rejects non-JWT keys with `UNAUTHORIZED_INVALID_JWT_FORMAT`. The new `sb_publishable_…` key is not a JWT and fails. |
+
+### Why we cannot just use the new keys everywhere
+
+The Data API gateway was migrated in 2026 to accept both the new and legacy key formats. The Edge Function gateway was not. A Supabase team member [confirmed this](https://github.com/orgs/supabase/discussions/41834): the only way to call Edge Functions with the new keys today is to deploy each function with `verify_jwt = false` and validate the key inside the function. Cerefox is not yet doing that (a future migration; see Decision Log 2026 Q2 for context and triggers).
+
+### Is the legacy key going away?
+
+Not yet. The Supabase docs explicitly state: *"You can still use old anon and service-role API keys after enabling the publishable and secret keys."* The "Legacy" label in the dashboard suggests deprecation, but **no end-of-life date has been published** as of May 2026. When Supabase announces one, Cerefox will migrate.
+
+### Sources
+
+- [Edge Function returning "JWT is invalid" after migrating to 2026 API Keys — supabase/discussions#41834](https://github.com/orgs/supabase/discussions/41834)
+- [Understanding API keys — Supabase Docs](https://supabase.com/docs/guides/api/api-keys)
+- [Securing Edge Functions — Supabase Docs](https://supabase.com/docs/guides/functions/auth)
+
+---
+
+## Connection pooling in 2026 <a id="connection-pooling-2026"></a>
+
+Supabase's "Connect" dialog was redesigned in 2026 and the **Session Pooler** is no longer a first-class tab in many projects. The other two surfaces (Direct Connection and Transaction Pooler) are present but neither works for Cerefox's deployment scripts. Here's the full picture.
+
+### The three Postgres connection types
+
+| Type | Host / port | DDL support | IPv4 compatible? | Use for Cerefox? |
+|---|---|---|---|---|
+| **Direct Connection** | `db.<project-ref>.supabase.co:5432` | ✓ | **IPv6 only on free tier.** Dashboard warns about this directly. | No — most networks can't reach it. |
+| **Transaction Pooler** | `aws-N-region.pooler.supabase.com:6543` (note port) | **✗ no DDL** | ✓ | No — `db_deploy.py` fails mid-schema. |
+| **Session Pooler** | `aws-N-region.pooler.supabase.com:5432` | ✓ | ✓ | **Yes — use this.** |
+
+The Transaction Pooler runs PgBouncer in transaction mode and does not maintain a session between statements, breaking DDL, prepared statements, `SET LOCAL`, and advisory locks. The Session Pooler is the same hostname on a different port and keeps a full session per connection.
+
+### Finding the Session Pooler URI
+
+Two reliable paths in the current dashboard:
+
+1. **Project Settings → Database → Connection pooling.** The Session Pooler URI is listed here.
+2. **Quick shortcut**: take whatever Transaction Pooler URI the "Connect" dialog shows you and change `:6543` → `:5432`. Same host, same username, just session mode instead of transaction mode.
+
+### Required pieces of the connection string
+
+- **Host**: `aws-N-region.pooler.supabase.com` (substituted by your project's region — e.g. `aws-1-us-east-1`).
+- **Port**: `5432` — **never `6543`** for Cerefox.
+- **Username**: `postgres.<project-ref>` — the `.<project-ref>` suffix is mandatory. Without it Supabase returns "Tenant or user not found".
+- **Password**: the database password set when you created the project (or rotated under Project Settings → Database). URL-encode special characters (`@` → `%40`, etc.) or pick a URL-safe password to avoid the gotcha.
+- **Query string**: append `?sslmode=require` to enforce TLS explicitly. Supabase enforces TLS server-side anyway; being explicit doesn't hurt.
+
+Final shape:
+
+```
+postgresql://postgres.<project-ref>:<password>@aws-N-<region>.pooler.supabase.com:5432/postgres?sslmode=require
+```
+
+### Common errors and what they mean
+
+| Error | Likely cause |
+|---|---|
+| `Tenant or user not found` | Username is missing the `.<project-ref>` suffix. |
+| `nodename nor servname provided` | You used the Direct Connection on an IPv4-only network. Switch to Session Pooler. |
+| `cannot create function ... transaction mode does not support ...` (or similar mid-schema failure) | You used the Transaction Pooler (port 6543). Switch to Session Pooler (port 5432). |
+| `password authentication failed` | Wrong password, or special characters not URL-encoded. Reset under Project Settings → Database. |

--- a/docs/guides/upgrading.md
+++ b/docs/guides/upgrading.md
@@ -192,6 +192,6 @@ If you use GPT Actions pointing at the Cerefox Edge Functions, **check the OpenA
 1. Open the Custom GPT editor and go to **Actions**
 2. Replace the OpenAPI schema with the latest version from `docs/guides/connect-agents.md`
 3. Save the schema
-4. **Re-enter the API key**: go to **Authentication** settings and re-enter your Supabase anon key as the Bearer token
+4. **Re-enter the API key**: go to **Authentication** settings and re-enter your Supabase **legacy anon JWT** (Project Settings → API Keys → Legacy → anon) as the Bearer token. The new `sb_publishable_…` key does not work for GPT Actions — see [`setup-supabase.md` → Supabase API keys (2026)](setup-supabase.md#supabase-api-keys-2026).
 
-**Known issue**: the ChatGPT editor clears the Bearer token (anon key) every time the OpenAPI schema is saved. This happens even if you only change whitespace. There is no workaround -- you must re-enter the key after every schema save.
+**Known issue**: the ChatGPT editor clears the Bearer token (legacy anon JWT) every time the OpenAPI schema is saved. This happens even if you only change whitespace. There is no workaround -- you must re-enter the key after every schema save.

--- a/docs/research/gemini-integration.md
+++ b/docs/research/gemini-integration.md
@@ -50,7 +50,7 @@ a personal Google account.
     "cerefox": {
       "httpUrl": "https://<project>.supabase.co/functions/v1/cerefox-mcp",
       "headers": {
-        "Authorization": "Bearer <supabase-anon-key>"
+        "Authorization": "Bearer <legacy-anon-jwt>"
       }
     }
   }

--- a/docs/research/oauth-mcp-auth.md
+++ b/docs/research/oauth-mcp-auth.md
@@ -253,7 +253,7 @@ user management not tool auth, and disproportionate for a single-user system.
 Perplexity Pro web UI → Settings → Custom connector → Remote:
 - Name: Cerefox
 - URL: `https://ljdznqldchupuohjcbti.supabase.co/functions/v1/cerefox-mcp`
-- Auth: API Key (anon key)
+- Auth: API Key (legacy anon JWT)
 - Transport: Streamable HTTP
 
 **Result**: Connection failed. The request never reached the `cerefox-mcp` Edge Function.

--- a/docs/solution-design.md
+++ b/docs/solution-design.md
@@ -1091,9 +1091,12 @@ DEFINER, service-role access). The Edge Function:
 2. Calls the Supabase client with the **service-role key** to execute the RPC
 3. Formats and returns the response as JSON
 
-Callers authenticate with the **anon key** (JWT validated by the Supabase API gateway).
-The service-role key is never exposed to callers -- it is read from `SUPABASE_SERVICE_ROLE_KEY`
-at runtime inside the Edge Function.
+Callers authenticate with the **legacy anon JWT** (validated as a JWT by the Supabase API
+gateway). As of 2026, the new `sb_publishable_…` key is not accepted here — the Edge
+Function gateway has not been migrated. See `docs/guides/setup-supabase.md` →
+"Supabase API keys (2026)" for context. The service-role-equivalent key (new `sb_secret_…`
+or legacy `service_role` JWT) is never exposed to callers -- it is read from
+`SUPABASE_SERVICE_ROLE_KEY` at runtime inside the Edge Function.
 
 **Single implementation principle**: each operation is implemented once in a Postgres RPC.
 Both the Python pipeline and the TypeScript Edge Functions call the same RPCs -- no parallel


### PR DESCRIPTION
## Summary

Documentation-only PR. Three intertwined threads, all surfaced during a fresh install on a new machine this session:

1. **Supabase 2026 API key migration is asymmetric.** The Data API gateway accepts the new `sb_secret_…` / `sb_publishable_…` keys, but the Edge Function gateway still requires the legacy JWT format and rejects non-JWT keys with `UNAUTHORIZED_INVALID_JWT_FORMAT`. This means `CEREFOX_SUPABASE_KEY` can move to the new secret key, but `CEREFOX_SUPABASE_ANON_KEY` must stay on the legacy anon JWT for Edge Function Bearer auth. Documented across every setup guide, with the canonical explanation in [`docs/guides/setup-supabase.md`](https://github.com/fstamatelopoulos/cerefox/blob/claude/angry-edison-7ebb66/docs/guides/setup-supabase.md#supabase-api-keys-2026) under a new "Supabase API keys (2026)" section. All other docs link there.

2. **Connection pooling in the redesigned Supabase Connect dashboard** often hides the Session Pooler, surfacing only Direct Connection (IPv6-only) and Transaction Pooler (port 6543, no DDL). Document the port-change shortcut (`:6543` → `:5432`), the mandatory `postgres.<project-ref>` username suffix, and `?sslmode=require`. Canonical reference in [`setup-supabase.md` under "Connection pooling (2026)"](https://github.com/fstamatelopoulos/cerefox/blob/claude/angry-edison-7ebb66/docs/guides/setup-supabase.md#connection-pooling-2026), including a common-errors table.

3. **Path C — Shell CLI for local coding agents.** Local coding agents (Claude Code, Codex CLI, opencode, OpenClaw, Hermes, …) increasingly invoke local CLIs via their Bash tool as an alternative to configuring MCP. New top-level section in [`connect-agents.md`](https://github.com/fstamatelopoulos/cerefox/blob/claude/angry-edison-7ebb66/docs/guides/connect-agents.md) covering setup, system-prompt template, MCP-tool ↔ CLI-command mapping, verification prompts, and caveats. [`AGENT_GUIDE.md`](https://github.com/fstamatelopoulos/cerefox/blob/claude/angry-edison-7ebb66/AGENT_GUIDE.md) gains a "Using Cerefox via the CLI" section; [`AGENT_QUICK_REFERENCE.md`](https://github.com/fstamatelopoulos/cerefox/blob/claude/angry-edison-7ebb66/AGENT_QUICK_REFERENCE.md) gains a CLI-fallback table; [`README.md`](https://github.com/fstamatelopoulos/cerefox/blob/claude/angry-edison-7ebb66/README.md) gains "Option 4".

[`CHANGELOG.md`](https://github.com/fstamatelopoulos/cerefox/blob/claude/angry-edison-7ebb66/CHANGELOG.md) gets an `[Unreleased]` section summarising all of the above plus the six follow-up tickets filed during the session — to be moved under the eventual version tag once those tickets land.

## Files changed

18 files, +570 / -91, all documentation:

- Setup-critical: [`.env.example`](https://github.com/fstamatelopoulos/cerefox/blob/claude/angry-edison-7ebb66/.env.example), [`docs/guides/setup-supabase.md`](https://github.com/fstamatelopoulos/cerefox/blob/claude/angry-edison-7ebb66/docs/guides/setup-supabase.md), [`docs/guides/quickstart.md`](https://github.com/fstamatelopoulos/cerefox/blob/claude/angry-edison-7ebb66/docs/guides/quickstart.md)
- High-traffic reference: [`docs/guides/configuration.md`](https://github.com/fstamatelopoulos/cerefox/blob/claude/angry-edison-7ebb66/docs/guides/configuration.md), [`docs/guides/access-paths.md`](https://github.com/fstamatelopoulos/cerefox/blob/claude/angry-edison-7ebb66/docs/guides/access-paths.md), [`docs/guides/connect-agents.md`](https://github.com/fstamatelopoulos/cerefox/blob/claude/angry-edison-7ebb66/docs/guides/connect-agents.md), [`README.md`](https://github.com/fstamatelopoulos/cerefox/blob/claude/angry-edison-7ebb66/README.md)
- Agent-facing: [`AGENT_GUIDE.md`](https://github.com/fstamatelopoulos/cerefox/blob/claude/angry-edison-7ebb66/AGENT_GUIDE.md), [`AGENT_QUICK_REFERENCE.md`](https://github.com/fstamatelopoulos/cerefox/blob/claude/angry-edison-7ebb66/AGENT_QUICK_REFERENCE.md)
- Lower-traffic: [`docs/guides/upgrading.md`](https://github.com/fstamatelopoulos/cerefox/blob/claude/angry-edison-7ebb66/docs/guides/upgrading.md), [`docs/guides/response-limits.md`](https://github.com/fstamatelopoulos/cerefox/blob/claude/angry-edison-7ebb66/docs/guides/response-limits.md), [`docs/e2e-use-cases.md`](https://github.com/fstamatelopoulos/cerefox/blob/claude/angry-edison-7ebb66/docs/e2e-use-cases.md), [`docs/examples/mcp-configs/README.md`](https://github.com/fstamatelopoulos/cerefox/blob/claude/angry-edison-7ebb66/docs/examples/mcp-configs/README.md)
- Internal/architectural: [`CLAUDE.md`](https://github.com/fstamatelopoulos/cerefox/blob/claude/angry-edison-7ebb66/CLAUDE.md), [`docs/solution-design.md`](https://github.com/fstamatelopoulos/cerefox/blob/claude/angry-edison-7ebb66/docs/solution-design.md), [`docs/research/gemini-integration.md`](https://github.com/fstamatelopoulos/cerefox/blob/claude/angry-edison-7ebb66/docs/research/gemini-integration.md), [`docs/research/oauth-mcp-auth.md`](https://github.com/fstamatelopoulos/cerefox/blob/claude/angry-edison-7ebb66/docs/research/oauth-mcp-auth.md)
- Release notes: [`CHANGELOG.md`](https://github.com/fstamatelopoulos/cerefox/blob/claude/angry-edison-7ebb66/CHANGELOG.md)

## Follow-up tickets (not in this PR)

This PR is documentation only. Code work surfaced during the session is tracked separately:

- [cerefox#26](https://github.com/fstamatelopoulos/cerefox/issues/26) — Add explicit GRANT block to schema.sql for the May/October 2026 Data API role-grants change
- [cerefox#27](https://github.com/fstamatelopoulos/cerefox/issues/27) — `cerefox search` NameError (may be resolved by [PR #25](https://github.com/fstamatelopoulos/cerefox/pull/25) from @reggaeguitar)
- [cerefox#28](https://github.com/fstamatelopoulos/cerefox/issues/28) — Add `--author`, `--author-type`, `--requestor` flags to the CLI for caller-identity parity
- [cerefox#29](https://github.com/fstamatelopoulos/cerefox/issues/29) — CLI ingest parity: `--document-id`, `--source`, `ingest-dir --metadata`
- [cerefox#30](https://github.com/fstamatelopoulos/cerefox/issues/30) — Add `cerefox get-audit-log` CLI command
- [cerefox#31](https://github.com/fstamatelopoulos/cerefox/issues/31) — Comprehensive [`docs/guides/cli.md`](docs/guides/cli.md) reference, written after #28/#29/#30 land

Each ticket has a "Documentation to update when this ships" section so the docs in this PR stay in sync as code lands.

## Test plan

- [ ] Render check: open each modified file in GitHub's preview and confirm formatting (tables, callouts, anchors).
- [ ] Anchor check: links to `setup-supabase.md#supabase-api-keys-2026` and `setup-supabase.md#connection-pooling-2026` resolve.
- [ ] Spot check fresh-install flow: a reader following [`quickstart.md`](https://github.com/fstamatelopoulos/cerefox/blob/claude/angry-edison-7ebb66/docs/guides/quickstart.md) end-to-end gets correct guidance for both API keys and the connection string.
- [ ] Run `uv run python scripts/sync_docs.py` after merge to push the updated content into the Cerefox knowledge base (already done locally; the doc text in the KB now matches this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)