### PR TITLE
feat(projects): project_names parameter + cerefox_set_document_projects tool (issue #38 follow-up)

### DIFF
--- a/AGENT_GUIDE.md
+++ b/AGENT_GUIDE.md
@@ -24,7 +24,7 @@ The rest of this guide is written around the MCP tool names, since those are sta
 
 ---
 
-## The 8 Tools
+## The 9 Tools
 
 ### cerefox_search
 
@@ -58,7 +58,8 @@ Save a new document or update an existing one.
 | `content` | Yes | Markdown content. Use H1/H2/H3 headings -- the chunker uses them for segmentation. |
 | `document_id` | No | UUID of an existing document to update. When provided, updates that document directly regardless of `update_if_exists`. Returns an error if the document does not exist. Workflow: search → note the `[id: ...]` → pass here. |
 | `update_if_exists` | No | When `true`, updates the document with the same title (versions the old content). Default `false`. Ignored when `document_id` is provided. |
-| `project_name` | No | Assign to a project (created automatically if it doesn't exist). |
+| `project_name` | No | **Single** project name (created if absent). On update: **non-destructive add** — ensures this membership exists, preserves others. See "Project membership semantics" below. |
+| `project_names` | No | **List** of project names (each created if absent). On update: **destructive replace** — sets the document's full project set to exactly this list. Use when you want to set multiple projects at once, or deliberately change the membership list. Wins over `project_name` when both are passed. |
 | `metadata` | No | Arbitrary JSON. Use at minimum: `type` and `status`. |
 | `author` | No | Your agent name for audit attribution. Always set this. |
 | `source` | No | Origin label (default "agent"). |
@@ -76,6 +77,18 @@ Save a new document or update an existing one.
 **Deduplication**: Content is SHA-256 hashed. Identical content is skipped (no re-indexing). Metadata-only changes update metadata without creating a version.
 
 **What to ingest**: Distilled summaries, decisions with rationale, curated insights. Not raw dumps, logs, or transcripts. Use Markdown headings for structure.
+
+#### Project membership semantics
+
+This is subtle but important — a document can belong to multiple projects (many-to-many), and an operator may have curated the project list via the web UI. **You must not silently strip their work when updating content.** The rules:
+
+| What you pass on update | What happens to memberships |
+|---|---|
+| `project_name: "X"` (singular) | **Non-destructive add.** Ensures the doc is in project X. Other memberships untouched. |
+| `project_names: ["X", "Y"]` (list) | **Destructive replace.** Sets the doc's project set to exactly `{X, Y}`. Other memberships are removed. Use when you want this. |
+| Neither | **No change** to project memberships. |
+
+**Rule of thumb**: if you just want to ensure a doc is *associated with* a project, use singular `project_name`. If you want to *change* the project list, use `project_names`. If you don't know — use singular. When in doubt, use the dedicated `cerefox_set_document_projects` tool, which makes the destructive replace intent explicit and doesn't require also writing content.
 
 ---
 
@@ -148,6 +161,28 @@ List all projects with names, IDs, and descriptions.
 | `requestor` | No | Your agent name. |
 
 Call once per session to discover available projects before filtering search results by `project_name`.
+
+---
+
+### cerefox_set_document_projects
+
+Set the document's project memberships to EXACTLY the given list. **Destructive replace.** Any existing memberships not in the list are removed. Content is untouched. Logged as `update-metadata` in the audit log.
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `document_id` | Yes | UUID of the document. Get from a prior `cerefox_search` result (the `[id: ...]` tag). |
+| `project_names` | Yes | Explicit list of project names. Each created if absent (case-insensitive lookup). Empty list = clear all memberships. Order is preserved. |
+| `author` | No | Your agent name for audit attribution. |
+
+**Use cases**:
+- You want to change project membership without rewriting the document body. This tool is faster and clearer than calling `cerefox_ingest` again.
+- You want to add a doc to multiple projects in one call (cleaner than N separate `cerefox_ingest` calls).
+- You want to *remove* a project from a doc's set (use the list of remaining projects without the one to drop).
+- An operator asked you to consolidate or clean up a doc's project list.
+
+**Use `cerefox_ingest` with `project_names` instead** if you're updating the content anyway — same destructive-replace semantics, one call instead of two.
+
+**Never use this tool to "just ensure X is in the list"** — that's what `cerefox_ingest` with singular `project_name` does, non-destructively. If you call this tool with only one name, you will REMOVE the document from every other project it was in.
 
 ---
 

--- a/AGENT_QUICK_REFERENCE.md
+++ b/AGENT_QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Cerefox Knowledge Base -- Agent Quick Reference
 
-Cerefox is a persistent, shared knowledge base. You have 8 MCP tools (or, if MCP isn't configured, the same 8 operations via the local CLI — see CLI section at the bottom).
+Cerefox is a persistent, shared knowledge base. You have 9 MCP tools (or, if MCP isn't configured, the same 9 operations via the local CLI — see CLI section at the bottom).
 For the full guide, search Cerefox for "How AI Agents Use Cerefox".
 
 ## Tools
@@ -8,12 +8,13 @@ For the full guide, search Cerefox for "How AI Agents Use Cerefox".
 | Tool | Purpose | Key params |
 |------|---------|------------|
 | `cerefox_search` | Find documents (hybrid FTS + semantic) | `query` (required), `project_name`, `metadata_filter`, `requestor` |
-| `cerefox_ingest` | Save or update a document | `title`, `content` (required), `document_id` (update by ID), `update_if_exists`, `project_name`, `metadata`, `author` |
+| `cerefox_ingest` | Save or update a document | `title`, `content` (required), `document_id` (update by ID), `update_if_exists`, `project_name` (single, non-destructive add on update), `project_names` (list, destructive replace on update), `metadata`, `author` |
 | `cerefox_get_document` | Get full document by ID | `document_id` (required) |
 | `cerefox_list_versions` | Version history of a document | `document_id` (required) |
 | `cerefox_metadata_search` | Find docs by metadata (no text query) | `metadata_filter` (required), `include_content`, `updated_since` |
 | `cerefox_list_metadata_keys` | Discover available metadata keys | (none required) |
 | `cerefox_list_projects` | List all projects | (none required) |
+| `cerefox_set_document_projects` | Set doc's project memberships to exactly the given list (destructive replace; metadata-only, no content change) | `document_id`, `project_names` (required) |
 | `cerefox_get_audit_log` | Query write operation history | `document_id`, `author`, `operation`, `since` |
 
 ## Essential Rules
@@ -26,6 +27,7 @@ For the full guide, search Cerefox for "How AI Agents Use Cerefox".
 6. **Write structured Markdown** with H1/H2/H3 headings for good chunking and search.
 7. **Deletes are soft (recoverable); purge is web-UI-only.** If you decide to delete, surface it to the user (`I soft-deleted X — recoverable from the Cerefox web UI trash`). You cannot un-do your own delete from agent code by design.
 8. **Cross-doc links inside content**: **always use `[Text](document-uuid)`.** UUIDs are the only fully reliable link form — stable across title changes, never ambiguous, no encoding gotchas. Every `cerefox_search` result shows `[id: <uuid>]` after the title; grab it and use it. Title-based linking (`[Text](<Title With Spaces>)`) is fragile (breaks on colons, parens, ampersands, brackets — silently navigates to wrong page) — **don't write title-based links**; do an extra search to get the UUID instead. Repo-path forms (`[Text](docs/path.md)`) exist for repo-ingested files; don't construct manually. See `AGENT_GUIDE.md → Writing linkable content` for the full rule.
+9. **Project memberships — non-destructive by default**: on `cerefox_ingest` updates, **`project_name` (singular) is a non-destructive add** (ensures membership, preserves others). Use **`project_names` (list)** when you want to set the doc's full project set in one call (destructive replace). For metadata-only project changes without writing content, use **`cerefox_set_document_projects(document_id, project_names)`** — that tool is the destructive-replace contract made explicit. Never call `cerefox_set_document_projects` with a single name when you mean "add" — that would REMOVE the doc from all other projects. When in doubt, use `cerefox_ingest` with singular `project_name`.
 
 ## Update Workflow (ID-based -- preferred)
 
@@ -61,6 +63,7 @@ If `cerefox_search` is not in your tool list, your user has likely pointed you a
 | `cerefox_list_projects` | `uv run cerefox list-projects --requestor "<your-name>"` |
 | `cerefox_list_metadata_keys` | `uv run cerefox list-metadata-keys` |
 | `cerefox_metadata_search` | `uv run cerefox metadata-search --metadata-filter '<json>' --requestor "<your-name>"` |
+| `cerefox_set_document_projects` | _MCP-only in v0.1.20; a CLI command will be added in a future release. Until then, run via MCP if available._ |
 | `cerefox_get_audit_log` | `uv run cerefox get-audit-log --requestor "<your-name>"` (add `--json` for scripted access) |
 
 **Set identity on every call**, exactly as you would on MCP:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,53 +21,87 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
   MCP and `cerefox-ingest` Edge Function) had a related but different bug:
   they silently *ignored* `project_name` on update, so agents could neither
   destroy memberships nor add them.
-  - **New contract for `project_name` on update (all three paths)**:
-    non-destructive add — "ensure this membership exists, leave others
-    alone." Idempotent if the doc is already in that project.
-  - **`project_ids: [...]`** (the Python-API list form, used by the web UI's
-    explicit `POST /documents/{id}/edit` endpoint) keeps its existing
-    full-set / destructive-replace semantics. Only the agent-facing
-    single-`project_name` path changed.
-  - **Implementation**:
-    - New `CerefoxClient.add_document_to_projects(doc_id, [pid…])` — the
-      non-destructive primitive. Idempotent. Computes the diff against
-      existing memberships and only inserts missing rows.
-    - `IngestionPipeline.ingest_text` no longer collapses single
-      `project_name`/`project_id` into a `project_ids=[uuid]` list when
-      taking an update branch. On update it passes `project_ids=None`
-      (preserving) and then calls the new non-destructive helper for any
-      singular project hint.
-    - Both Edge Functions (`cerefox-ingest/index.ts` and
-      `cerefox-mcp/tools/ingest.ts`) gain a shared
-      `ensureDocumentInProject(supabase, docId, projectName)` helper that
-      resolves the project (creating if absent), checks for existing
-      membership, and inserts only when missing. Called from both update
-      branches (id-based and title-based) and from the create path
-      (refactored for consistency).
-  - **Not implemented in this PR — proposed for follow-up**:
-    - `project_names: string[]` on `cerefox_ingest` for explicit full-set
-      semantics from the MCP layer (today the only way to get full-set
-      semantics is via the Python `project_ids` list or the web UI edit
-      form).
-    - Dedicated metadata-only tool `cerefox_set_document_projects` /
-      `cerefox_add_project` / `cerefox_remove_project` so agents have
-      first-class project-membership write surface independent of content
-      updates. The audit log already enumerates `update-metadata` as a
-      distinct operation type, so the data model is ready.
-  - **Tests**: 12 new unit tests under
-    `tests/ingestion/test_pipeline.py::TestMultiProjectPreservationOnUpdate`
-    + `TestAddDocumentToProjects`. All 495 unit + 80 e2e tests pass against
-    the newly deployed Edge Functions. Live repro against the maintainer's
-    Cerefox instance confirmed: doc that started in two projects survives
-    a content update via `cerefox_ingest` with `project_name="Cerefox"`
-    intact — both project filters return the doc afterwards.
-  - **⚠️ Edge Function redeploy required to pick up the TS fixes** (the
-    Python-side fix takes effect on `git pull` + restarting the local MCP
-    server):
-    ```bash
-    npx supabase functions deploy cerefox-ingest
-    npx supabase functions deploy cerefox-mcp
-    ```
+
+  **The fix is a coordinated set of four pieces** (the full
+  proposal from the issue):
+  - **Part 1**: non-destructive add semantics for singular `project_name`
+    on update across all three paths (local Python MCP, remote MCP,
+    Edge Function).
+  - **Part 2**: parity across the three paths — same contract everywhere.
+  - **Part 3**: new `project_names: string[]` parameter on `cerefox_ingest`
+    for **explicit full-set semantics from the MCP layer**.
+  - **Part 4**: new MCP tool `cerefox_set_document_projects` for
+    **metadata-only project-membership writes** (no content update needed).
+
+  **Final contract on update (all three paths)**:
+
+  | Caller form on update | Behavior |
+  |---|---|
+  | `project_name: "X"` (singular) | **Non-destructive add.** Ensures membership X exists; other memberships untouched. |
+  | `project_names: ["X","Y","Z"]` (list) | **Destructive replace.** Sets the doc's project set to exactly `{X,Y,Z}`. |
+  | `project_ids: ["uuid-a","uuid-b"]` (Python API only) | Same destructive-replace semantics; used by web UI's edit form. |
+  | None of the above | No change to memberships. |
+
+  The destructive `project_ids` form (Python API only) is the web UI's
+  explicit edit contract — preserved. The new `project_names` form
+  gives agents the same full-set semantics by name. Singular
+  `project_name` is the safe-by-default agent path.
+
+  **New MCP tool surface**: `cerefox_set_document_projects(document_id,
+  project_names: string[])` — sets the doc's project membership to
+  exactly the given list, no content write. Empty list clears all
+  memberships. Logged as `update-metadata` in the audit log. Tool count
+  goes from 8 to 9.
+
+  **Implementation**:
+  - New `CerefoxClient.add_document_to_projects(doc_id, [pid…])` — the
+    non-destructive primitive (Part 1). Idempotent.
+  - New `CerefoxClient.set_document_projects(doc_id, project_names,
+    author=..., author_type=...)` — destructive replace by name with
+    audit (Part 4). Case-insensitive dedup; creates missing projects.
+  - `IngestionPipeline.ingest_text` now accepts `project_names: list[str]`
+    (Part 3). Precedence on the resolved set: `project_ids` (Python API
+    list) > `project_names` (name list) > `project_id` (singular) >
+    `project_name` (singular).
+  - Both Edge Functions (`cerefox-ingest/index.ts` and
+    `cerefox-mcp/tools/ingest.ts`) gain two helpers:
+    `ensureDocumentInProject` (non-destructive, Part 1) and
+    `setDocumentProjectsByName` (destructive, Part 3). Both wired into
+    every code path (create + both update branches).
+  - New TS handler `cerefox-mcp/tools/set-document-projects.ts` exposes
+    Part 4 over remote MCP. Registered in `cerefox-mcp/index.ts`.
+  - **Local MCP gap closed**: `cerefox_ingest` on the local Python MCP
+    now also exposes `document_id` (previously local-MCP-only schema gap
+    relative to remote MCP).
+
+  **Tests**: 25 new unit tests across two new classes — 12 from the
+  original fix (`TestMultiProjectPreservationOnUpdate` +
+  `TestAddDocumentToProjects`) and 13 added for Parts 3+4
+  (`TestProjectNamesListParameter` + `TestSetDocumentProjects`). All
+  508 unit + 80 e2e tests pass against the newly deployed Edge
+  Functions. Live verification on the maintainer's Cerefox instance
+  confirmed all four scenarios end-to-end (destructive replace via
+  list, non-destructive add via singular, set-projects via dedicated
+  tool, clear-all via empty list).
+
+  **Documentation**: `AGENT_GUIDE.md` gained a "Project membership
+  semantics" section under `cerefox_ingest` and a full section for
+  `cerefox_set_document_projects`. `AGENT_QUICK_REFERENCE.md` rule #9
+  codifies the non-destructive default. The CLI mapping notes
+  `cerefox_set_document_projects` is MCP-only in v0.1.20 (CLI command
+  in a future release).
+
+  **⚠️ Edge Function redeploy required to pick up the TS fixes** (the
+  Python-side fix takes effect on `git pull` + restarting the local MCP
+  server):
+
+  ```bash
+  npx supabase functions deploy cerefox-ingest
+  npx supabase functions deploy cerefox-mcp
+  ```
+
+  See [`docs/guides/upgrading.md` → Upgrading to v0.1.20](docs/guides/upgrading.md#upgrading-to-v0120-from-v0119----multi-project-preservation-fix)
+  for the full upgrade note.
 
 ### Filed (carried forward, no new code)
 

--- a/docs/guides/upgrading.md
+++ b/docs/guides/upgrading.md
@@ -61,6 +61,52 @@ open http://localhost:8000/app/
 
 Most upgrades require no special steps beyond the standard checklist above. Notes below only apply when upgrading across specific version boundaries.
 
+### Upgrading to v0.1.20 (from v0.1.19) -- Multi-Project Preservation Fix
+
+**Edge Function redeploy is required.** v0.1.20 fixes
+[issue #38](https://github.com/fstamatelopoulos/cerefox/issues/38): `cerefox_ingest`
+no longer destructively replaces multi-project memberships when an agent updates
+content with a single `project_name`. It also adds a new `project_names: string[]`
+parameter for explicit full-set semantics and a new MCP tool
+`cerefox_set_document_projects` for first-class agent control over project
+membership independent of content updates.
+
+The fix touches two Edge Functions in `supabase/functions/`. Pulling the new
+code does **not** apply the TS changes to your live Supabase. After `git pull`,
+step 6 of the standard checklist (Edge Function redeploy) is **mandatory for
+this release**:
+
+```bash
+npx supabase functions deploy cerefox-ingest
+npx supabase functions deploy cerefox-mcp
+```
+
+**If you skip this step**: the Python pipeline fix still applies on next local
+MCP server restart, so the destructive bug is fixed for the local Python MCP
+path. But the **remote MCP** (Claude.ai, ChatGPT Custom GPT via OpenAPI, any
+HTTP MCP client pointed at `cerefox-mcp` Edge Function) and the **direct
+`cerefox-ingest` Edge Function** path will still silently ignore `project_name`
+on update — non-destructive, but agents can't add a membership via that path.
+And the new `cerefox_set_document_projects` MCP tool won't appear in the remote
+MCP tool list until `cerefox-mcp` is redeployed.
+
+**No schema migration, no RPC redeploy, no chunk reindex** needed. The fix is
+purely application-layer; the underlying junction table (`cerefox_document_projects`)
+and its many-to-many semantics were always correct. Only the write surface had bugs.
+
+**New behaviour to be aware of (no breaking changes)**:
+- `cerefox_ingest` with `project_name="X"` on update → ensures membership in X,
+  preserves all others (was: destructive replace in local MCP / silent ignore in TS).
+- `cerefox_ingest` with `project_names=["X","Y","Z"]` (new) on update → sets
+  full project set to exactly {X, Y, Z}; opt-in to destructive replace.
+- `cerefox_ingest` with neither → no membership changes.
+- `cerefox_set_document_projects(document_id, project_names=["X","Y"])` (new tool)
+  → explicit metadata-only write of the full project set. Logged as
+  `update-metadata` in the audit log.
+
+Architectural rationale: see the cerefox#38 PR commit message and
+[`docs/solution-design.md`](../solution-design.md).
+
 ### Upgrading to v0.1.19 (from v0.1.18) -- FTS Query Parser
 
 **RPC redeploy is required.** v0.1.19 changes the FTS query parser used by

--- a/src/cerefox/db/client.py
+++ b/src/cerefox/db/client.py
@@ -493,6 +493,82 @@ class CerefoxClient:
             logger.error("assign_document_projects failed: %s", exc)
             raise RuntimeError(f"assign_document_projects failed: {exc}") from exc
 
+    def set_document_projects(
+        self,
+        document_id: str,
+        project_names: list[str],
+        *,
+        author: str = "unknown",
+        author_type: str = "user",
+    ) -> dict[str, Any]:
+        """Set the document's project memberships to exactly ``project_names``.
+
+        Resolves each name to a project_id (creating projects that don't exist),
+        then performs a DELETE-then-INSERT replace on ``cerefox_document_projects``.
+        Empty list = remove from all projects.
+
+        Logged in the audit log as ``update-metadata`` (project membership is
+        document metadata, not content). The agent-facing
+        ``cerefox_set_document_projects`` MCP tool wraps this method.
+
+        Returns:
+            Dict with ``document_id``, ``project_ids`` (resolved UUIDs in order),
+            and ``project_names`` (the names, mirrored back).
+
+        Raises:
+            ValueError: If the document doesn't exist (or is soft-deleted).
+        """
+        # Verify the document exists and isn't soft-deleted.
+        doc = self.get_document_by_id(document_id)
+        if doc is None:
+            raise ValueError(f"Document not found: {document_id}")
+
+        # Strip empties; preserve order; dedup case-insensitively to avoid
+        # creating the same project twice when an agent passes ["Foo", "foo"].
+        seen_lower: set[str] = set()
+        clean_names: list[str] = []
+        for n in project_names:
+            if not isinstance(n, str) or not n.strip():
+                continue
+            stripped = n.strip()
+            key = stripped.lower()
+            if key in seen_lower:
+                continue
+            seen_lower.add(key)
+            clean_names.append(stripped)
+
+        # Resolve names to UUIDs (create missing projects).
+        resolved_ids: list[str] = []
+        for name in clean_names:
+            project = self.get_or_create_project(name)
+            resolved_ids.append(project["id"])
+
+        # Destructive replace via the existing primitive.
+        self.assign_document_projects(document_id, resolved_ids)
+
+        # Audit entry. update-metadata semantics — project membership is part
+        # of the document's structured metadata, not its content.
+        try:
+            self.create_audit_entry(
+                operation="update-metadata",
+                author=author,
+                author_type=author_type,
+                document_id=document_id,
+                description=(
+                    f"Set document projects to [{', '.join(clean_names)}]"
+                    if clean_names
+                    else "Cleared all project memberships"
+                ),
+            )
+        except Exception as exc:
+            logger.warning("set_document_projects: audit entry failed: %s", exc)
+
+        return {
+            "document_id": document_id,
+            "project_ids": resolved_ids,
+            "project_names": clean_names,
+        }
+
     def add_document_to_projects(self, document_id: str, project_ids: list[str]) -> None:
         """Non-destructively add project memberships. Idempotent.
 

--- a/src/cerefox/ingestion/pipeline.py
+++ b/src/cerefox/ingestion/pipeline.py
@@ -101,6 +101,7 @@ class IngestionPipeline:
         project_name: str | None = None,
         project_id: str | None = None,
         project_ids: list[str] | None = None,
+        project_names: list[str] | None = None,
         metadata: dict | None = None,
         update_existing: bool = False,
         document_id: str | None = None,
@@ -114,13 +115,17 @@ class IngestionPipeline:
             title: Human-readable document title.
             source: Origin label (e.g. ``"file"``, ``"paste"``, ``"agent"``).
             source_path: Optional filesystem path or URL the content came from.
-            project_name: If given, the document is linked to this project
-                (created automatically if it doesn't exist).  Ignored when
-                ``project_ids`` is provided.
-            project_id: Single project UUID (legacy convenience; converted to
-                ``project_ids=[project_id]`` internally).
-            project_ids: List of project UUIDs to assign (M2M).  Takes
-                precedence over ``project_id`` and ``project_name``.
+            project_name: Single project name (created if absent). On update,
+                non-destructive add — "ensure this membership exists, leave
+                others alone."
+            project_id: Single project UUID. Same non-destructive-add semantics
+                as ``project_name`` on update.
+            project_ids: Explicit list of project UUIDs. Full-set semantics —
+                destructive replace on update. Wins over ``project_names``.
+            project_names: Explicit list of project names (each created if
+                absent). Full-set semantics — destructive replace on update.
+                The name-based equivalent of ``project_ids``. Use when an agent
+                wants to set the document's full project membership in one call.
             metadata: Arbitrary key/value pairs stored as JSONB on the document.
             update_existing: When True, look up an existing document by
                 ``source_path`` (for file ingestion) or by ``title`` (for
@@ -136,30 +141,42 @@ class IngestionPipeline:
         # which document to update.  Errors if the document does not exist.
         #
         # Project semantics on update (per issue #38):
-        # - ``project_ids=[…]`` (an explicit list, even one-element): full-set
-        #   semantics — destructive replace. Used by the web UI's edit form.
-        # - ``project_name`` / ``project_id`` (singular): non-destructive add
-        #   — "ensure this membership exists, leave others alone." This is
-        #   the agent-facing path; agents must not be able to silently strip
-        #   project memberships an operator added via the web UI.
+        # - List form (``project_ids=[…]`` or ``project_names=[…]``): full-set
+        #   semantics — destructive replace. Used by the web UI's edit form
+        #   and by agents that want explicit set-the-membership semantics.
+        # - Singular form (``project_name`` / ``project_id``): non-destructive
+        #   add — "ensure this membership exists, leave others alone." Agents
+        #   must not be able to silently strip memberships an operator added
+        #   via the web UI when they only intended to add one.
+        list_form_provided = project_ids is not None or project_names is not None
         if document_id is not None:
             existing_doc = self._client.get_document_by_id(document_id)
             if existing_doc is None:
                 raise ValueError(f"Document not found: {document_id}")
+            # Resolve the full-set list (if either form was provided) for the
+            # destructive-replace path. Both project_ids and project_names
+            # converge to a single resolved list here.
+            full_set_resolved: list[str] | None = None
+            if list_form_provided:
+                full_set_resolved = self._resolve_project_ids(
+                    project_ids=project_ids,
+                    project_id=None,
+                    project_name=None,
+                    project_names=project_names,
+                )
             result = self.update_document(
                 document_id=document_id,
                 text=text,
                 title=title,
                 source=source,
-                # Only the explicit list form propagates as a full-set replace.
-                # Singular project_name/project_id are handled non-destructively below.
-                project_ids=project_ids if project_ids is not None else None,
+                project_ids=full_set_resolved,
                 metadata=metadata,
                 author=author,
                 author_type=author_type,
             )
             # Non-destructive add for singular project_name / project_id on update.
-            if project_ids is None and (project_id or project_name):
+            # Only fires when the caller did NOT supply a list form.
+            if not list_form_provided and (project_id or project_name):
                 singular_resolved = self._resolve_project_ids(
                     project_ids=None, project_id=project_id, project_name=project_name,
                 )
@@ -184,19 +201,28 @@ class IngestionPipeline:
                     existing_doc["id"],
                     lookup_key,
                 )
-                # Same semantics as the document_id branch: explicit list = full set,
-                # singular project_name/project_id = non-destructive add (issue #38).
+                # Same semantics as the document_id branch:
+                # list form = full-set destructive replace,
+                # singular form = non-destructive add (issue #38).
+                full_set_resolved = None
+                if list_form_provided:
+                    full_set_resolved = self._resolve_project_ids(
+                        project_ids=project_ids,
+                        project_id=None,
+                        project_name=None,
+                        project_names=project_names,
+                    )
                 result = self.update_document(
                     document_id=existing_doc["id"],
                     text=text,
                     title=title,
                     source=source,
-                    project_ids=project_ids if project_ids is not None else None,
+                    project_ids=full_set_resolved,
                     metadata=metadata,
                     author=author,
                     author_type=author_type,
                 )
-                if project_ids is None and (project_id or project_name):
+                if not list_form_provided and (project_id or project_name):
                     singular_resolved = self._resolve_project_ids(
                         project_ids=None, project_id=project_id, project_name=project_name,
                     )
@@ -206,8 +232,10 @@ class IngestionPipeline:
                 return result
             log.info("update_existing: no existing doc found — creating new document")
 
-        # Resolve project_ids from the various caller styles.
-        resolved_ids = self._resolve_project_ids(project_ids, project_id, project_name)
+        # Resolve project_ids from the various caller styles (singular or list, ID or name).
+        resolved_ids = self._resolve_project_ids(
+            project_ids, project_id, project_name, project_names=project_names,
+        )
 
         validated_meta = metadata or {}
 
@@ -571,10 +599,33 @@ class IngestionPipeline:
         project_ids: list[str] | None,
         project_id: str | None,
         project_name: str | None,
+        project_names: list[str] | None = None,
     ) -> list[str]:
-        """Return a normalised list of project UUIDs from the caller's inputs."""
+        """Return a normalised list of project UUIDs from the caller's inputs.
+
+        Precedence (highest wins):
+          1. ``project_ids`` (explicit UUID list) — used as-is, empties stripped.
+          2. ``project_names`` (explicit name list) — each name resolved via
+             ``get_or_create_project`` and assembled in order.
+          3. ``project_id`` (single UUID) — wrapped in a list.
+          4. ``project_name`` (single name) — resolved and wrapped in a list.
+
+        Note that tiers 1 and 2 carry FULL-SET semantics (destructive replace
+        when passed to ``assign_document_projects``) and tiers 3 and 4 carry
+        SINGLE-HINT semantics (non-destructive add via
+        ``add_document_to_projects``). The caller chooses semantics by which
+        argument they pass; this helper just resolves the values.
+        """
         if project_ids is not None:
-            return [p for p in project_ids if p]  # strip empties / empty strings
+            return [p for p in project_ids if p]
+        if project_names is not None:
+            resolved: list[str] = []
+            for name in project_names:
+                if not name:
+                    continue
+                project = self._client.get_or_create_project(name)
+                resolved.append(project["id"])
+            return resolved
         if project_id:
             return [project_id]
         if project_name:

--- a/src/cerefox/mcp_server.py
+++ b/src/cerefox/mcp_server.py
@@ -161,7 +161,26 @@ async def list_tools() -> list[types.Tool]:
                     },
                     "project_name": {
                         "type": "string",
-                        "description": "Optional: assign to a project (created if it doesn't exist)",
+                        "description": (
+                            "Optional: single project name (created if absent). "
+                            "On update: non-destructive add — ensures this membership "
+                            "exists; preserves other memberships an operator may have "
+                            "added via the web UI. For explicit set-the-full-list "
+                            "semantics, use project_names (list) instead, or call "
+                            "cerefox_set_document_projects."
+                        ),
+                    },
+                    "project_names": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": (
+                            "Optional: explicit list of project names (each created "
+                            "if absent). Full-set semantics — on update this REPLACES "
+                            "the document's project memberships with exactly this set. "
+                            "Use when you want to set multiple projects at once or "
+                            "deliberately change the membership list. Wins over "
+                            "project_name when both are passed."
+                        ),
                     },
                     "source": {
                         "type": "string",
@@ -178,7 +197,16 @@ async def list_tools() -> list[types.Tool]:
                         "description": (
                             "When true, update an existing document with the same title "
                             "instead of creating a new one. Useful for keeping notes in sync "
-                            "across multiple agent sessions."
+                            "across multiple agent sessions. Ignored when document_id is set."
+                        ),
+                    },
+                    "document_id": {
+                        "type": "string",
+                        "description": (
+                            "UUID of an existing document to update. When set, updates "
+                            "that document directly regardless of update_if_exists; errors "
+                            "if the document doesn't exist. The deterministic update path — "
+                            "prefer this when you have the ID from a prior cerefox_search."
                         ),
                     },
                     "author": {
@@ -378,6 +406,48 @@ async def list_tools() -> list[types.Tool]:
                 },
             },
         ),
+        types.Tool(
+            name="cerefox_set_document_projects",
+            description=(
+                "Set the document's project memberships to EXACTLY the given list. "
+                "Destructive replace: any existing memberships not in this list are "
+                "removed. Pass an empty list to clear all project memberships. "
+                "Projects are looked up by name (case-insensitive); missing projects "
+                "are created. Logged as update-metadata in the audit log — content "
+                "is untouched. Use cerefox_ingest with project_names if you want to "
+                "set memberships AND update content in one call. Use this tool when "
+                "you only need to change project membership without re-writing the "
+                "document body."
+            ),
+            inputSchema={
+                "type": "object",
+                "required": ["document_id", "project_names"],
+                "properties": {
+                    "document_id": {
+                        "type": "string",
+                        "description": (
+                            "UUID of the document. Get this from a prior cerefox_search "
+                            "result (the [id: ...] tag after the title)."
+                        ),
+                    },
+                    "project_names": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": (
+                            "Explicit list of project names. Each created if absent. "
+                            "Order is preserved. Empty list = remove from all projects."
+                        ),
+                    },
+                    "author": {
+                        "type": "string",
+                        "description": (
+                            "Agent or tool name recorded in the audit log. "
+                            'Defaults to "mcp-agent".'
+                        ),
+                    },
+                },
+            },
+        ),
     ]
 
 
@@ -431,13 +501,19 @@ async def call_tool(name: str, arguments: dict) -> list[types.TextContent]:
     settings = deps["settings"]
 
     # Configurable requestor identity enforcement
-    identity_field = "author" if name == "cerefox_ingest" else "requestor"
+    # cerefox_ingest + cerefox_set_document_projects are writes → check author
+    if name in ("cerefox_ingest", "cerefox_set_document_projects"):
+        identity_field = "author"
+    else:
+        identity_field = "requestor"
     _validate_requestor_identity(client, arguments, identity_field)
 
     if name == "cerefox_search":
         return await _handle_search(client, embedder, settings, arguments)
     elif name == "cerefox_ingest":
         return await _handle_ingest(client, pipeline, arguments)
+    elif name == "cerefox_set_document_projects":
+        return await _handle_set_document_projects(client, arguments)
     elif name == "cerefox_list_metadata_keys":
         return await _handle_list_metadata_keys(client, arguments)
     elif name == "cerefox_get_document":
@@ -536,11 +612,23 @@ async def _handle_search(
 
 async def _handle_ingest(client: Any, pipeline: Any, arguments: dict) -> list[types.TextContent]:
     author = arguments.get("author") or "mcp-agent"
+    project_names_arg = arguments.get("project_names")
+    # Validate type (MCP clients sometimes pass a string for an array param)
+    if project_names_arg is not None and not isinstance(project_names_arg, list):
+        return [types.TextContent(
+            type="text",
+            text=(
+                "Invalid argument: project_names must be a JSON array of strings, "
+                f"got {type(project_names_arg).__name__}. For a single project use "
+                "project_name (string)."
+            ),
+        )]
     result = pipeline.ingest_text(
         text=arguments["content"],
         title=arguments["title"],
         source=arguments.get("source", "agent"),
         project_name=arguments.get("project_name"),
+        project_names=project_names_arg,
         metadata=arguments.get("metadata") or {},
         update_existing=bool(arguments.get("update_if_exists", False)),
         document_id=arguments.get("document_id") or None,
@@ -587,6 +675,68 @@ async def _handle_ingest(client: Any, pipeline: Any, arguments: dict) -> list[ty
             document_id=result.document_id, result_count=result.chunk_count,
         )
 
+    return [types.TextContent(type="text", text=msg)]
+
+
+async def _handle_set_document_projects(
+    client: Any, arguments: dict,
+) -> list[types.TextContent]:
+    """Set the full project-membership list for a document. Destructive replace."""
+    document_id = arguments.get("document_id", "")
+    project_names_arg = arguments.get("project_names")
+    author = arguments.get("author") or "mcp-agent"
+
+    if not document_id:
+        return [types.TextContent(
+            type="text",
+            text="Missing required argument: document_id (UUID from a prior cerefox_search result).",
+        )]
+    if project_names_arg is None or not isinstance(project_names_arg, list):
+        return [types.TextContent(
+            type="text",
+            text=(
+                "Missing or invalid argument: project_names must be a JSON array of "
+                "strings (empty array allowed to clear all memberships). Got: "
+                f"{type(project_names_arg).__name__}."
+            ),
+        )]
+    if not all(isinstance(n, str) for n in project_names_arg):
+        return [types.TextContent(
+            type="text",
+            text="project_names must contain only strings.",
+        )]
+
+    try:
+        result = client.set_document_projects(
+            document_id=document_id,
+            project_names=project_names_arg,
+            author=author,
+            author_type="agent",
+        )
+    except ValueError as exc:
+        return [types.TextContent(type="text", text=str(exc))]
+
+    client.log_usage(
+        operation="set-document-projects",
+        access_path="local-mcp",
+        requestor=author,
+        document_id=document_id,
+        result_count=len(result["project_ids"]),
+    )
+
+    if result["project_names"]:
+        msg = (
+            f"Set project memberships for document {document_id}:\n"
+            f"  Projects ({len(result['project_names'])}): {', '.join(result['project_names'])}\n"
+            f"  Project IDs: {', '.join(result['project_ids'])}\n"
+            "  Note: this REPLACED the previous membership set. Any projects not "
+            "listed above are no longer associated with this document."
+        )
+    else:
+        msg = (
+            f"Cleared all project memberships for document {document_id}. "
+            "The document no longer belongs to any project."
+        )
     return [types.TextContent(type="text", text=msg)]
 
 

--- a/supabase/functions/cerefox-ingest/index.ts
+++ b/supabase/functions/cerefox-ingest/index.ts
@@ -33,6 +33,7 @@ interface IngestRequest {
   content: string;
   document_id?: string;
   project_name?: string;
+  project_names?: string[]; // Full-set semantics; wins over project_name when both provided
   source?: string;
   metadata?: Record<string, unknown>;
   update_if_exists?: boolean;
@@ -344,6 +345,52 @@ async function ensureDocumentInProject(
   return projectId;
 }
 
+// ── Destructive set-the-full-list helper (project_names list form) ─────────
+//
+// Resolves each name to a project_id (creating if absent), then REPLACES the
+// document's project memberships with exactly that set. Used by the
+// project_names: string[] form on cerefox_ingest (full-set semantics).
+//
+// Empty list = remove from all projects.
+
+// deno-lint-ignore no-explicit-any
+async function setDocumentProjectsByName(
+  // deno-lint-ignore no-explicit-any
+  supabase: any,
+  documentId: string,
+  projectNames: string[],
+): Promise<string[]> {
+  const projectIds: string[] = [];
+  for (const name of projectNames) {
+    if (!name) continue;
+    const { data: proj } = await supabase
+      .from("cerefox_projects")
+      .select("id")
+      .ilike("name", name)
+      .limit(1);
+    if (proj?.length) {
+      projectIds.push(proj[0].id);
+    } else {
+      const { data: newProj } = await supabase
+        .from("cerefox_projects")
+        .insert({ name })
+        .select("id");
+      if (newProj?.[0]?.id) projectIds.push(newProj[0].id);
+    }
+  }
+
+  // DELETE-then-INSERT replace (matches Python assign_document_projects).
+  await supabase
+    .from("cerefox_document_projects")
+    .delete()
+    .eq("document_id", documentId);
+  if (projectIds.length > 0) {
+    const rows = projectIds.map((pid) => ({ document_id: documentId, project_id: pid }));
+    await supabase.from("cerefox_document_projects").insert(rows);
+  }
+  return projectIds;
+}
+
 // ── Main handler ───────────────────────────────────────────────────────────
 
 Deno.serve(async (req: Request) => {
@@ -374,6 +421,18 @@ Deno.serve(async (req: Request) => {
   }
 
   const { title, content, document_id = null, project_name, source = "agent", metadata = {}, update_if_exists = false, author = "agent", author_type = "agent" } = body;
+
+  // Validate + normalize project_names if provided (full-set destructive form)
+  let project_names: string[] | null = null;
+  if (body.project_names !== undefined && body.project_names !== null) {
+    if (!Array.isArray(body.project_names)) {
+      return new Response(
+        JSON.stringify({ error: "project_names must be an array of strings; use project_name (string) for a single project" }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    project_names = body.project_names.filter((s): s is string => typeof s === "string" && s.length > 0);
+  }
 
   const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
   const supabaseKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
@@ -509,10 +568,12 @@ Deno.serve(async (req: Request) => {
       p_result_count: chunks.length,
     })).catch(() => {});
 
-    // Non-destructive project membership add (issue #38). If project_name is
-    // provided on an update, ensure the document is in that project without
-    // touching existing memberships.
-    if (project_name) {
+    // Project membership semantics on update (issue #38):
+    // - project_names (list) → destructive replace (full-set semantics)
+    // - project_name (singular) → non-destructive add (only if project_names absent)
+    if (project_names !== null) {
+      await setDocumentProjectsByName(supabase, existingDoc.id, project_names);
+    } else if (project_name) {
       await ensureDocumentInProject(supabase, existingDoc.id, project_name);
     }
 
@@ -616,8 +677,12 @@ Deno.serve(async (req: Request) => {
         p_result_count: chunks.length,
       })).catch(() => {});
 
-      // Non-destructive project membership add (issue #38).
-      if (project_name) {
+      // Project membership semantics on update (issue #38):
+      // - project_names (list) → destructive replace (full-set semantics)
+      // - project_name (singular) → non-destructive add (only if project_names absent)
+      if (project_names !== null) {
+        await setDocumentProjectsByName(supabase, existingDoc.id, project_names);
+      } else if (project_name) {
         await ensureDocumentInProject(supabase, existingDoc.id, project_name);
       }
 
@@ -710,11 +775,13 @@ Deno.serve(async (req: Request) => {
 
   const documentId = ingestResult[0].document_id;
 
-  // Resolve / create project if requested (separate from ingestion -- pure CRUD).
-  // Uses the shared non-destructive helper so create + update paths behave
-  // identically with respect to membership semantics (issue #38).
+  // Project assignment on CREATE:
+  // - project_names (list) → assign all
+  // - project_name (singular) → assign one via the non-destructive helper
   let projectId: string | null = null;
-  if (project_name) {
+  if (project_names !== null && project_names.length > 0) {
+    await setDocumentProjectsByName(supabase, documentId, project_names);
+  } else if (project_name) {
     projectId = await ensureDocumentInProject(supabase, documentId, project_name);
   }
 

--- a/supabase/functions/cerefox-mcp/index.ts
+++ b/supabase/functions/cerefox-mcp/index.ts
@@ -25,6 +25,7 @@ import { handleListVersions } from "./tools/list-versions.ts";
 import { handleGetAuditLog } from "./tools/audit-log.ts";
 import { handleListProjects } from "./tools/list-projects.ts";
 import { handleMetadataSearch } from "./tools/metadata-search.ts";
+import { handleSetDocumentProjects } from "./tools/set-document-projects.ts";
 
 const MCP_VERSION = "2025-03-26";
 const SERVER_NAME = "cerefox";
@@ -94,7 +95,14 @@ const TOOLS = [
         },
         project_name: {
           type: "string",
-          description: "Project to assign to (created if absent, optional)",
+          description:
+            "Optional: single project name (created if absent). On update: non-destructive add — ensures this membership exists; preserves other memberships an operator may have added via the web UI. For explicit set-the-full-list semantics, use project_names (list) instead, or call cerefox_set_document_projects.",
+        },
+        project_names: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Optional: explicit list of project names (each created if absent). Full-set semantics — on update this REPLACES the document's project memberships with exactly this set. Use when you want to set multiple projects at once or deliberately change the membership list. Wins over project_name when both are passed.",
         },
         source: {
           type: "string",
@@ -275,6 +283,33 @@ const TOOLS = [
       },
     },
   },
+  {
+    name: "cerefox_set_document_projects",
+    description:
+      "Set the document's project memberships to EXACTLY the given list. Destructive replace: any existing memberships not in this list are removed. Pass an empty list to clear all project memberships. Projects are looked up by name (case-insensitive); missing projects are created. Logged as update-metadata in the audit log — content is untouched. Use cerefox_ingest with project_names if you want to set memberships AND update content in one call. Use this tool when you only need to change project membership without re-writing the document body.",
+    inputSchema: {
+      type: "object",
+      required: ["document_id", "project_names"],
+      properties: {
+        document_id: {
+          type: "string",
+          description:
+            "UUID of the document. Get this from a prior cerefox_search result (the [id: ...] tag after the title).",
+        },
+        project_names: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Explicit list of project names. Each created if absent. Order is preserved. Empty list = remove from all projects.",
+        },
+        author: {
+          type: "string",
+          description:
+            'Agent or tool name recorded in the audit log. Defaults to "mcp-agent". May be enforced via server config.',
+        },
+      },
+    },
+  },
 ];
 
 // ── Method handlers ──────────────────────────────────────────────────────────
@@ -322,6 +357,8 @@ async function dispatchToolCall(
       return await handleListProjects(args);
     case "cerefox_metadata_search":
       return await handleMetadataSearch(args);
+    case "cerefox_set_document_projects":
+      return await handleSetDocumentProjects(args);
     default:
       throw new Error(`Unknown tool: ${name}`);
   }

--- a/supabase/functions/cerefox-mcp/tools/ingest.ts
+++ b/supabase/functions/cerefox-mcp/tools/ingest.ts
@@ -244,6 +244,54 @@ async function ensureDocumentInProject(
   return projectId;
 }
 
+// ── Destructive set-the-full-list helper (project_names list form) ─────────
+//
+// Resolves each name to a project_id (creating if absent), then REPLACES the
+// document's project memberships with exactly that set. Used by the
+// project_names: string[] form on cerefox_ingest (full-set semantics) and by
+// the cerefox_set_document_projects MCP tool.
+//
+// Empty list = remove from all projects.
+
+// deno-lint-ignore no-explicit-any
+async function setDocumentProjectsByName(
+  // deno-lint-ignore no-explicit-any
+  supabase: any,
+  documentId: string,
+  projectNames: string[],
+): Promise<string[]> {
+  // Resolve each name → project_id (create if absent). Preserve order.
+  const projectIds: string[] = [];
+  for (const name of projectNames) {
+    if (!name) continue;
+    const { data: proj } = await supabase
+      .from("cerefox_projects")
+      .select("id")
+      .ilike("name", name)
+      .limit(1);
+    if (proj?.length) {
+      projectIds.push(proj[0].id);
+    } else {
+      const { data: newProj } = await supabase
+        .from("cerefox_projects")
+        .insert({ name })
+        .select("id");
+      if (newProj?.[0]?.id) projectIds.push(newProj[0].id);
+    }
+  }
+
+  // DELETE-then-INSERT replace (matches Python assign_document_projects).
+  await supabase
+    .from("cerefox_document_projects")
+    .delete()
+    .eq("document_id", documentId);
+  if (projectIds.length > 0) {
+    const rows = projectIds.map((pid) => ({ document_id: documentId, project_id: pid }));
+    await supabase.from("cerefox_document_projects").insert(rows);
+  }
+  return projectIds;
+}
+
 // ── Handler ────────────────────────────────────────────────────────────────
 
 export async function handleIngest(
@@ -254,6 +302,7 @@ export async function handleIngest(
   const content = args.content as string | undefined;
   const document_id = (args.document_id as string | undefined) ?? null;
   const project_name = args.project_name as string | undefined;
+  const project_names_raw = args.project_names;
   const source = (args.source as string | undefined) ?? "agent";
   const metadata = (args.metadata as Record<string, unknown> | undefined) ?? {};
   const update_if_exists = (args.update_if_exists as boolean | undefined) ?? false;
@@ -263,6 +312,16 @@ export async function handleIngest(
   if (!title || !content?.trim()) {
     throw new Error("title and content are required");
   }
+  // Validate project_names is an array if provided
+  if (project_names_raw !== undefined && project_names_raw !== null
+      && !Array.isArray(project_names_raw)) {
+    throw new Error(
+      "project_names must be a JSON array of strings; for a single project use project_name (string)",
+    );
+  }
+  const project_names: string[] | null = Array.isArray(project_names_raw)
+    ? project_names_raw.filter((s): s is string => typeof s === "string" && s.length > 0)
+    : null;
 
   const supabase = makeSupabaseClient();
   const contentHash = await sha256hex(normalizeContent(content));
@@ -334,10 +393,13 @@ export async function handleIngest(
       document_id: existingDoc.id, result_count: chunks.length,
     });
 
-    // Non-destructive project membership add (issue #38). If project_name is
-    // provided on an update, ensure the document is in that project without
-    // touching existing memberships.
-    if (project_name) {
+    // Project membership semantics on update (issue #38):
+    // - project_names (list) → destructive replace (full-set semantics)
+    // - project_name (singular) → non-destructive add (only if project_names absent)
+    // - Neither → no change
+    if (project_names !== null) {
+      await setDocumentProjectsByName(supabase, existingDoc.id, project_names);
+    } else if (project_name) {
       await ensureDocumentInProject(supabase, existingDoc.id, project_name);
     }
 
@@ -406,8 +468,12 @@ export async function handleIngest(
         document_id: existingDoc.id, result_count: chunks.length,
       });
 
-      // Non-destructive project membership add (issue #38).
-      if (project_name) {
+      // Project membership semantics on update (issue #38):
+      // - project_names (list) → destructive replace (full-set semantics)
+      // - project_name (singular) → non-destructive add (only if project_names absent)
+      if (project_names !== null) {
+        await setDocumentProjectsByName(supabase, existingDoc.id, project_names);
+      } else if (project_name) {
         await ensureDocumentInProject(supabase, existingDoc.id, project_name);
       }
 
@@ -467,10 +533,14 @@ export async function handleIngest(
 
   const documentId = ingestResult[0].document_id;
 
-  // Resolve / create project if requested. Uses the shared non-destructive
-  // helper so create + update paths behave identically (issue #38).
+  // Project assignment on CREATE:
+  // - project_names (list) → assign all (destructive primitive runs on empty doc, so
+  //   no existing memberships are lost)
+  // - project_name (singular) → assign one via the non-destructive helper
   let projectId: string | null = null;
-  if (project_name) {
+  if (project_names !== null && project_names.length > 0) {
+    await setDocumentProjectsByName(supabase, documentId, project_names);
+  } else if (project_name) {
     projectId = await ensureDocumentInProject(supabase, documentId, project_name);
   }
 

--- a/supabase/functions/cerefox-mcp/tools/set-document-projects.ts
+++ b/supabase/functions/cerefox-mcp/tools/set-document-projects.ts
@@ -1,0 +1,144 @@
+// ── cerefox_set_document_projects tool handler ────────────────────────────
+//
+// Destructive replace of a document's project memberships. Mirror of the
+// Python CerefoxClient.set_document_projects + _handle_set_document_projects.
+//
+// Inputs: document_id (UUID), project_names (string[]), optional author.
+//
+// Semantics:
+//   - Verifies the document exists and isn't soft-deleted.
+//   - Resolves each project name to a project_id, creating projects that
+//     don't exist (case-insensitive name match against cerefox_projects).
+//   - DELETE-then-INSERT replace on cerefox_document_projects → exactly the
+//     listed projects remain.
+//   - Empty list = clear all memberships.
+//   - Logs an audit entry with operation="update-metadata" (project
+//     membership is metadata, not content).
+//   - Returns a human-readable summary; the document's content is untouched.
+//
+// Use cases (per AGENT_GUIDE.md):
+//   - Agent wants to change project membership without rewriting the doc.
+//   - Agent wants to add a doc to multiple projects at once (cleaner than N
+//     ingest calls).
+//   - Operator wants to consolidate / clean up project membership via an
+//     agent without touching content.
+
+import { makeSupabaseClient, logUsage } from "../shared.ts";
+
+export async function handleSetDocumentProjects(
+  args: Record<string, unknown>,
+): Promise<string> {
+  const document_id = (args.document_id as string | undefined)?.trim();
+  const project_names_raw = args.project_names;
+  const author = (args.author as string | undefined) ?? "mcp-agent";
+
+  if (!document_id) {
+    throw new Error(
+      "Missing required argument: document_id (UUID from a prior cerefox_search result).",
+    );
+  }
+  if (project_names_raw === undefined || project_names_raw === null
+      || !Array.isArray(project_names_raw)) {
+    throw new Error(
+      "Missing or invalid argument: project_names must be a JSON array of strings "
+      + "(empty array allowed to clear all memberships).",
+    );
+  }
+  if (!project_names_raw.every((n) => typeof n === "string")) {
+    throw new Error("project_names must contain only strings.");
+  }
+
+  // Strip empties; preserve order; dedup case-insensitively.
+  const seenLower = new Set<string>();
+  const cleanNames: string[] = [];
+  for (const n of project_names_raw as string[]) {
+    const stripped = n.trim();
+    if (!stripped) continue;
+    const key = stripped.toLowerCase();
+    if (seenLower.has(key)) continue;
+    seenLower.add(key);
+    cleanNames.push(stripped);
+  }
+
+  const supabase = makeSupabaseClient();
+
+  // Verify the document exists and isn't soft-deleted.
+  const { data: doc } = await supabase
+    .from("cerefox_documents")
+    .select("id, title")
+    .eq("id", document_id)
+    .is("deleted_at", null)
+    .limit(1);
+  if (!doc?.length) {
+    throw new Error(`Document not found (or soft-deleted): ${document_id}`);
+  }
+
+  // Resolve each name → project_id (create if absent). Preserve order.
+  const projectIds: string[] = [];
+  for (const name of cleanNames) {
+    const { data: proj } = await supabase
+      .from("cerefox_projects")
+      .select("id")
+      .ilike("name", name)
+      .limit(1);
+    if (proj?.length) {
+      projectIds.push(proj[0].id);
+    } else {
+      const { data: newProj } = await supabase
+        .from("cerefox_projects")
+        .insert({ name })
+        .select("id");
+      if (newProj?.[0]?.id) projectIds.push(newProj[0].id);
+    }
+  }
+
+  // DELETE-then-INSERT replace (matches Python assign_document_projects).
+  await supabase
+    .from("cerefox_document_projects")
+    .delete()
+    .eq("document_id", document_id);
+  if (projectIds.length > 0) {
+    const rows = projectIds.map((pid) => ({ document_id, project_id: pid }));
+    await supabase.from("cerefox_document_projects").insert(rows);
+  }
+
+  // Audit entry — project membership is metadata, not content.
+  try {
+    await supabase.rpc("cerefox_create_audit_entry", {
+      p_document_id: document_id,
+      p_version_id: null,
+      p_operation: "update-metadata",
+      p_author: author,
+      p_author_type: "agent",
+      p_size_before: null,
+      p_size_after: null,
+      p_description: cleanNames.length > 0
+        ? `Set document projects to [${cleanNames.join(", ")}]`
+        : "Cleared all project memberships",
+    });
+  } catch (err) {
+    console.warn("set-document-projects: audit entry failed", err);
+  }
+
+  // Usage log.
+  logUsage(supabase, {
+    operation: "set-document-projects",
+    requestor: author,
+    document_id,
+    result_count: projectIds.length,
+  });
+
+  if (cleanNames.length === 0) {
+    return (
+      `Cleared all project memberships for document ${document_id}. `
+      + "The document no longer belongs to any project."
+    );
+  }
+  return (
+    `Set project memberships for document ${document_id}:\n`
+    + `  Projects (${cleanNames.length}): ${cleanNames.join(", ")}\n`
+    + `  Project IDs: ${projectIds.join(", ")}\n`
+    + "  Note: this REPLACED the previous membership set. Any projects not "
+    + "listed above are no longer associated with this document."
+  );
+}

--- a/tests/e2e/test_mcp_e2e.py
+++ b/tests/e2e/test_mcp_e2e.py
@@ -86,7 +86,7 @@ class TestMCPHealthAndProtocol:
         assert result["serverInfo"]["name"] == "cerefox"
 
     def test_tools_list(self, e2e_mcp: MCPClient | None) -> None:
-        """MCP-3: tools/list returns all 8 tools with correct names and inputSchemas."""
+        """MCP-3: tools/list returns all 9 tools with correct names and inputSchemas."""
         if e2e_mcp is None:
             pytest.skip("No anon key -- skipping MCP e2e tests")
         resp = e2e_mcp.call("tools/list")
@@ -102,6 +102,7 @@ class TestMCPHealthAndProtocol:
             "cerefox_get_audit_log",
             "cerefox_list_projects",
             "cerefox_metadata_search",
+            "cerefox_set_document_projects",  # v0.1.20: Part 4 of issue #38 fix
         }
         assert tool_names == expected
         for tool in tools:

--- a/tests/ingestion/test_pipeline.py
+++ b/tests/ingestion/test_pipeline.py
@@ -1065,6 +1065,302 @@ class TestAddDocumentToProjects:
         )
 
 
+# ── Issue #38 follow-up: project_names list parameter (full-set semantics) ────
+
+
+class TestProjectNamesListParameter:
+    """Parts 3 of the issue #38 coordinated fix.
+
+    The new ``project_names: list[str]`` parameter on ``cerefox_ingest`` gives
+    agents explicit full-set semantics — "set the document's project memberships
+    to exactly this list." Wins over the singular ``project_name`` when both are
+    passed. On update, this is a destructive replace (the contract the web UI's
+    edit form already used via ``project_ids``).
+    """
+
+    @pytest.fixture()
+    def existing_doc(self) -> dict:
+        return {
+            "id": "doc-multi",
+            "title": "Multi-Project Note",
+            "content_hash": "oldhash",
+            "metadata": {},
+            "chunk_count": 1,
+            "total_chars": 50,
+            "source_path": "multi.md",
+        }
+
+    # ── Create path: project_names assigns the full set ──────────────────────
+
+    def test_create_with_project_names_assigns_all(
+        self, pipeline, mock_client, mock_embedder
+    ) -> None:
+        # get_or_create_project called once per name; assign called with full UUID list
+        mock_client.get_document_by_hash.return_value = None
+        mock_client.get_or_create_project.side_effect = [
+            {"id": "pid-a", "name": "Cerefox"},
+            {"id": "pid-b", "name": "research"},
+        ]
+        mock_embedder.embed_batch.return_value = [[0.0] * 768]
+
+        result = pipeline.ingest_text(
+            "# T\n\nBody.",
+            title="Multi-Project Note",
+            project_names=["Cerefox", "research"],
+        )
+
+        assert mock_client.get_or_create_project.call_count == 2
+        mock_client.assign_document_projects.assert_called_once_with(
+            "doc-001", ["pid-a", "pid-b"]
+        )
+        assert result.project_ids == ["pid-a", "pid-b"]
+
+    def test_project_names_takes_precedence_over_project_name(
+        self, pipeline, mock_client, mock_embedder
+    ) -> None:
+        """When both project_names and project_name are passed, the list wins."""
+        mock_client.get_document_by_hash.return_value = None
+        mock_client.get_or_create_project.side_effect = [
+            {"id": "pid-list-a", "name": "A"},
+            {"id": "pid-list-b", "name": "B"},
+        ]
+        mock_embedder.embed_batch.return_value = [[0.0] * 768]
+
+        pipeline.ingest_text(
+            "# T\n\nBody.",
+            title="X",
+            project_names=["A", "B"],
+            project_name="would-be-ignored",
+        )
+
+        # Only the two names from project_names get resolved
+        assert mock_client.get_or_create_project.call_count == 2
+        mock_client.assign_document_projects.assert_called_once_with(
+            "doc-001", ["pid-list-a", "pid-list-b"]
+        )
+
+    def test_project_ids_still_takes_precedence_over_project_names(
+        self, pipeline, mock_client, mock_embedder
+    ) -> None:
+        """project_ids is the most direct form; wins even over project_names."""
+        mock_client.get_document_by_hash.return_value = None
+        mock_embedder.embed_batch.return_value = [[0.0] * 768]
+
+        pipeline.ingest_text(
+            "# T\n\nBody.",
+            title="X",
+            project_ids=["pid-direct"],
+            project_names=["would-be-ignored"],
+        )
+
+        # project_names should NOT be resolved when project_ids is provided
+        mock_client.get_or_create_project.assert_not_called()
+        mock_client.assign_document_projects.assert_called_once_with(
+            "doc-001", ["pid-direct"]
+        )
+
+    # ── Update path: project_names = destructive replace ─────────────────────
+
+    def test_update_existing_with_project_names_replaces(
+        self, pipeline, mock_client, mock_embedder, existing_doc
+    ) -> None:
+        """On update_existing, project_names is full-set destructive replace."""
+        mock_client.find_document_by_source_path.return_value = None
+        mock_client.find_document_by_title.return_value = existing_doc
+        mock_client.get_document_by_id.return_value = existing_doc
+        mock_client.get_document_by_hash.return_value = None
+        mock_client.update_document.return_value = existing_doc
+        mock_client.get_document_project_ids.return_value = []
+        mock_client.get_or_create_project.side_effect = [
+            {"id": "pid-x", "name": "X"},
+            {"id": "pid-y", "name": "Y"},
+        ]
+        mock_embedder.embed_batch.return_value = [[0.0] * 768]
+
+        pipeline.ingest_text(
+            "# T\n\nBody.",
+            title="Multi-Project Note",
+            update_existing=True,
+            project_names=["X", "Y"],
+        )
+
+        # Destructive primitive called with the resolved list (full-set replace)
+        mock_client.assign_document_projects.assert_called_once_with(
+            "doc-multi", ["pid-x", "pid-y"]
+        )
+        # Non-destructive add primitive NOT called (list form short-circuits it)
+        mock_client.add_document_to_projects.assert_not_called()
+
+    def test_document_id_branch_with_project_names_replaces(
+        self, pipeline, mock_client, mock_embedder, existing_doc
+    ) -> None:
+        """Same for the document_id update branch."""
+        mock_client.get_document_by_id.return_value = existing_doc
+        mock_client.get_document_by_hash.return_value = None
+        mock_client.update_document.return_value = existing_doc
+        mock_client.get_document_project_ids.return_value = []
+        mock_client.get_or_create_project.return_value = {"id": "pid-only", "name": "Only"}
+        mock_embedder.embed_batch.return_value = [[0.0] * 768]
+
+        pipeline.ingest_text(
+            "# T\n\nBody.",
+            title="Multi-Project Note",
+            document_id="doc-multi",
+            project_names=["Only"],
+        )
+
+        mock_client.assign_document_projects.assert_called_once_with("doc-multi", ["pid-only"])
+        mock_client.add_document_to_projects.assert_not_called()
+
+    def test_update_with_empty_project_names_clears_all(
+        self, pipeline, mock_client, mock_embedder, existing_doc
+    ) -> None:
+        """Empty project_names list = remove from all projects (matches assign contract)."""
+        mock_client.find_document_by_source_path.return_value = None
+        mock_client.find_document_by_title.return_value = existing_doc
+        mock_client.get_document_by_id.return_value = existing_doc
+        mock_client.get_document_by_hash.return_value = None
+        mock_client.update_document.return_value = existing_doc
+        mock_client.get_document_project_ids.return_value = []
+        mock_embedder.embed_batch.return_value = [[0.0] * 768]
+
+        pipeline.ingest_text(
+            "# T\n\nBody.",
+            title="Multi-Project Note",
+            update_existing=True,
+            project_names=[],
+        )
+
+        # Empty list → assign called with [] (the documented "clear all" form)
+        mock_client.assign_document_projects.assert_called_once_with("doc-multi", [])
+
+    def test_project_names_empty_strings_filtered(
+        self, pipeline, mock_client, mock_embedder
+    ) -> None:
+        """Empty-string entries are dropped, same as project_ids."""
+        mock_client.get_document_by_hash.return_value = None
+        mock_client.get_or_create_project.return_value = {"id": "pid-x", "name": "X"}
+        mock_embedder.embed_batch.return_value = [[0.0] * 768]
+
+        pipeline.ingest_text(
+            "# T\n\nBody.",
+            title="X",
+            project_names=["", "X", ""],
+        )
+
+        # Only 'X' was resolved
+        assert mock_client.get_or_create_project.call_count == 1
+        mock_client.assign_document_projects.assert_called_once_with("doc-001", ["pid-x"])
+
+
+# ── Issue #38 follow-up: CerefoxClient.set_document_projects (Part 4) ─────────
+
+
+class TestSetDocumentProjects:
+    """Unit tests for the new CerefoxClient.set_document_projects method.
+
+    Backs the new cerefox_set_document_projects MCP tool. Semantics:
+      - Verify document exists (raise on missing).
+      - Resolve each project name (create if absent), dedup case-insensitively.
+      - Destructive replace via assign_document_projects.
+      - Audit entry with operation=update-metadata.
+    """
+
+    @pytest.fixture()
+    def client_with_mocks(self):
+        from cerefox.db.client import CerefoxClient
+
+        client = CerefoxClient.__new__(CerefoxClient)
+        client._client = MagicMock()
+        # Replace the methods we exercise with mocks; we test the orchestration,
+        # not the underlying primitives (which have their own tests).
+        client.get_document_by_id = MagicMock(return_value={"id": "doc-1", "title": "T"})
+        client.get_or_create_project = MagicMock()
+        client.assign_document_projects = MagicMock()
+        client.create_audit_entry = MagicMock()
+        return client
+
+    def test_resolves_names_and_replaces(self, client_with_mocks) -> None:
+        client_with_mocks.get_or_create_project.side_effect = [
+            {"id": "pid-a", "name": "Cerefox"},
+            {"id": "pid-b", "name": "research"},
+        ]
+
+        result = client_with_mocks.set_document_projects(
+            "doc-1", ["Cerefox", "research"], author="test", author_type="agent",
+        )
+
+        # Each name resolved exactly once
+        assert client_with_mocks.get_or_create_project.call_count == 2
+        # Destructive replace called with the resolved UUIDs in order
+        client_with_mocks.assign_document_projects.assert_called_once_with(
+            "doc-1", ["pid-a", "pid-b"],
+        )
+        # Audit entry created with update-metadata operation
+        audit_call = client_with_mocks.create_audit_entry.call_args
+        assert audit_call.kwargs["operation"] == "update-metadata"
+        assert audit_call.kwargs["document_id"] == "doc-1"
+        assert "Cerefox" in audit_call.kwargs["description"]
+        assert "research" in audit_call.kwargs["description"]
+        # Return shape
+        assert result["document_id"] == "doc-1"
+        assert result["project_ids"] == ["pid-a", "pid-b"]
+        assert result["project_names"] == ["Cerefox", "research"]
+
+    def test_empty_list_clears_all_memberships(self, client_with_mocks) -> None:
+        result = client_with_mocks.set_document_projects(
+            "doc-1", [], author="test", author_type="agent",
+        )
+
+        # No project resolution
+        client_with_mocks.get_or_create_project.assert_not_called()
+        # Destructive replace called with empty list (the documented "clear all" form)
+        client_with_mocks.assign_document_projects.assert_called_once_with("doc-1", [])
+        # Audit entry mentions clearing
+        audit_call = client_with_mocks.create_audit_entry.call_args
+        assert "Cleared" in audit_call.kwargs["description"]
+        assert result["project_ids"] == []
+        assert result["project_names"] == []
+
+    def test_raises_when_document_not_found(self, client_with_mocks) -> None:
+        client_with_mocks.get_document_by_id.return_value = None
+        with pytest.raises(ValueError, match="not found"):
+            client_with_mocks.set_document_projects("missing", ["any"])
+
+    def test_case_insensitive_dedup(self, client_with_mocks) -> None:
+        """Passing ['Foo', 'foo', 'FOO'] should resolve only one project."""
+        client_with_mocks.get_or_create_project.return_value = {"id": "pid-foo", "name": "Foo"}
+
+        result = client_with_mocks.set_document_projects(
+            "doc-1", ["Foo", "foo", "FOO"], author="test", author_type="agent",
+        )
+
+        assert client_with_mocks.get_or_create_project.call_count == 1
+        # Only the first form (with original casing) is kept
+        assert result["project_names"] == ["Foo"]
+        assert result["project_ids"] == ["pid-foo"]
+
+    def test_empty_string_names_filtered(self, client_with_mocks) -> None:
+        client_with_mocks.get_or_create_project.return_value = {"id": "pid-x", "name": "X"}
+        result = client_with_mocks.set_document_projects(
+            "doc-1", ["", "X", "   ", "X"], author="test", author_type="agent",
+        )
+        assert result["project_names"] == ["X"]
+        assert result["project_ids"] == ["pid-x"]
+
+    def test_audit_failure_does_not_break_call(self, client_with_mocks) -> None:
+        """If the audit entry fails (e.g., RLS), the project set still succeeds."""
+        client_with_mocks.get_or_create_project.return_value = {"id": "pid-a", "name": "A"}
+        client_with_mocks.create_audit_entry.side_effect = RuntimeError("audit logging down")
+
+        # Should not raise — audit failure is logged but swallowed
+        result = client_with_mocks.set_document_projects(
+            "doc-1", ["A"], author="test", author_type="agent",
+        )
+        assert result["project_ids"] == ["pid-a"]
+        client_with_mocks.assign_document_projects.assert_called_once_with("doc-1", ["pid-a"])
+
+
 # ── Title boosting (17A) ──────────────────────────────────────────────────────
 
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -75,7 +75,8 @@ class TestListTools:
     @pytest.mark.asyncio
     async def test_returns_all_tools(self) -> None:
         tools = await list_tools()
-        assert len(tools) == 8
+        # v0.1.20 adds cerefox_set_document_projects (Part 4 of issue #38 fix) → 9
+        assert len(tools) == 9
 
     @pytest.mark.asyncio
     async def test_tool_names(self) -> None:
@@ -90,6 +91,7 @@ class TestListTools:
             "cerefox_get_audit_log",
             "cerefox_list_projects",
             "cerefox_metadata_search",
+            "cerefox_set_document_projects",
         }
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Completes the coordinated four-part fix for [issue #38](https://github.com/fstamatelopoulos/cerefox/issues/38). Parts 1+2 (non-destructive add on update) landed in PR #39 and are already on `main`. This PR adds Parts 3+4:

- **Part 3**: new `project_names: string[]` parameter on `cerefox_ingest` — explicit full-set semantics from the MCP layer (destructive replace on update).
- **Part 4**: new MCP tool `cerefox_set_document_projects(document_id, project_names)` — metadata-only project-membership write, no content change. Logged as `update-metadata` in the audit log.

After this PR, the three paths (local Python MCP, remote MCP, `cerefox-ingest` Edge Function) share one contract:

| Caller form on update | Behavior |
|---|---|
| `project_name: "X"` (singular) | Non-destructive add. Ensures X is in the set; other memberships untouched. |
| `project_names: ["X","Y","Z"]` (list) | Destructive replace. Sets the doc's project set to exactly `{X,Y,Z}`. |
| `project_ids: [uuid-a, uuid-b]` (Python API only) | Same destructive-replace semantics; web UI's edit form contract. |
| Neither | No change to memberships. |

Tool count: **8 → 9**.

Local Python MCP also gained the `document_id` parameter on `cerefox_ingest` (separate inconsistency fixed while in the area — local MCP's schema was missing it relative to remote MCP).

## Test plan

- [x] 13 new unit tests (`TestProjectNamesListParameter`, `TestSetDocumentProjects`) — all pass
- [x] 508 unit + 80 e2e tests pass against the newly-deployed Edge Functions
- [x] Edge Functions deployed to live Supabase as part of verification
- [x] Live agent-visible MCP test through restarted local Python MCP server:
  - **Test 1**: `cerefox_set_document_projects(doc, [A,B,C])` → 3 assigned ✓
  - **Test 2**: `cerefox_ingest` update + singular `project_name="newly-added"` → non-destructive add (3 → 4) ✓
  - **Test 3**: `cerefox_ingest` update + `project_names=[X,Y]` → destructive replace (4 → 2) ✓
  - **Test 4**: `cerefox_set_document_projects(doc, [])` → cleared all ✓
- [x] Audit log records each Part 4 operation as `update-metadata` with correct author attribution
- [x] Remote MCP `tools/list` exposes 9 tools including `cerefox_set_document_projects`
- [x] `cerefox_ingest` schema on remote MCP includes `project_names: array` of strings

## Deploy

Edge Function redeploy already done on the maintainer's Supabase. For others upgrading from main:

```bash
npx supabase functions deploy cerefox-ingest
npx supabase functions deploy cerefox-mcp
```

See [`docs/guides/upgrading.md` → Upgrading to v0.1.20](https://github.com/fstamatelopoulos/cerefox/blob/fix/issue-38-multi-project-preservation/docs/guides/upgrading.md) for the full upgrade note.

## Documentation

- `AGENT_GUIDE.md`: "Project membership semantics" subsection under `cerefox_ingest` + full new section for `cerefox_set_document_projects`. Tool count updated 8 → 9.
- `AGENT_QUICK_REFERENCE.md`: rule #9 added; new tool listed; CLI mapping notes the new tool is MCP-only in v0.1.20.
- `docs/guides/upgrading.md`: full v0.1.20 upgrade section.
- `CHANGELOG.md` `[Unreleased]`: rewritten to cover all four parts of the coordinated fix as one story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)