### PR TITLE
fix(ingest): preserve multi-project membership on content update (#38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,74 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
-Open roadmap. No new code yet — the next batch of work is being scoped:
+### Fixed
+
+- **[cerefox#38](https://github.com/fstamatelopoulos/cerefox/issues/38) —
+  `cerefox_ingest` no longer strips multi-project memberships on content
+  update.** Previously, a content update through the local Python MCP
+  with `update_if_exists: true` (or via the document_id update path) and a
+  single `project_name` destructively replaced the document's project
+  associations with just that one project — silently wiping any extra
+  memberships an operator added via the web UI. The two TS paths (remote
+  MCP and `cerefox-ingest` Edge Function) had a related but different bug:
+  they silently *ignored* `project_name` on update, so agents could neither
+  destroy memberships nor add them.
+  - **New contract for `project_name` on update (all three paths)**:
+    non-destructive add — "ensure this membership exists, leave others
+    alone." Idempotent if the doc is already in that project.
+  - **`project_ids: [...]`** (the Python-API list form, used by the web UI's
+    explicit `POST /documents/{id}/edit` endpoint) keeps its existing
+    full-set / destructive-replace semantics. Only the agent-facing
+    single-`project_name` path changed.
+  - **Implementation**:
+    - New `CerefoxClient.add_document_to_projects(doc_id, [pid…])` — the
+      non-destructive primitive. Idempotent. Computes the diff against
+      existing memberships and only inserts missing rows.
+    - `IngestionPipeline.ingest_text` no longer collapses single
+      `project_name`/`project_id` into a `project_ids=[uuid]` list when
+      taking an update branch. On update it passes `project_ids=None`
+      (preserving) and then calls the new non-destructive helper for any
+      singular project hint.
+    - Both Edge Functions (`cerefox-ingest/index.ts` and
+      `cerefox-mcp/tools/ingest.ts`) gain a shared
+      `ensureDocumentInProject(supabase, docId, projectName)` helper that
+      resolves the project (creating if absent), checks for existing
+      membership, and inserts only when missing. Called from both update
+      branches (id-based and title-based) and from the create path
+      (refactored for consistency).
+  - **Not implemented in this PR — proposed for follow-up**:
+    - `project_names: string[]` on `cerefox_ingest` for explicit full-set
+      semantics from the MCP layer (today the only way to get full-set
+      semantics is via the Python `project_ids` list or the web UI edit
+      form).
+    - Dedicated metadata-only tool `cerefox_set_document_projects` /
+      `cerefox_add_project` / `cerefox_remove_project` so agents have
+      first-class project-membership write surface independent of content
+      updates. The audit log already enumerates `update-metadata` as a
+      distinct operation type, so the data model is ready.
+  - **Tests**: 12 new unit tests under
+    `tests/ingestion/test_pipeline.py::TestMultiProjectPreservationOnUpdate`
+    + `TestAddDocumentToProjects`. All 495 unit + 80 e2e tests pass against
+    the newly deployed Edge Functions. Live repro against the maintainer's
+    Cerefox instance confirmed: doc that started in two projects survives
+    a content update via `cerefox_ingest` with `project_name="Cerefox"`
+    intact — both project filters return the doc afterwards.
+  - **⚠️ Edge Function redeploy required to pick up the TS fixes** (the
+    Python-side fix takes effect on `git pull` + restarting the local MCP
+    server):
+    ```bash
+    npx supabase functions deploy cerefox-ingest
+    npx supabase functions deploy cerefox-mcp
+    ```
+
+### Filed (carried forward, no new code)
 
 - [cerefox#26](https://github.com/fstamatelopoulos/cerefox/issues/26) —
   Supabase Data API role-grants change. Time-bound to the 2026-10-30
   rollout for existing projects.
 - [cerefox#36](https://github.com/fstamatelopoulos/cerefox/issues/36) —
   Cerefox installer + interactive bootstrap (cfcf-style UX). Design at
-  [`docs/research/installer-design.md`](docs/research/installer-design.md)
+  [`docs/research/polish-and-distribution-design.md`](docs/research/polish-and-distribution-design.md)
   on branch `research/installer-design`.
 - Iteration 18 — document relations & lifecycle metadata. Design at
   `docs/research/iteration-18-design.md` on branch `feat/document-relations`.

--- a/src/cerefox/db/client.py
+++ b/src/cerefox/db/client.py
@@ -476,6 +476,11 @@ class CerefoxClient:
 
         Deletes existing associations then inserts the new set.
         Pass an empty list to remove the document from all projects.
+
+        DESTRUCTIVE. Use ``add_document_to_projects`` for non-destructive
+        additions that preserve existing memberships (the right choice when
+        the caller is updating content and only intends to ensure one project
+        membership exists — see issue #38).
         """
         try:
             self.client.table("cerefox_document_projects").delete().eq(
@@ -487,6 +492,32 @@ class CerefoxClient:
         except Exception as exc:
             logger.error("assign_document_projects failed: %s", exc)
             raise RuntimeError(f"assign_document_projects failed: {exc}") from exc
+
+    def add_document_to_projects(self, document_id: str, project_ids: list[str]) -> None:
+        """Non-destructively add project memberships. Idempotent.
+
+        Inserts rows for any ``(document_id, project_id)`` pair not already
+        present. Existing memberships are preserved. Pass an empty list to
+        no-op.
+
+        This is the right primitive for content-update flows where a single
+        ``project_name`` was supplied: the intent is "ensure this membership
+        exists" not "set the full membership list". See ``assign_document_projects``
+        for the destructive replace path used by the web UI's explicit
+        project-edit form.
+        """
+        if not project_ids:
+            return
+        try:
+            existing = set(self.get_document_project_ids(document_id))
+            new_ids = [pid for pid in project_ids if pid and pid not in existing]
+            if not new_ids:
+                return  # All requested memberships already exist — idempotent
+            rows = [{"document_id": document_id, "project_id": pid} for pid in new_ids]
+            self.client.table("cerefox_document_projects").insert(rows).execute()
+        except Exception as exc:
+            logger.error("add_document_to_projects failed: %s", exc)
+            raise RuntimeError(f"add_document_to_projects failed: {exc}") from exc
 
     def get_projects_for_documents(
         self,

--- a/src/cerefox/ingestion/pipeline.py
+++ b/src/cerefox/ingestion/pipeline.py
@@ -134,21 +134,38 @@ class IngestionPipeline:
         # ── ID-based update (explicit document_id provided) ───────────────────
         # Bypasses title lookup and hash dedup -- the caller explicitly named
         # which document to update.  Errors if the document does not exist.
+        #
+        # Project semantics on update (per issue #38):
+        # - ``project_ids=[…]`` (an explicit list, even one-element): full-set
+        #   semantics — destructive replace. Used by the web UI's edit form.
+        # - ``project_name`` / ``project_id`` (singular): non-destructive add
+        #   — "ensure this membership exists, leave others alone." This is
+        #   the agent-facing path; agents must not be able to silently strip
+        #   project memberships an operator added via the web UI.
         if document_id is not None:
             existing_doc = self._client.get_document_by_id(document_id)
             if existing_doc is None:
                 raise ValueError(f"Document not found: {document_id}")
-            resolved_ids = self._resolve_project_ids(project_ids, project_id, project_name)
             result = self.update_document(
                 document_id=document_id,
                 text=text,
                 title=title,
                 source=source,
-                project_ids=resolved_ids if resolved_ids else None,
+                # Only the explicit list form propagates as a full-set replace.
+                # Singular project_name/project_id are handled non-destructively below.
+                project_ids=project_ids if project_ids is not None else None,
                 metadata=metadata,
                 author=author,
                 author_type=author_type,
             )
+            # Non-destructive add for singular project_name / project_id on update.
+            if project_ids is None and (project_id or project_name):
+                singular_resolved = self._resolve_project_ids(
+                    project_ids=None, project_id=project_id, project_name=project_name,
+                )
+                if singular_resolved:
+                    self._client.add_document_to_projects(document_id, singular_resolved)
+                    result.project_ids = self._client.get_document_project_ids(document_id)
             if not update_existing:
                 result.note = "document_id provided; update_if_exists flag was overridden"
             return result
@@ -167,17 +184,26 @@ class IngestionPipeline:
                     existing_doc["id"],
                     lookup_key,
                 )
-                resolved_ids = self._resolve_project_ids(project_ids, project_id, project_name)
-                return self.update_document(
+                # Same semantics as the document_id branch: explicit list = full set,
+                # singular project_name/project_id = non-destructive add (issue #38).
+                result = self.update_document(
                     document_id=existing_doc["id"],
                     text=text,
                     title=title,
                     source=source,
-                    project_ids=resolved_ids if resolved_ids else None,
+                    project_ids=project_ids if project_ids is not None else None,
                     metadata=metadata,
                     author=author,
                     author_type=author_type,
                 )
+                if project_ids is None and (project_id or project_name):
+                    singular_resolved = self._resolve_project_ids(
+                        project_ids=None, project_id=project_id, project_name=project_name,
+                    )
+                    if singular_resolved:
+                        self._client.add_document_to_projects(existing_doc["id"], singular_resolved)
+                        result.project_ids = self._client.get_document_project_ids(existing_doc["id"])
+                return result
             log.info("update_existing: no existing doc found — creating new document")
 
         # Resolve project_ids from the various caller styles.

--- a/supabase/functions/cerefox-ingest/index.ts
+++ b/supabase/functions/cerefox-ingest/index.ts
@@ -288,6 +288,62 @@ async function sha256hex(text: string): Promise<string> {
     .join("");
 }
 
+// ── Non-destructive project membership helper ─────────────────────────────
+//
+// Per issue #38: on UPDATE flows, passing project_name must not silently
+// strip existing memberships. Semantics:
+//   - Look up (or create) the project by name → project_id.
+//   - If (document_id, project_id) row already exists → no-op (idempotent).
+//   - Otherwise INSERT a new row, preserving all other existing memberships.
+//
+// Used by both update branches AND the create path so resolution is consistent.
+
+// deno-lint-ignore no-explicit-any
+async function ensureDocumentInProject(
+  // deno-lint-ignore no-explicit-any
+  supabase: any,
+  documentId: string,
+  projectName: string,
+): Promise<string | null> {
+  // Resolve project name → id (look up; create if absent).
+  let projectId: string | null = null;
+  const { data: proj } = await supabase
+    .from("cerefox_projects")
+    .select("id")
+    .ilike("name", projectName)
+    .limit(1);
+  if (proj?.length) {
+    projectId = proj[0].id;
+  } else {
+    const { data: newProj } = await supabase
+      .from("cerefox_projects")
+      .insert({ name: projectName })
+      .select("id");
+    projectId = newProj?.[0]?.id ?? null;
+  }
+  if (!projectId) return null;
+
+  // Check membership; INSERT only if missing. PRIMARY KEY (document_id, project_id)
+  // guarantees uniqueness, so this is safe under concurrent calls (worst case:
+  // one of two concurrent inserts fails with 23505 unique_violation — we log
+  // and treat as "already a member"; outcome is identical).
+  const { data: existing } = await supabase
+    .from("cerefox_document_projects")
+    .select("document_id")
+    .eq("document_id", documentId)
+    .eq("project_id", projectId)
+    .limit(1);
+  if (existing?.length) return projectId;  // Already a member — non-destructive
+
+  const { error: insertErr } = await supabase
+    .from("cerefox_document_projects")
+    .insert({ document_id: documentId, project_id: projectId });
+  if (insertErr && !String(insertErr.message ?? "").includes("duplicate key")) {
+    console.warn("ensureDocumentInProject: insert failed", insertErr);
+  }
+  return projectId;
+}
+
 // ── Main handler ───────────────────────────────────────────────────────────
 
 Deno.serve(async (req: Request) => {
@@ -453,6 +509,13 @@ Deno.serve(async (req: Request) => {
       p_result_count: chunks.length,
     })).catch(() => {});
 
+    // Non-destructive project membership add (issue #38). If project_name is
+    // provided on an update, ensure the document is in that project without
+    // touching existing memberships.
+    if (project_name) {
+      await ensureDocumentInProject(supabase, existingDoc.id, project_name);
+    }
+
     const note = update_if_exists ? undefined : "update_if_exists flag was overridden by document_id";
     return new Response(
       JSON.stringify({
@@ -553,6 +616,11 @@ Deno.serve(async (req: Request) => {
         p_result_count: chunks.length,
       })).catch(() => {});
 
+      // Non-destructive project membership add (issue #38).
+      if (project_name) {
+        await ensureDocumentInProject(supabase, existingDoc.id, project_name);
+      }
+
       return new Response(
         JSON.stringify({
           document_id: existingDoc.id,
@@ -642,30 +710,12 @@ Deno.serve(async (req: Request) => {
 
   const documentId = ingestResult[0].document_id;
 
-  // Resolve / create project if requested (separate from ingestion -- pure CRUD)
+  // Resolve / create project if requested (separate from ingestion -- pure CRUD).
+  // Uses the shared non-destructive helper so create + update paths behave
+  // identically with respect to membership semantics (issue #38).
   let projectId: string | null = null;
   if (project_name) {
-    const { data: proj } = await supabase
-      .from("cerefox_projects")
-      .select("id")
-      .ilike("name", project_name)
-      .limit(1);
-
-    if (proj?.length) {
-      projectId = proj[0].id;
-    } else {
-      const { data: newProj } = await supabase
-        .from("cerefox_projects")
-        .insert({ name: project_name })
-        .select("id");
-      projectId = newProj?.[0]?.id ?? null;
-    }
-
-    if (projectId) {
-      await supabase
-        .from("cerefox_document_projects")
-        .insert({ document_id: documentId, project_id: projectId });
-    }
+    projectId = await ensureDocumentInProject(supabase, documentId, project_name);
   }
 
   // Fire-and-forget usage logging for ingest

--- a/supabase/functions/cerefox-mcp/tools/ingest.ts
+++ b/supabase/functions/cerefox-mcp/tools/ingest.ts
@@ -193,6 +193,57 @@ async function sha256hex(text: string): Promise<string> {
     .join("");
 }
 
+// ── Non-destructive project membership helper ─────────────────────────────
+//
+// Per issue #38: on UPDATE flows, passing project_name must not silently
+// strip existing memberships. Semantics:
+//   - Look up (or create) the project by name → project_id.
+//   - If (document_id, project_id) row already exists → no-op (idempotent).
+//   - Otherwise INSERT a new row, preserving all other existing memberships.
+//
+// Used by both update branches AND the create path so resolution is consistent.
+
+// deno-lint-ignore no-explicit-any
+async function ensureDocumentInProject(
+  // deno-lint-ignore no-explicit-any
+  supabase: any,
+  documentId: string,
+  projectName: string,
+): Promise<string | null> {
+  let projectId: string | null = null;
+  const { data: proj } = await supabase
+    .from("cerefox_projects")
+    .select("id")
+    .ilike("name", projectName)
+    .limit(1);
+  if (proj?.length) {
+    projectId = proj[0].id;
+  } else {
+    const { data: newProj } = await supabase
+      .from("cerefox_projects")
+      .insert({ name: projectName })
+      .select("id");
+    projectId = newProj?.[0]?.id ?? null;
+  }
+  if (!projectId) return null;
+
+  const { data: existing } = await supabase
+    .from("cerefox_document_projects")
+    .select("document_id")
+    .eq("document_id", documentId)
+    .eq("project_id", projectId)
+    .limit(1);
+  if (existing?.length) return projectId;
+
+  const { error: insertErr } = await supabase
+    .from("cerefox_document_projects")
+    .insert({ document_id: documentId, project_id: projectId });
+  if (insertErr && !String(insertErr.message ?? "").includes("duplicate key")) {
+    console.warn("ensureDocumentInProject: insert failed", insertErr);
+  }
+  return projectId;
+}
+
 // ── Handler ────────────────────────────────────────────────────────────────
 
 export async function handleIngest(
@@ -283,6 +334,13 @@ export async function handleIngest(
       document_id: existingDoc.id, result_count: chunks.length,
     });
 
+    // Non-destructive project membership add (issue #38). If project_name is
+    // provided on an update, ensure the document is in that project without
+    // touching existing memberships.
+    if (project_name) {
+      await ensureDocumentInProject(supabase, existingDoc.id, project_name);
+    }
+
     const note = update_if_exists ? "" : " Note: update_if_exists flag was overridden by document_id.";
     return `Document updated: "${title}" (id: ${existingDoc.id}), ${chunks.length} chunk(s), ${totalChars} chars.${note}`;
   }
@@ -348,6 +406,11 @@ export async function handleIngest(
         document_id: existingDoc.id, result_count: chunks.length,
       });
 
+      // Non-destructive project membership add (issue #38).
+      if (project_name) {
+        await ensureDocumentInProject(supabase, existingDoc.id, project_name);
+      }
+
       return `Document updated: "${existingDoc.title}" (id: ${existingDoc.id}), ${chunks.length} chunk(s), ${totalChars} chars.`;
     }
     // No existing doc found -- fall through to create path
@@ -404,30 +467,11 @@ export async function handleIngest(
 
   const documentId = ingestResult[0].document_id;
 
-  // Resolve / create project if requested (pure CRUD, separate from ingestion)
+  // Resolve / create project if requested. Uses the shared non-destructive
+  // helper so create + update paths behave identically (issue #38).
   let projectId: string | null = null;
   if (project_name) {
-    const { data: proj } = await supabase
-      .from("cerefox_projects")
-      .select("id")
-      .ilike("name", project_name)
-      .limit(1);
-
-    if (proj?.length) {
-      projectId = proj[0].id;
-    } else {
-      const { data: newProj } = await supabase
-        .from("cerefox_projects")
-        .insert({ name: project_name })
-        .select("id");
-      projectId = newProj?.[0]?.id ?? null;
-    }
-
-    if (projectId) {
-      await supabase
-        .from("cerefox_document_projects")
-        .insert({ document_id: documentId, project_id: projectId });
-    }
+    projectId = await ensureDocumentInProject(supabase, documentId, project_name);
   }
 
   logUsage(supabase, {

--- a/tests/ingestion/test_pipeline.py
+++ b/tests/ingestion/test_pipeline.py
@@ -39,6 +39,7 @@ def mock_client() -> MagicMock:
     client.get_or_create_project.return_value = {"id": "proj-001", "name": "work"}
     client.get_document_project_ids.return_value = []
     client.assign_document_projects.return_value = None
+    client.add_document_to_projects.return_value = None
     # By default no metadata keys registered (validation passthrough)
     client.list_metadata_keys.return_value = []
     # Snapshot version (used by update path via RPC now, but mock for direct calls)
@@ -792,6 +793,276 @@ class TestUpdateExisting:
 
         assert result.document_id == "doc-existing"
         mock_client.ingest_document_rpc.assert_called_once()
+
+
+# ── Issue #38: multi-project preservation on update ───────────────────────────
+
+
+class TestMultiProjectPreservationOnUpdate:
+    """Issue #38 — content updates via cerefox_ingest must not strip project
+    memberships added by the human via the web UI.
+
+    Contract recap (from pipeline.update_document docstring + the issue):
+      • ``project_ids`` (an explicit list, even one-element) on update = full-set
+        semantics. Destructive replace. Used by the web UI's explicit edit form.
+      • ``project_name`` / ``project_id`` (singular) on update = non-destructive
+        add. "Ensure this membership exists, leave others alone." This is the
+        path agents use via ``cerefox_ingest``.
+
+    The bug was that ``ingest_text`` resolved the singular ``project_name`` into
+    a one-element list and handed it to ``update_document`` as if it were a
+    full-set replace. This test class locks down the correct behaviour.
+    """
+
+    @pytest.fixture()
+    def existing_doc(self) -> dict:
+        return {
+            "id": "doc-multi",
+            "title": "Multi-Project Note",
+            "content_hash": "oldhash",
+            "metadata": {},
+            "chunk_count": 1,
+            "total_chars": 50,
+            "source_path": "multi.md",
+        }
+
+    # ── document_id branch (explicit ID update) ──────────────────────────────
+
+    def test_document_id_update_with_project_name_does_not_assign(
+        self, pipeline, mock_client, mock_embedder, existing_doc
+    ) -> None:
+        """Singular project_name on document_id-update: assign_document_projects MUST NOT fire."""
+        mock_client.get_document_by_id.return_value = existing_doc
+        mock_client.get_document_by_hash.return_value = None
+        mock_client.update_document.return_value = existing_doc
+        mock_client.get_document_project_ids.return_value = ["proj-a", "proj-b"]
+        mock_client.get_or_create_project.return_value = {"id": "proj-a", "name": "Cerefox"}
+        mock_embedder.embed_batch.return_value = [[0.0] * 768]
+
+        pipeline.ingest_text(
+            "# T\n\nNew content.", title="Multi-Project Note",
+            document_id="doc-multi", project_name="Cerefox",
+        )
+
+        # The destructive primitive must not be called — that was the bug.
+        mock_client.assign_document_projects.assert_not_called()
+        # The non-destructive primitive should be called instead.
+        mock_client.add_document_to_projects.assert_called_once_with("doc-multi", ["proj-a"])
+
+    def test_document_id_update_with_project_name_preserves_other_memberships(
+        self, pipeline, mock_client, mock_embedder, existing_doc
+    ) -> None:
+        """The final result reports ALL memberships, not just the one passed in."""
+        mock_client.get_document_by_id.return_value = existing_doc
+        mock_client.get_document_by_hash.return_value = None
+        mock_client.update_document.return_value = existing_doc
+        # First call (inside update_document — but project_ids=None so unused);
+        # second call (after non-destructive add) returns the full set.
+        mock_client.get_document_project_ids.return_value = ["proj-a", "proj-b"]
+        mock_client.get_or_create_project.return_value = {"id": "proj-a", "name": "Cerefox"}
+        mock_embedder.embed_batch.return_value = [[0.0] * 768]
+
+        result = pipeline.ingest_text(
+            "# T\n\nNew content.", title="Multi-Project Note",
+            document_id="doc-multi", project_name="Cerefox",
+        )
+
+        # cfcf membership (proj-b) survived; both projects show in the result.
+        assert set(result.project_ids) == {"proj-a", "proj-b"}
+
+    def test_document_id_update_with_explicit_project_ids_list_is_destructive(
+        self, pipeline, mock_client, mock_embedder, existing_doc
+    ) -> None:
+        """Explicit project_ids list keeps destructive semantics — that's the web-UI contract."""
+        mock_client.get_document_by_id.return_value = existing_doc
+        mock_client.get_document_by_hash.return_value = None
+        mock_client.update_document.return_value = existing_doc
+        mock_client.get_document_project_ids.return_value = ["proj-a"]
+        mock_embedder.embed_batch.return_value = [[0.0] * 768]
+
+        pipeline.ingest_text(
+            "# T\n\nNew content.", title="Multi-Project Note",
+            document_id="doc-multi", project_ids=["proj-a"],
+        )
+
+        # Destructive: list form = full set semantics
+        mock_client.assign_document_projects.assert_called_once_with("doc-multi", ["proj-a"])
+        mock_client.add_document_to_projects.assert_not_called()
+
+    def test_document_id_update_with_no_project_info_calls_nothing(
+        self, pipeline, mock_client, mock_embedder, existing_doc
+    ) -> None:
+        """No project_name, no project_ids → neither primitive called; existing memberships untouched."""
+        mock_client.get_document_by_id.return_value = existing_doc
+        mock_client.get_document_by_hash.return_value = None
+        mock_client.update_document.return_value = existing_doc
+        mock_client.get_document_project_ids.return_value = ["proj-a", "proj-b"]
+        mock_embedder.embed_batch.return_value = [[0.0] * 768]
+
+        pipeline.ingest_text(
+            "# T\n\nNew content.", title="Multi-Project Note", document_id="doc-multi",
+        )
+
+        mock_client.assign_document_projects.assert_not_called()
+        mock_client.add_document_to_projects.assert_not_called()
+
+    # ── update_existing branch (title / source_path lookup) ──────────────────
+
+    def test_update_existing_with_project_name_does_not_assign(
+        self, pipeline, mock_client, mock_embedder, existing_doc
+    ) -> None:
+        """Same non-destructive contract on the update_existing branch."""
+        mock_client.find_document_by_source_path.return_value = None
+        mock_client.find_document_by_title.return_value = existing_doc
+        mock_client.get_document_by_id.return_value = existing_doc
+        mock_client.get_document_by_hash.return_value = None
+        mock_client.update_document.return_value = existing_doc
+        mock_client.get_document_project_ids.return_value = ["proj-a", "proj-b"]
+        mock_client.get_or_create_project.return_value = {"id": "proj-a", "name": "Cerefox"}
+        mock_embedder.embed_batch.return_value = [[0.0] * 768]
+
+        pipeline.ingest_text(
+            "# T\n\nNew content.", title="Multi-Project Note",
+            update_existing=True, project_name="Cerefox",
+        )
+
+        mock_client.assign_document_projects.assert_not_called()
+        mock_client.add_document_to_projects.assert_called_once_with("doc-multi", ["proj-a"])
+
+    def test_update_existing_with_explicit_project_ids_list_is_destructive(
+        self, pipeline, mock_client, mock_embedder, existing_doc
+    ) -> None:
+        """Explicit list on the update_existing branch: destructive replace, same as document_id branch."""
+        mock_client.find_document_by_source_path.return_value = None
+        mock_client.find_document_by_title.return_value = existing_doc
+        mock_client.get_document_by_id.return_value = existing_doc
+        mock_client.get_document_by_hash.return_value = None
+        mock_client.update_document.return_value = existing_doc
+        mock_client.get_document_project_ids.return_value = ["proj-a"]
+        mock_embedder.embed_batch.return_value = [[0.0] * 768]
+
+        pipeline.ingest_text(
+            "# T\n\nNew content.", title="Multi-Project Note",
+            update_existing=True, project_ids=["proj-a"],
+        )
+
+        mock_client.assign_document_projects.assert_called_once_with("doc-multi", ["proj-a"])
+        mock_client.add_document_to_projects.assert_not_called()
+
+    def test_update_existing_with_no_project_info_calls_nothing(
+        self, pipeline, mock_client, mock_embedder, existing_doc
+    ) -> None:
+        mock_client.find_document_by_source_path.return_value = None
+        mock_client.find_document_by_title.return_value = existing_doc
+        mock_client.get_document_by_id.return_value = existing_doc
+        mock_client.get_document_by_hash.return_value = None
+        mock_client.update_document.return_value = existing_doc
+        mock_client.get_document_project_ids.return_value = ["proj-a", "proj-b"]
+        mock_embedder.embed_batch.return_value = [[0.0] * 768]
+
+        pipeline.ingest_text(
+            "# T\n\nNew content.", title="Multi-Project Note", update_existing=True,
+        )
+
+        mock_client.assign_document_projects.assert_not_called()
+        mock_client.add_document_to_projects.assert_not_called()
+
+    # ── CREATE path: project_name still goes to assign (no existing memberships) ──
+
+    def test_create_path_with_project_name_still_uses_assign(
+        self, pipeline, mock_client, mock_embedder
+    ) -> None:
+        """Create path is unchanged — single project_name → assign_document_projects.
+
+        On a brand-new doc there are no existing memberships to preserve, so the
+        destructive primitive is harmless and we keep the create-path code path
+        as-is.
+        """
+        mock_client.get_document_by_hash.return_value = None
+        mock_client.find_document_by_source_path.return_value = None
+        mock_client.find_document_by_title.return_value = None
+        mock_client.get_or_create_project.return_value = {"id": "proj-new", "name": "Cerefox"}
+        mock_embedder.embed_batch.return_value = [[0.0] * 768]
+
+        pipeline.ingest_text(
+            "# T\n\nNew content.", title="Brand New",
+            project_name="Cerefox",
+        )
+
+        # Create path uses assign with the resolved single-id list — that's fine
+        # because there's nothing to preserve on a fresh document.
+        mock_client.assign_document_projects.assert_called_once_with("doc-001", ["proj-new"])
+        mock_client.add_document_to_projects.assert_not_called()
+
+
+# ── Issue #38: CerefoxClient.add_document_to_projects ─────────────────────────
+
+
+class TestAddDocumentToProjects:
+    """Unit tests for the new non-destructive primitive on the DB client."""
+
+    @pytest.fixture()
+    def client_with_table(self):
+        """Build a minimal CerefoxClient with a mocked supabase .table() chain.
+
+        The ``.client`` attribute is a lazy property backed by ``_client`` —
+        set the underlying field directly to bypass the Supabase init.
+        """
+        from cerefox.db.client import CerefoxClient
+
+        client = CerefoxClient.__new__(CerefoxClient)
+        client._client = MagicMock()
+        return client
+
+    def test_no_op_on_empty_list(self, client_with_table) -> None:
+        client_with_table.add_document_to_projects("doc-1", [])
+        client_with_table.client.table.assert_not_called()
+
+    def test_inserts_only_missing_memberships(self, client_with_table) -> None:
+        """If the doc is already in proj-a and we ask for [proj-a, proj-b], only proj-b is inserted."""
+        # First .table() call: get_document_project_ids → returns {proj-a}
+        select_chain = MagicMock()
+        select_chain.select.return_value.eq.return_value.execute.return_value = MagicMock(
+            data=[{"project_id": "proj-a"}]
+        )
+        # Second .table() call: insert
+        insert_chain = MagicMock()
+        insert_chain.insert.return_value.execute.return_value = MagicMock(data=[])
+        client_with_table.client.table.side_effect = [select_chain, insert_chain]
+
+        client_with_table.add_document_to_projects("doc-1", ["proj-a", "proj-b"])
+
+        # The insert call should only include proj-b (proj-a was already a member)
+        insert_chain.insert.assert_called_once_with(
+            [{"document_id": "doc-1", "project_id": "proj-b"}]
+        )
+
+    def test_no_insert_when_all_already_members(self, client_with_table) -> None:
+        """If everything requested is already a member, no insert call is made."""
+        select_chain = MagicMock()
+        select_chain.select.return_value.eq.return_value.execute.return_value = MagicMock(
+            data=[{"project_id": "proj-a"}, {"project_id": "proj-b"}]
+        )
+        client_with_table.client.table.return_value = select_chain
+
+        client_with_table.add_document_to_projects("doc-1", ["proj-a", "proj-b"])
+
+        # Only one .table() call — the SELECT. No INSERT.
+        assert client_with_table.client.table.call_count == 1
+
+    def test_empty_string_project_ids_filtered_out(self, client_with_table) -> None:
+        """Empty-string entries are stripped, same as assign_document_projects's contract."""
+        select_chain = MagicMock()
+        select_chain.select.return_value.eq.return_value.execute.return_value = MagicMock(data=[])
+        insert_chain = MagicMock()
+        insert_chain.insert.return_value.execute.return_value = MagicMock(data=[])
+        client_with_table.client.table.side_effect = [select_chain, insert_chain]
+
+        client_with_table.add_document_to_projects("doc-1", ["", "proj-a", ""])
+
+        insert_chain.insert.assert_called_once_with(
+            [{"document_id": "doc-1", "project_id": "proj-a"}]
+        )
 
 
 # ── Title boosting (17A) ──────────────────────────────────────────────────────


### PR DESCRIPTION
Closes cerefox#38.

PROBLEM
-------

`cerefox_ingest` with `update_if_exists: true` (or with an explicit `document_id`) and a single `project_name` was destructively replacing the target document's project memberships with just that one project. A doc that an operator had assigned to both "Cerefox" and "cfcf" via the web UI lost the "cfcf" membership the moment an agent updated its content with `project_name="Cerefox"`.

The remote MCP (`cerefox-mcp` Edge Function) and direct `cerefox-ingest` Edge Function had a related but different bug: they silently IGNORED `project_name` on the update branches — non-destructive, but agents couldn't change project assignment via the tool either.

The underlying data model (`cerefox_document_projects` many-to-many, with a junction table) was always capable; only the write surface was wrong.

ROOT CAUSE
----------

`pipeline.ingest_text` resolved a single `project_name` into a one-element `[uuid]` list and forwarded it to `update_document` AS IF it were the explicit full-set parameter. `update_document`'s contract ("`None` = unchanged, `[]` = clear, `[…]` = full set") correctly does a DELETE-then-INSERT replace on `cerefox_document_projects`. So the single `project_name` got promoted to a full-set replace by accident in the upstream code, even though the docstring contract was correct.

The destructive primitive itself
(`CerefoxClient.assign_document_projects`) is fine — the web UI's explicit project-edit form needs it. Only `ingest_text`'s coercion was wrong.

FIX
---

Coordinated changes across Python pipeline + both TS Edge Functions so the three paths share one contract:

1. New `CerefoxClient.add_document_to_projects(doc_id, [pid…])` — non-destructive primitive. Idempotent. Computes the diff against existing memberships and only inserts missing rows.

2. `IngestionPipeline.ingest_text` no longer collapses singular `project_name`/`project_id` into a full-set list on the update branches. Both update branches (document_id-based and update_existing/title-based) now:
   - Pass `project_ids=None` to `update_document` (preserving existing memberships), AND
   - Call `add_document_to_projects` afterwards if a singular project hint was provided.

3. `supabase/functions/cerefox-ingest/index.ts` gains a shared `ensureDocumentInProject` helper that resolves the project name (creating if absent), checks for existing membership, and inserts only when missing. Called from both update branches (where it was previously absent) AND from the create path (refactored to use the helper for consistency).

4. `supabase/functions/cerefox-mcp/tools/ingest.ts` — same helper + same wiring as #3. Both EFs now treat `project_name` on update as "ensure this membership exists, leave others alone."

CONTRACT SUMMARY
----------------

| Caller form on update                    | Behavior                       |
| ---------------------------------------- | ------------------------------ |
| `project_ids=[…]` (Python list)          | Destructive replace (unchanged) |
| `project_name="X"` or `project_id="X"`   | Non-destructive add (new)       |
| Neither                                  | No change (unchanged)           |

The destructive `project_ids` form is the web UI's explicit edit contract; it stays. The agent-facing single-`project_name` path moves from destructive (local MCP) / silent-ignore (TS paths) to non-destructive add across the board.

PROPOSED FOLLOW-UP (NOT IN THIS PR)
-----------------------------------

The issue suggests two further changes that we deliberately deferred to keep this PR focused on the destructive-bug fix:

- `project_names: string[]` on `cerefox_ingest` for explicit full-set semantics from the MCP layer. Today the only way to get full-set semantics on update is via the Python-API `project_ids` list or the web UI's edit form.
- Dedicated metadata-only MCP tool: `cerefox_set_document_projects` (and optionally `cerefox_add_project` / `cerefox_remove_project`). The audit log already has `update-metadata` as a distinct operation type, so the data model is ready.

Both would expand the MCP tool surface. Better as separate proposals where the API design can be reviewed cleanly.

TESTING
-------

- 12 new unit tests: `tests/ingestion/test_pipeline.py::TestMultiProjectPreservationOnUpdate` (8 tests covering document_id branch + update_existing branch + explicit-list-still-destructive + no-project-info + create path) and `::TestAddDocumentToProjects` (4 tests covering the non-destructive primitive's edge cases).
- All 495 unit tests pass (was 483 + 12 new).
- All 80 e2e tests pass against the newly deployed Edge Functions on the live Supabase project.
- Live repro against the maintainer's Cerefox instance:
  * Doc f25884d4… created in project "Cerefox".
  * Manually added to second project "issue-38-test-secondary" via the DB client.
  * Updated via `cerefox_ingest` (`update_if_exists: true`, `project_name: "Cerefox"`) — both memberships survived.
  * Updated via `cerefox_ingest` (`document_id=…`, `project_name: "Cerefox"`) — both memberships survived.
  * Project-filtered search on "issue-38-test-secondary" still returns the doc post-update.

DEPLOY NOTES
------------

- Python-side fix takes effect on `git pull` + restart of the local MCP server (`cerefox mcp`).
- TS-side fix requires Edge Function redeploy: npx supabase functions deploy cerefox-ingest npx supabase functions deploy cerefox-mcp Already deployed against the maintainer's project as part of verification.