### PR TITLE
v0.5.2 — strip the cerefox mcp (Python) soft wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,65 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
-Open roadmap.
+**Hotfix.** Strips the `cerefox mcp` (Python CLI) soft wrapper. Reported
+in the field: Claude Desktop fails to attach to the MCP server after
+restart when the config uses `uv run --directory /path/to/cerefox cerefox mcp`
+— "Could not attach to MCP server cerefox."
+
+### Fixed
+
+- **`cerefox mcp` (Python) no longer probes / execvp's via npx.** The
+  v0.4–v0.5.1 soft wrapper tried to delegate to the npm package's TS
+  MCP server when `@cerefox/memory` was installed, falling back to the
+  in-tree Python server otherwise. The probe — `npx --no-install
+  --package=@cerefox/memory cerefox --version` — was fundamentally
+  unreliable under `uv run`-launched contexts. `uv run` prepends
+  `.venv/bin/` to PATH; npx's PATH-fallback finds the venv's Python
+  `cerefox` console_script when the cached @cerefox/memory version
+  doesn't ship a `cerefox` bin (true for v0.4.x — only `cerefox-mcp`
+  existed there). Probe reports success; execvp PATH-falls-back to
+  the same Python `cerefox`; `_run_mcp()` recurses until the MCP
+  client times out. Fix: strip the wrapper. `cerefox mcp` (Python)
+  now directly starts the Python MCP server, period.
+
+- **Two paths to the MCP server, both explicit:**
+
+  | Path | Config form |
+  |---|---|
+  | Python in-tree MCP server | `"command": "/path/to/uv", "args": ["--directory", "/path/to/cerefox", "run", "cerefox", "mcp"]` |
+  | TS MCP server (npm-installed globally) | `"command": "cerefox", "args": ["mcp"]` |
+  | TS MCP server (npx ad-hoc) | `"command": "npx", "args": ["-y", "--package=@cerefox/memory", "cerefox", "mcp"]` |
+
+  All three are functionally equivalent (same 10 tools, same wire
+  shapes). Pick whichever fits your environment.
+
+### Changed
+
+- **`tests/test_mcp_soft_wrapper.py`** rewritten — old tests asserted
+  on probe args / execvp args / fallback stderr messages; new tests
+  guard against re-introducing the bug class by asserting `_run_mcp()`
+  doesn't call `subprocess.run` or `os.execvp` or `shutil.which`.
+
+- **`docs/guides/migration-v0.5.md`** gains a "v0.5.2 fixed the soft
+  wrapper" section explaining the recursion bug + the explicit config
+  forms.
+
+- **`docs/guides/migration-v0.4.md`** updated to drop the "auto-delegation"
+  wording. Existing v0.4 configs still work — they just start the
+  Python server (which they always actually did when the probe
+  succeeded under uv-launched contexts, via the PATH-fallback path
+  through `.venv/bin/cerefox`, accidentally).
+
+### Migration
+
+No user-visible config change required. Anyone whose Claude Desktop
+was broken by this on v0.5.1 needs to pull the latest `main` and
+`uv sync` (or wait for v0.5.2 to land on PyPI — there is no PyPI
+publish for the Python CLI yet; it's installed from the repo today,
+so a `git pull && uv sync` is the upgrade path).
+
+The npm package `@cerefox/memory@0.5.1` is unaffected — the bug was
+entirely in the Python wrapper.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,7 +174,7 @@ Because `_shared/mcp-tools/*.ts` is imported by both Edge Functions (Deno) and t
 
 The normal release flow for v0.3.0+ is:
 
-1. PRs land on `main` without touching `VERSION`. `VERSION` sits at the last released value (e.g. `0.2.0`) while you accumulate changes.
+1. PRs land on `main` without touching `VERSION`. `VERSION` sits at the last released value (e.g. `0.5.1` at the time of writing) while you accumulate changes.
 2. When ready to cut, fill in the `## [Unreleased]` section of `CHANGELOG.md` with the release notes.
 3. From `main`, on a clean tree:
    ```bash

--- a/docs/guides/migration-v0.4.md
+++ b/docs/guides/migration-v0.4.md
@@ -24,9 +24,14 @@ the canonical configuration recipe per MCP client.
   3 of MCP discoverability — agents can now retrieve
   `AGENT_QUICK_REFERENCE.md` content over MCP without filesystem
   access.
-- **`cerefox mcp` (Python CLI) is a soft wrapper**: tries to delegate
-  to `npx --package=@cerefox/memory cerefox-mcp` first; falls back to the legacy
-  Python implementation if npm/Bun isn't available.
+- **`cerefox mcp` (Python CLI)** starts the in-tree Python MCP server.
+  (v0.4–v0.5.1 advertised a "soft wrapper" that tried to delegate to the
+  npm package's TS MCP server via npx, but the probe was unreliable
+  under `uv run`-launched MCP-client contexts and caused infinite
+  recursion. v0.5.2 stripped the wrapper; the Python path is now
+  always the Python server, and the npm/TS path is configured
+  explicitly. See `docs/guides/migration-v0.5.md` § "v0.5.2 fixed the
+  soft wrapper" for the migration story.)
 
 ## The optional one-time upgrade
 
@@ -38,11 +43,18 @@ npm install -g @cerefox/memory
 bun install -g @cerefox/memory
 ```
 
-After this, your existing `cerefox mcp` configs automatically use the
-TS server (the soft wrapper detects the package and delegates).
+After this, the npm `cerefox` is on your PATH. To actually have your
+MCP client use the TS server, you need to **update your MCP client
+config explicitly** — v0.5.2 removed the auto-delegation. The
+canonical config invokes the npm bin directly; see the next section.
 
-You can also point your MCP client directly at `cerefox-mcp` (the bin
-shipped by the package) and bypass the Python wrapper entirely:
+(v0.4–v0.5.1 *thought* it had auto-delegation, but the soft wrapper
+was unreliable under `uv run`-launched contexts and caused infinite
+recursion when the MCP client launched it. v0.5.2 took the simpler
+"each path is explicit" stance.)
+
+You can also point your MCP client directly at `cerefox mcp` (the
+TS-CLI subcommand) and bypass the Python path entirely:
 
 ### Claude Code
 

--- a/docs/guides/migration-v0.5.md
+++ b/docs/guides/migration-v0.5.md
@@ -149,6 +149,53 @@ cerefox configure-agent --tool claude-code              # apply
 
 ---
 
+## v0.5.2 fixed the soft wrapper
+
+v0.4.0 through v0.5.1 advertised that `cerefox mcp` (the Python CLI's
+subcommand, used by configs of the form `uv run --directory /path/to/cerefox cerefox mcp`)
+was a "soft wrapper": it would try to delegate to the npm package's
+TS MCP server via `npx --no-install --package=@cerefox/memory cerefox`
+and fall back to the in-tree Python server otherwise.
+
+**The probe was unreliable under `uv run`-launched MCP-client contexts.**
+`uv run` puts the project's `.venv/bin/` first on PATH. When the npm
+cache only has v0.4.x (which doesn't ship a `cerefox` bin name), npx
+falls back to PATH and finds `.venv/bin/cerefox` — the Python CLI
+itself — making the probe report success. The execvp then PATH-falls
+back to the same `.venv/bin/cerefox`, which calls `_run_mcp()` again
+→ infinite recursion → MCP client times out with "Could not attach
+to MCP server cerefox."
+
+**v0.5.2 stripped the wrapper.** `cerefox mcp` always starts the
+in-tree Python MCP server. To use the TS MCP server, configure your
+client to invoke it explicitly:
+
+```json
+"command": "npx",
+"args": ["-y", "--package=@cerefox/memory", "cerefox", "mcp"]
+```
+
+or, if you have `@cerefox/memory` installed globally:
+
+```json
+"command": "cerefox",
+"args": ["mcp"]
+```
+
+The two paths (Python via `uv run`, TS via `cerefox mcp` on PATH or
+via `npx`) are functionally equivalent — same 10 MCP tools, same wire
+shapes. Pick whichever fits your environment, but the choice is now
+explicit instead of "magic delegation".
+
+> **Affected configs**: if your Claude Desktop / Claude Code / Cursor
+> config invokes `uv run … cerefox mcp` AND you saw "Could not attach
+> to MCP server cerefox" after restarting your client on
+> @cerefox/memory v0.5.1 or earlier, this is the bug. Upgrade to
+> v0.5.2+ (pull `main` and `uv sync`) — the Python MCP server boots
+> directly and your existing config works again.
+
+---
+
 ## Known gotchas
 
 ### `npx` from inside an npm workspace

--- a/src/cerefox/cli.py
+++ b/src/cerefox/cli.py
@@ -1029,88 +1029,47 @@ def reindex(batch: int, reindex_all: bool, dry_run: bool) -> None:
 
 @cli.command("mcp")
 def mcp_server() -> None:
-    """Start the Cerefox MCP server (stdio transport).
+    """Start the Cerefox MCP server (Python; stdio transport).
 
-    Soft wrapper as of v0.4.0: tries the new TypeScript implementation
-    (@cerefox/memory on npm) first; falls back to the legacy Python
-    server if Bun/Node + the npm package aren't available.
+    This command always starts the in-tree Python MCP server.
+    Functionally identical to the TS MCP server in `@cerefox/memory`
+    (same 10 tools, same wire shapes), so MCP clients see the same
+    surface regardless of which path they're configured to use.
 
-    The new TS server has 10 tools (the 9 Cerefox tools + cerefox_get_help);
-    the legacy Python fallback also exposes all 10 so MCP clients see the
-    same surface regardless of which path serves them.
+    .. note::
+       v0.4.0–v0.5.1 had a "soft wrapper" here that tried `npx`-delegation
+       to the npm package's TS MCP server before falling back to the
+       Python server. The probe was fundamentally unreliable: under
+       `uv run`-launched contexts (which Claude Desktop and other MCP
+       clients use), `npx --no-install --package=@cerefox/memory cerefox`
+       falls back to the venv's Python `cerefox` console_script when the
+       cached npm package doesn't ship a `cerefox` bin (true for v0.4.x).
+       That made the probe report success, then execvp'd into the same
+       PATH-fallback path, recursing until Claude Desktop timed out
+       and showed "Could not attach to MCP server cerefox."
 
-    Existing MCP configs pointing at `uv run cerefox mcp` keep working —
-    transport is stdio either way, agents see the same tools.
+       v0.5.2 stripped the wrapper. To use the TS MCP server, configure
+       your client to invoke it explicitly:
 
-    To upgrade to the TS path (faster boot, fewer Python deps):
+           "command": "npx",
+           "args": ["-y", "--package=@cerefox/memory", "cerefox", "mcp"]
 
-        bun install -g @cerefox/memory        # or: npm install -g @cerefox/memory
-
-    Then this command transparently forwards to it.
+       The Python path (this command) stays as the offline / no-npm
+       option. The two are no longer linked.
     """
     _run_mcp()
 
 
 def _run_mcp() -> None:
-    """Soft-wrapper logic — try npx, fall back to legacy Python.
+    """Start the in-tree Python MCP server.
 
-    Pulled out for unit testing (we patch subprocess + os.execvp without
-    bringing in Click's invocation machinery).
+    Pulled out as a separate function so unit tests can verify the entry
+    point without going through Click's invocation machinery.
+
+    v0.5.2: this is now a direct call to the legacy MCP server — no
+    npx probing, no execvp magic. See the docstring on `mcp_server`
+    for why the soft wrapper was removed.
     """
-    import os  # noqa: PLC0415
-    import shutil  # noqa: PLC0415
-    import subprocess  # noqa: PLC0415
-
-    npx = shutil.which("npx")
-    if npx is not None:
-        # Probe whether @cerefox/memory is already installed (globally or in
-        # npx's local cache). We don't want `npx` to silently pull from the
-        # registry on every server start — that adds a multi-second delay on
-        # first run and a hidden network dependency.
-        #
-        # `--package=@cerefox/memory cerefox` is the canonical npx invocation
-        # for the @cerefox/memory bin. v0.5.0 also shipped a `cerefox-mcp`
-        # bin as a v0.4 backward-compat shim; v0.5.1 removed it. Probe the
-        # current canonical form; users on v0.5.0 (briefly published with
-        # both bins) keep working because `cerefox` is in both v0.5.x lines.
-        probe = subprocess.run(
-            [npx, "--no-install", "--package=@cerefox/memory", "cerefox", "--version"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-            check=False,
-        )
-        if probe.returncode == 0:
-            # Forward stdio cleanly; replace the current process so the MCP
-            # client's stdio pipes connect directly to the TS server. The
-            # `mcp` arg invokes the MCP subcommand inside the `cerefox` bin
-            # (which then calls buildServer() in-process).
-            os.execvp(
-                npx,
-                [npx, "--no-install", "--package=@cerefox/memory", "cerefox", "mcp"],
-            )
-            # `execvp` doesn't return on success. The `return` below is
-            # defensive — tests sometimes mock execvp so it returns
-            # normally, and we don't want the legacy fallback to kick in
-            # then. If execvp ever fails for real (e.g. the bin file was
-            # deleted between the probe and the exec), it raises OSError,
-            # which propagates out and crashes the server — the user fixes
-            # their install.
-            return
-
-        click.echo(
-            "ℹ  @cerefox/memory not installed; falling back to legacy Python MCP server.\n"
-            "   Run `npm install -g @cerefox/memory` (or `bun install -g …`) for the new TS version.",
-            err=True,
-        )
-    else:
-        click.echo(
-            "ℹ  npx not found; falling back to legacy Python MCP server.\n"
-            "   Install Node 20+ and `npm install -g @cerefox/memory` for the new TS version.",
-            err=True,
-        )
-
-    # Legacy fallback — the existing Python MCP server.
     from cerefox.mcp_server import run  # noqa: PLC0415
 
     run()

--- a/tests/test_mcp_soft_wrapper.py
+++ b/tests/test_mcp_soft_wrapper.py
@@ -1,11 +1,24 @@
-"""Tests for the `cerefox mcp` soft wrapper (iter-22 Part E).
+"""Tests for the `cerefox mcp` command.
 
-The wrapper tries `npx @cerefox/memory cerefox-mcp` first; falls back to
-the legacy Python server with a stderr nudge if npx is missing or the
-package isn't installed.
+v0.4.0–v0.5.1 had a "soft wrapper" here that probed for the npm
+`@cerefox/memory` package via npx and delegated via execvp when found,
+falling back to the in-tree Python MCP server otherwise. The probe was
+fundamentally unreliable in `uv run`-launched contexts (which Claude
+Desktop and other MCP clients use): PATH starts with `.venv/bin/` and
+the Python `cerefox` console_script there satisfies npx's PATH-fallback
+lookup, making the probe report success even when @cerefox/memory has
+no `cerefox` bin in its cached version. The execvp then PATH-falls-back
+again to the Python `cerefox`, recursing into `_run_mcp()` forever
+until the MCP client times out.
 
-We mock `shutil.which`, `subprocess.run`, and `os.execvp` so the tests
-never actually spawn a process.
+v0.5.2 stripped the wrapper. `_run_mcp()` now directly starts the
+in-tree Python MCP server, period. Users who want the TS MCP server
+configure their client to invoke `cerefox mcp` (npm-installed) or
+`npx -y --package=@cerefox/memory cerefox mcp` directly. The two
+paths are no longer linked.
+
+These tests verify the post-strip contract: no subprocess probing,
+no execvp, just a direct call to `cerefox.mcp_server.run()`.
 """
 
 from __future__ import annotations
@@ -17,93 +30,40 @@ import pytest
 
 @pytest.fixture
 def mock_legacy_run():
-    """Pin `cerefox.mcp_server.run` so the fallback path is observable
+    """Pin `cerefox.mcp_server.run` so we can verify it was called
     without actually starting an MCP server."""
     with patch("cerefox.mcp_server.run") as m:
         yield m
 
 
-class TestSoftWrapper:
-    def test_uses_npx_when_package_is_installed(self, mock_legacy_run):
-        """Happy path: npx + @cerefox/memory both present → execvp delegates,
-        legacy fallback never runs."""
+class TestRunMcp:
+    def test_run_mcp_starts_python_mcp_server(self, mock_legacy_run):
+        """`_run_mcp()` must directly invoke the in-tree Python MCP
+        server — no npx delegation, no execvp."""
         from cerefox.cli import _run_mcp
 
+        # Probes / execvp must NEVER be called now — the soft wrapper is
+        # gone. If a future commit re-introduces them, this guard fails.
         with (
-            patch("shutil.which", return_value="/opt/homebrew/bin/npx"),
-            patch("subprocess.run") as mock_run,
-            patch("os.execvp") as mock_execvp,
-        ):
-            mock_run.return_value = MagicMock(returncode=0, stdout="0.4.0", stderr="")
-            _run_mcp()
-
-        mock_execvp.assert_called_once()
-        args = mock_execvp.call_args.args
-        assert args[0] == "/opt/homebrew/bin/npx"
-        # v0.5.1: canonical npx invocation is
-        # `npx --package=@cerefox/memory cerefox mcp` (the legacy
-        # `cerefox-mcp` bin was dropped in v0.5.1).
-        assert "--package=@cerefox/memory" in args[1]
-        assert "cerefox" in args[1]
-        assert "mcp" in args[1]
-        # Legacy path NOT called.
-        mock_legacy_run.assert_not_called()
-
-    def test_falls_back_when_npx_missing(self, mock_legacy_run, capsys):
-        """No npx in PATH → falls back to legacy Python MCP server."""
-        from cerefox.cli import _run_mcp
-
-        with (
-            patch("shutil.which", return_value=None),
+            patch("subprocess.run") as mock_subprocess_run,
             patch("os.execvp") as mock_execvp,
         ):
             _run_mcp()
 
-        mock_execvp.assert_not_called()
         mock_legacy_run.assert_called_once()
-        stderr = capsys.readouterr().err
-        assert "npx not found" in stderr
-        assert "@cerefox/memory" in stderr
-
-    def test_falls_back_when_package_not_installed(self, mock_legacy_run, capsys):
-        """npx present but @cerefox/memory not installed → fallback with nudge."""
-        from cerefox.cli import _run_mcp
-
-        with (
-            patch("shutil.which", return_value="/usr/bin/npx"),
-            patch("subprocess.run") as mock_run,
-            patch("os.execvp") as mock_execvp,
-        ):
-            mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="")
-            _run_mcp()
-
+        mock_subprocess_run.assert_not_called()
         mock_execvp.assert_not_called()
-        mock_legacy_run.assert_called_once()
-        stderr = capsys.readouterr().err
-        assert "@cerefox/memory not installed" in stderr
 
-    def test_probe_uses_no_install_flag(self, mock_legacy_run):
-        """The probe must include --no-install so it doesn't hit the registry
-        on every server start (multi-second delay + hidden network dep)."""
+    def test_run_mcp_does_not_inspect_path(self, mock_legacy_run):
+        """`_run_mcp()` must not call `shutil.which("npx")` or any
+        equivalent PATH probe. That was the bug class in v0.4-v0.5.1."""
         from cerefox.cli import _run_mcp
 
-        with (
-            patch("shutil.which", return_value="/usr/bin/npx"),
-            patch("subprocess.run") as mock_run,
-            patch("os.execvp"),
-        ):
-            mock_run.return_value = MagicMock(returncode=0, stdout="0.4.0", stderr="")
+        with patch("shutil.which") as mock_which:
             _run_mcp()
 
-        # Asserts on the first (and only) subprocess.run call: the probe.
-        probe_args = mock_run.call_args.args[0]
-        assert "--no-install" in probe_args
-        assert "--version" in probe_args
-        # v0.5.1: probe targets the `cerefox` bin (with --package= form
-        # so npx resolves @cerefox/memory). v0.4.1 / v0.5.0 used the
-        # `cerefox-mcp` bin name; that bin was dropped in v0.5.1.
-        assert "--package=@cerefox/memory" in probe_args
-        assert "cerefox" in probe_args
+        mock_legacy_run.assert_called_once()
+        mock_which.assert_not_called()
 
 
 class TestPythonGetHelp:


### PR DESCRIPTION
## TL;DR

Hotfix for the "Could not attach to MCP server cerefox" failure on Claude Desktop. Strips the v0.4–v0.5.1 soft wrapper from `cerefox mcp` (Python CLI), which had a latent infinite-recursion bug under `uv run`-launched MCP-client contexts. The Python MCP server now boots directly; no more probing or execvp.

## What was wrong

`_run_mcp()` probed `npx --no-install --package=@cerefox/memory cerefox --version` to detect whether the npm package was installed. Under `uv run` (the typical Claude Desktop / Cursor / Claude Code config form), PATH starts with `.venv/bin/`. When npx couldn't find a `cerefox` bin in the cached `@cerefox/memory` (v0.4.x didn't ship one — only `cerefox-mcp`), it **fell back to PATH** and ran `.venv/bin/cerefox` — the Python CLI. Probe exit 0; soft wrapper assumed "npm package installed"; execvp'd → npx PATH-fell-back again → Python `cerefox mcp` → `_run_mcp()` → recursion → Claude Desktop timeout.

I verified the failure mode end-to-end locally before fixing.

## Affected configs

- `"command": "uv", "args": ["--directory", "/path/…", "run", "cerefox", "mcp"]` ← the bug
- `"command": "cerefox", "args": ["mcp"]` ← unaffected (no Python wrapper)
- `"command": "npx", "args": ["…", "cerefox", "mcp"]` ← unaffected

## What changes

- **`src/cerefox/cli.py`**: `_run_mcp()` now directly calls `cerefox.mcp_server.run()`. No `shutil.which`, no `subprocess.run`, no `os.execvp`. The `mcp_server` Click command docstring documents why the wrapper was stripped.
- **`tests/test_mcp_soft_wrapper.py`**: rewritten. Old tests asserted on probe args / execvp args; new tests guard against re-introducing the bug class (assert no `subprocess.run`, no `os.execvp`, no `shutil.which`).
- **CHANGELOG**: hotfix story + the three-config-form table.
- **docs/guides/migration-v0.5.md**: new "v0.5.2 fixed the soft wrapper" section.
- **docs/guides/migration-v0.4.md**: "soft wrapper" wording removed.
- **CONTRIBUTING.md**: stale `e.g. 0.2.0` example → `e.g. 0.5.1`.

## Verification done

- 585 Python tests pass (was 587 — 2 obsolete soft-wrapper tests removed in the rewrite; coverage of the contract is now broader).
- Smoke: launched `uv run cerefox mcp` directly, drove `initialize` through stdin → server responded with the correct JSON-RPC shape, no recursion, no timeout.

## After merge

No npm cut needed — the npm package `@cerefox/memory@0.5.1` is unaffected (the bug lived entirely in the Python wrapper). To recover an existing maintainer install:

```bash
cd /path/to/cerefox && git pull --ff-only && uv sync
```

Then restart your MCP client. Your existing `uv run cerefox mcp` config will start working again.

## Known follow-up (not in this PR)

`src/cerefox/mcp_server.py` reports `serverInfo.version: "0.1.0"` (stale hardcoded literal). Cosmetic. Tracked for v0.5.3 or v0.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)