### PR TITLE
Re-apply fresh-deploy bug fixes (originally #25 by @reggaeguitar)

### DIFF
--- a/src/cerefox/cli.py
+++ b/src/cerefox/cli.py
@@ -397,7 +397,7 @@ def search(
 
     client.log_usage(
         operation="search", access_path="cli", requestor="user",
-        query_text=query, project_id=project_id, result_count=len(resp.results),
+        query_text=query, project_id=project, result_count=len(resp.results),
     )
 
 

--- a/src/cerefox/db/rpcs.sql
+++ b/src/cerefox/db/rpcs.sql
@@ -458,6 +458,68 @@ BEGIN
 END;
 $$;
 
+-- ── cerefox_context_expand ────────────────────────────────────────────────────
+-- Small-to-big retrieval: given a set of chunk IDs from a search result,
+-- return those chunks plus their immediate neighbours (±window_size by
+-- chunk_index within the same document).  Use this after a chunk-level search
+-- to recover more surrounding context without fetching the full document.
+--
+-- Parameters:
+--   p_chunk_ids   : Array of chunk UUIDs from the search results
+--   p_window_size : Number of chunks to expand in each direction (default: 1)
+--
+-- Returns each expanded chunk with is_seed=TRUE for original results.
+
+CREATE OR REPLACE FUNCTION cerefox_context_expand(
+    p_chunk_ids   UUID[],
+    p_window_size INT DEFAULT 1
+)
+RETURNS TABLE (
+    chunk_id      UUID,
+    document_id   UUID,
+    chunk_index   INT,
+    title         TEXT,
+    content       TEXT,
+    heading_path  TEXT[],
+    heading_level INT,
+    doc_title     TEXT,
+    is_seed       BOOL
+)
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = public, pg_catalog
+AS $$
+    WITH seeds AS (
+        SELECT c.id, c.document_id, c.chunk_index
+        FROM cerefox_chunks c
+        WHERE c.id = ANY(p_chunk_ids)
+          AND c.version_id IS NULL
+    ),
+    expanded AS (
+        SELECT DISTINCT c.id
+        FROM cerefox_chunks c
+        JOIN seeds s ON c.document_id = s.document_id
+        WHERE c.version_id IS NULL
+          AND c.chunk_index BETWEEN s.chunk_index - p_window_size
+                                AND s.chunk_index + p_window_size
+    )
+    SELECT
+        c.id            AS chunk_id,
+        c.document_id,
+        c.chunk_index,
+        c.title,
+        c.content,
+        c.heading_path,
+        c.heading_level,
+        d.title         AS doc_title,
+        c.id = ANY(p_chunk_ids) AS is_seed
+    FROM expanded e
+    JOIN cerefox_chunks   c ON c.id = e.id
+    JOIN cerefox_documents d ON c.document_id = d.id
+    ORDER BY c.document_id, c.chunk_index;
+$$;
+
 -- ── cerefox_search_docs ───────────────────────────────────────────────────────
 -- Document-level hybrid search: runs hybrid search internally, deduplicates
 -- results by document (keeping the best-scoring chunk per document), and
@@ -642,68 +704,6 @@ AS $$
     JOIN doc_sizes ds ON ds.document_id = td.document_id
     JOIN all_content ac ON ac.document_id = td.document_id
     ORDER BY td.best_score DESC;
-$$;
-
--- ── cerefox_context_expand ────────────────────────────────────────────────────
--- Small-to-big retrieval: given a set of chunk IDs from a search result,
--- return those chunks plus their immediate neighbours (±window_size by
--- chunk_index within the same document).  Use this after a chunk-level search
--- to recover more surrounding context without fetching the full document.
---
--- Parameters:
---   p_chunk_ids   : Array of chunk UUIDs from the search results
---   p_window_size : Number of chunks to expand in each direction (default: 1)
---
--- Returns each expanded chunk with is_seed=TRUE for original results.
-
-CREATE OR REPLACE FUNCTION cerefox_context_expand(
-    p_chunk_ids   UUID[],
-    p_window_size INT DEFAULT 1
-)
-RETURNS TABLE (
-    chunk_id      UUID,
-    document_id   UUID,
-    chunk_index   INT,
-    title         TEXT,
-    content       TEXT,
-    heading_path  TEXT[],
-    heading_level INT,
-    doc_title     TEXT,
-    is_seed       BOOL
-)
-LANGUAGE sql
-SECURITY DEFINER
-STABLE
-SET search_path = public, pg_catalog
-AS $$
-    WITH seeds AS (
-        SELECT c.id, c.document_id, c.chunk_index
-        FROM cerefox_chunks c
-        WHERE c.id = ANY(p_chunk_ids)
-          AND c.version_id IS NULL
-    ),
-    expanded AS (
-        SELECT DISTINCT c.id
-        FROM cerefox_chunks c
-        JOIN seeds s ON c.document_id = s.document_id
-        WHERE c.version_id IS NULL
-          AND c.chunk_index BETWEEN s.chunk_index - p_window_size
-                                AND s.chunk_index + p_window_size
-    )
-    SELECT
-        c.id            AS chunk_id,
-        c.document_id,
-        c.chunk_index,
-        c.title,
-        c.content,
-        c.heading_path,
-        c.heading_level,
-        d.title         AS doc_title,
-        c.id = ANY(p_chunk_ids) AS is_seed
-    FROM expanded e
-    JOIN cerefox_chunks   c ON c.id = e.id
-    JOIN cerefox_documents d ON c.document_id = d.id
-    ORDER BY c.document_id, c.chunk_index;
 $$;
 
 -- ── Metadata key discovery RPC ───────────────────────────────────────────────


### PR DESCRIPTION
Re-applies the fix originally submitted by @reggaeguitar in #25.

## What and why

#25 was previously merged then reverted in #33. The revert removed the *changes* from `main`, so this PR re-applies them as a fresh commit cherry-picked from the original PR — same diff, original author email preserved on the commit (`Joe Brady <jbrady@grandtimber.com>`).

The two fixes (no changes vs. #25):

1. **`src/cerefox/db/rpcs.sql`** — reorder so `cerefox_context_expand` is defined before `cerefox_search_docs`. `cerefox_search_docs` is `LANGUAGE sql` and validates references at creation time, so a fresh `db_deploy.py` was failing with `function cerefox_context_expand does not exist`. Pure reordering — function bodies are byte-identical. Existing deployments are unaffected; only fresh installs were broken.

2. **`src/cerefox/cli.py:400`** — rename `project_id=project_id` to `project_id=project` in the `log_usage` call. `project_id` was undefined (the click parameter is named `project`), so every `cerefox search` raised `NameError` after printing results.

Closes #27.

## A note on Contributors-graph attribution (cc @reggaeguitar)

The original commit `fd66d1c` is in `main`'s history as a parent of merge commit `d8b26f7`, so per-commit authorship is already preserved in git. However, the GitHub Contributors graph still doesn't list @reggaeguitar — investigation showed that the commit's author email (`jbrady@grandtimber.com`) is not linked to your GitHub account. GitHub's commit API returns `github_user: null` for that commit, which is why the graph can't connect it to your `reggaeguitar` login.

**To get Contributors-graph credit on this and future contributions**, you can add `jbrady@grandtimber.com` (or whichever email you use for git commits) to your GitHub verified emails:

1. https://github.com/settings/emails
2. Add the email used in `git config user.email`
3. Verify it via the confirmation email
4. GitHub re-indexes commit→user mappings within a few hours; the graph then picks it up retroactively for all your past commits across all repos.

This is purely a GitHub UI thing — the commits and their author records on `main` are correct already.

## Merge instructions (for maintainer)

**Merge with "Rebase and merge" (not Squash)** — that's the point of this re-apply. The CLI equivalent is `gh pr merge <n> --rebase --delete-branch`. Squash-merging would re-author the resulting commit as the maintainer, undoing the credit work.

Co-authored-by: reggaeguitar <jbrady@grandtimber.com>