### PR TITLE
v0.5.3: paths precedence inversion + init coexistence flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,62 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
-Open roadmap.
+**v0.5.3 brings forward the v1.0 `.env` precedence flip for the TS CLI.**
+
+### Changed
+
+- **`_shared/config/paths.ts` precedence inverted**: when `~/.cerefox/.env`
+  exists, it now wins over the repo-local `<cwd>/.env` (the v0.5.2
+  precedence was the opposite). Existing users see **zero behavior change**
+  until they run `cerefox init` and create the home file — the legacy
+  dev-mode fallback (level 3 in the new ordering) catches that case
+  unchanged. After `init`, the TS CLI reads from `~/.cerefox/.env` and the
+  repo file becomes a Python-only fallback. Tests updated in
+  `_shared/__tests__/paths.test.ts`. New helper `hasLegacyCwdEnv()` powers
+  the doctor shadow-detection below. **Python `src/cerefox/paths.py` is
+  deliberately unchanged** (CWD still wins there) so existing
+  `uv run cerefox …` workflows keep reading the repo `.env` through the
+  v0.5–v0.7 migration window.
+
+- **`cerefox init` is migration-aware.** When the home file doesn't exist
+  but `<cwd>/.env` does, init now offers a three-choice prompt instead of
+  a binary overwrite:
+
+  | Choice | What happens | Best for |
+  |---|---|---|
+  | `[c]` Copy to `~/.cerefox/.env` *(default)* | Copies the repo file, chmods 0600, validates against Supabase + OpenAI. Repo file untouched. | Typical Python → TS upgrade. TS uses the new home; Python keeps the repo file. |
+  | `[u]` Use repo `.env` as-is | Validates the existing file. No copy, no write. | "I just want to verify the install works against my current config." |
+  | `[f]` Fresh start | Ignores the existing file, prompts interactively, writes a brand-new `~/.cerefox/.env`. | Stale or wrong existing config. |
+
+  Fresh installs (no `.env` anywhere) are unchanged — standard 5-step
+  interactive flow writes `~/.cerefox/.env`. Reconfigure (home file
+  already exists) is unchanged — standard overwrite confirmation.
+  `CEREFOX_CONFIG_DIR` overrides still win and skip the migration prompt.
+
+- **`cerefox doctor` reports shadowed legacy `.env`.** When both
+  `~/.cerefox/.env` and `<cwd>/.env` exist (and they're not the same file
+  via symlink), doctor adds an informational line:
+
+  ```
+  ℹ legacy env   /path/to/cerefox/.env (shadowed by ~/.cerefox/.env)
+      → Python `uv run cerefox …` still reads this during the v0.5–v0.7
+        migration window. Safe to delete in v0.9+.
+  ```
+
+  Doesn't fail doctor; just surfaces what's there.
+
+### Docs
+
+- `docs/guides/migration-v0.5.md` — new section "v0.5.3 migrated `.env`
+  from `<repo>/.env` to `~/.cerefox/.env`" with the three-choice menu
+  and the Python coexistence model.
+- `packages/memory/README.md` — "Upgrading from the Python `cerefox` CLI?"
+  callout pointing at the `[c]` copy flow.
+- `README.md` (root) — `configure-agent --tool claude-desktop` line added
+  alongside `--tool claude-code` (already shipped in v0.5.2; consolidated
+  framing here).
+- `src/cerefox/paths.py` docstring updated to cross-reference the v0.5.3
+  TS change.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,12 @@ npm install -g @cerefox/memory      # Node ≥ 20
 
 cerefox init                         # interactive 5-step setup
 cerefox doctor                       # verify the install
-cerefox configure-agent --tool claude-code   # wire up Claude Code
+
+# Wire up your MCP client(s) — run the ones that apply to your setup:
+cerefox configure-agent --tool claude-code      # Claude Code (~/.claude/mcp.json)
+cerefox configure-agent --tool claude-desktop   # Claude Desktop config
+# (Cursor / Codex / Gemini land in a future v0.5.x; see migration-v0.5.md
+#  for the manual config snippets in the meantime.)
 ```
 
 That's the path for end users who don't need to hack on Cerefox itself. For

--- a/_shared/__tests__/paths.test.ts
+++ b/_shared/__tests__/paths.test.ts
@@ -1,5 +1,9 @@
 /**
- * TS port of tests/test_paths.py. Same precedence rules covered.
+ * Tests for `_shared/config/paths.ts`. Covers the v0.5.3 precedence
+ * inversion: `~/.cerefox/.env` (when it exists) wins over repo-local
+ * `<cwd>/.env`, with the legacy dev-mode fallback retained for existing
+ * users who haven't migrated.
+ *
  * Run: `cd _shared && bun test` (or `bun test paths.test.ts`).
  */
 
@@ -9,6 +13,7 @@ import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
+  hasLegacyCwdEnv,
   isDevMode,
   resolveConfigDir,
   resolveEnvFile,
@@ -18,26 +23,38 @@ import {
 
 let savedEnv: string | undefined;
 let tmpDir: string;
+let fakeHome: string;
 
 beforeEach(() => {
   savedEnv = process.env.CEREFOX_CONFIG_DIR;
   delete process.env.CEREFOX_CONFIG_DIR;
-  tmpDir = mkdtempSync(join(tmpdir(), "cerefox-paths-"));
+  tmpDir = mkdtempSync(join(tmpdir(), "cerefox-paths-cwd-"));
+  fakeHome = mkdtempSync(join(tmpdir(), "cerefox-paths-home-"));
 });
 
 afterEach(() => {
   if (savedEnv !== undefined) process.env.CEREFOX_CONFIG_DIR = savedEnv;
   else delete process.env.CEREFOX_CONFIG_DIR;
   rmSync(tmpDir, { recursive: true, force: true });
+  rmSync(fakeHome, { recursive: true, force: true });
 });
 
-describe("resolveConfigDir", () => {
-  test("env override wins over dev mode", () => {
-    writeFileSync(join(tmpDir, ".env"), "CEREFOX_FOO=bar\n");
+function writeHomeEnv(): string {
+  const dir = join(fakeHome, USER_STATE_DIR_NAME);
+  mkdirSync(dir, { recursive: true });
+  const p = join(dir, ".env");
+  writeFileSync(p, "CEREFOX_FOO=home\n");
+  return p;
+}
+
+describe("resolveConfigDir — v0.5.3 precedence", () => {
+  test("env override wins over everything else", () => {
+    writeFileSync(join(tmpDir, ".env"), "CEREFOX_FOO=cwd\n");
+    writeHomeEnv();
     const explicit = mkdtempSync(join(tmpdir(), "cerefox-explicit-"));
     try {
       process.env.CEREFOX_CONFIG_DIR = explicit;
-      expect(resolveConfigDir({ cwd: tmpDir })).toBe(explicit);
+      expect(resolveConfigDir({ cwd: tmpDir, home: fakeHome })).toBe(explicit);
     } finally {
       rmSync(explicit, { recursive: true, force: true });
     }
@@ -45,59 +62,88 @@ describe("resolveConfigDir", () => {
 
   test("env override expands tilde", () => {
     process.env.CEREFOX_CONFIG_DIR = "~/custom-cerefox";
-    expect(resolveConfigDir({ cwd: tmpDir })).toBe(join(homedir(), "custom-cerefox"));
+    expect(resolveConfigDir({ cwd: tmpDir, home: fakeHome })).toBe(
+      join(homedir(), "custom-cerefox"),
+    );
   });
 
-  test("dev mode wins over user state", () => {
-    writeFileSync(join(tmpDir, ".env"), "CEREFOX_FOO=bar\n");
-    expect(resolveConfigDir({ cwd: tmpDir })).toBe(tmpDir);
+  test("~/.cerefox/.env wins over CWD .env when both exist (v0.5.3 inversion)", () => {
+    writeFileSync(join(tmpDir, ".env"), "CEREFOX_FOO=cwd\n");
+    writeHomeEnv();
+    expect(resolveConfigDir({ cwd: tmpDir, home: fakeHome })).toBe(
+      join(fakeHome, USER_STATE_DIR_NAME),
+    );
   });
 
-  test("user-state dir is the fallback", () => {
-    const result = resolveConfigDir({ cwd: tmpDir });
-    expect(result).toBe(join(homedir(), USER_STATE_DIR_NAME));
+  test("CWD .env wins when ~/.cerefox/.env doesn't exist (legacy dev-mode)", () => {
+    writeFileSync(join(tmpDir, ".env"), "CEREFOX_FOO=cwd\n");
+    // No home env written.
+    expect(resolveConfigDir({ cwd: tmpDir, home: fakeHome })).toBe(tmpDir);
+  });
+
+  test("~/.cerefox/ is the fallback when neither home env nor CWD .env exist", () => {
+    const result = resolveConfigDir({ cwd: tmpDir, home: fakeHome });
+    expect(result).toBe(join(fakeHome, USER_STATE_DIR_NAME));
   });
 
   test("empty env value treated as unset", () => {
     process.env.CEREFOX_CONFIG_DIR = "";
-    writeFileSync(join(tmpDir, ".env"), "CEREFOX_FOO=bar\n");
-    expect(resolveConfigDir({ cwd: tmpDir })).toBe(tmpDir);
+    writeFileSync(join(tmpDir, ".env"), "CEREFOX_FOO=cwd\n");
+    expect(resolveConfigDir({ cwd: tmpDir, home: fakeHome })).toBe(tmpDir);
   });
 
   test("whitespace-only env value treated as unset", () => {
     process.env.CEREFOX_CONFIG_DIR = "   ";
-    writeFileSync(join(tmpDir, ".env"), "CEREFOX_FOO=bar\n");
-    expect(resolveConfigDir({ cwd: tmpDir })).toBe(tmpDir);
+    writeFileSync(join(tmpDir, ".env"), "CEREFOX_FOO=cwd\n");
+    expect(resolveConfigDir({ cwd: tmpDir, home: fakeHome })).toBe(tmpDir);
   });
 });
 
 describe("resolveEnvFile", () => {
-  test("returns .env under resolved dir", () => {
+  test("returns ~/.cerefox/.env when home file exists (v0.5.3)", () => {
     writeFileSync(join(tmpDir, ".env"), "X=1\n");
-    expect(resolveEnvFile({ cwd: tmpDir })).toBe(join(tmpDir, ".env"));
+    writeHomeEnv();
+    expect(resolveEnvFile({ cwd: tmpDir, home: fakeHome })).toBe(
+      join(fakeHome, USER_STATE_DIR_NAME, ".env"),
+    );
   });
 
-  test("uses user-state dir in fallback", () => {
-    expect(resolveEnvFile({ cwd: tmpDir })).toBe(
-      join(homedir(), USER_STATE_DIR_NAME, ".env"),
+  test("returns CWD .env in legacy dev-mode", () => {
+    writeFileSync(join(tmpDir, ".env"), "X=1\n");
+    expect(resolveEnvFile({ cwd: tmpDir, home: fakeHome })).toBe(join(tmpDir, ".env"));
+  });
+
+  test("returns ~/.cerefox/.env when nothing exists (caller materialises)", () => {
+    expect(resolveEnvFile({ cwd: tmpDir, home: fakeHome })).toBe(
+      join(fakeHome, USER_STATE_DIR_NAME, ".env"),
     );
   });
 });
 
 describe("userStateDir", () => {
-  test("returns ~/.cerefox", () => {
+  test("returns the home-rooted ~/.cerefox path", () => {
+    expect(userStateDir({ home: fakeHome })).toBe(join(fakeHome, USER_STATE_DIR_NAME));
+  });
+
+  test("defaults to real homedir() when no override", () => {
     expect(userStateDir()).toBe(join(homedir(), USER_STATE_DIR_NAME));
   });
 });
 
-describe("isDevMode", () => {
-  test("true when .env in cwd", () => {
+describe("isDevMode (v0.5.3 — reflects actual behavior)", () => {
+  test("true when CWD .env exists and home env doesn't", () => {
     writeFileSync(join(tmpDir, ".env"), "X=1\n");
-    expect(isDevMode({ cwd: tmpDir })).toBe(true);
+    expect(isDevMode({ cwd: tmpDir, home: fakeHome })).toBe(true);
   });
 
-  test("false when no .env in cwd", () => {
-    expect(isDevMode({ cwd: tmpDir })).toBe(false);
+  test("false when both CWD .env AND home env exist (home wins)", () => {
+    writeFileSync(join(tmpDir, ".env"), "X=1\n");
+    writeHomeEnv();
+    expect(isDevMode({ cwd: tmpDir, home: fakeHome })).toBe(false);
+  });
+
+  test("false when no .env in CWD", () => {
+    expect(isDevMode({ cwd: tmpDir, home: fakeHome })).toBe(false);
   });
 
   test("false when env override set", () => {
@@ -105,9 +151,23 @@ describe("isDevMode", () => {
     const explicit = mkdtempSync(join(tmpdir(), "cerefox-explicit-"));
     try {
       process.env.CEREFOX_CONFIG_DIR = explicit;
-      expect(isDevMode({ cwd: tmpDir })).toBe(false);
+      expect(isDevMode({ cwd: tmpDir, home: fakeHome })).toBe(false);
     } finally {
       rmSync(explicit, { recursive: true, force: true });
     }
+  });
+});
+
+describe("hasLegacyCwdEnv (v0.5.3 — for doctor shadow detection)", () => {
+  test("true when CWD .env exists, regardless of home env", () => {
+    writeFileSync(join(tmpDir, ".env"), "X=1\n");
+    writeHomeEnv();
+    // Even though home wins for resolution, the legacy file still exists.
+    expect(hasLegacyCwdEnv({ cwd: tmpDir, home: fakeHome })).toBe(true);
+  });
+
+  test("false when no .env in CWD", () => {
+    writeHomeEnv();
+    expect(hasLegacyCwdEnv({ cwd: tmpDir, home: fakeHome })).toBe(false);
   });
 });

--- a/_shared/config/paths.ts
+++ b/_shared/config/paths.ts
@@ -1,14 +1,32 @@
 /**
  * TypeScript port of `src/cerefox/paths.py`.
  *
- * Same precedence — highest wins:
+ * Precedence — highest wins:
  *
  *   1. `CEREFOX_CONFIG_DIR` env var (explicit override; supports `~`).
- *   2. Repo-local `.env` in the current working directory (dev mode).
- *   3. `~/.cerefox/` — the user-state root for installed setups.
+ *   2. `~/.cerefox/` — the user-state root, **if `.env` exists there**.
+ *   3. Repo-local `.env` in the current working directory (legacy dev-mode
+ *      fallback).
+ *   4. `~/.cerefox/` — fallback when nothing else matches (path may not
+ *      yet exist; caller materialises it via `mkdirSync`).
  *
- * Mirrored 1:1 so `bun scripts/<name>.ts` finds the same `.env` the
- * Python CLI would. See the Python module for the v1.0 revisit note.
+ * **v0.5.3 precedence change**: levels 2 and 3 are now inverted vs. v0.5.2.
+ * Before v0.5.3, repo-local `.env` always won over `~/.cerefox/.env`. That
+ * matched the v0.x defensive default but blocked the migration from
+ * Python's `<repo>/.env` model to the installer's `~/.cerefox/.env` model.
+ * Now, once a user runs `cerefox init` and writes `~/.cerefox/.env`, the
+ * home file wins; existing repo `.env` files stay readable only via the
+ * legacy fallback (level 3), which Python (`uv run cerefox …`) keeps
+ * using through v0.7.x. See the v0.5.3 entry in the Cerefox Decision Log.
+ *
+ * **Existing users see no behavior change** until they run `cerefox init`:
+ * if `~/.cerefox/.env` doesn't exist, level 3 still matches their repo
+ * `.env` and the CLI reads it as before.
+ *
+ * Python `src/cerefox/paths.py` keeps the v0.5.2 precedence (CWD wins
+ * over `~/.cerefox/`) through v0.7.x for backward compatibility with
+ * `uv run cerefox …` workflows. When Python is fully retired in v0.9+,
+ * `paths.py` goes with it.
  */
 
 import { existsSync } from "node:fs";
@@ -28,6 +46,12 @@ function expandTilde(p: string): string {
 export interface ResolverOptions {
   /** Override CWD; mainly for tests. */
   cwd?: string;
+  /** Override home directory; mainly for tests. */
+  home?: string;
+}
+
+function userStateDirAbs(opts: ResolverOptions): string {
+  return resolvePath(join(opts.home ?? homedir(), USER_STATE_DIR_NAME));
 }
 
 export function resolveConfigDir(opts: ResolverOptions = {}): string {
@@ -36,24 +60,51 @@ export function resolveConfigDir(opts: ResolverOptions = {}): string {
     return resolvePath(expandTilde(override));
   }
 
+  // v0.5.3: prefer ~/.cerefox/.env if the user has run `cerefox init`.
+  const userState = userStateDirAbs(opts);
+  if (existsSync(join(userState, ".env"))) {
+    return userState;
+  }
+
+  // Legacy dev-mode fallback: repo-local .env wins when home isn't set up.
+  // This preserves the experience for existing users who haven't migrated
+  // yet — their <repo>/.env keeps working without any action on their part.
   const here = opts.cwd ?? processCwd();
   if (existsSync(join(here, ".env"))) {
     return resolvePath(here);
   }
 
-  return resolvePath(join(homedir(), USER_STATE_DIR_NAME));
+  return userState;
 }
 
 export function resolveEnvFile(opts: ResolverOptions = {}): string {
   return join(resolveConfigDir(opts), ".env");
 }
 
-export function userStateDir(): string {
-  return resolvePath(join(homedir(), USER_STATE_DIR_NAME));
+export function userStateDir(opts: ResolverOptions = {}): string {
+  return userStateDirAbs(opts);
 }
 
+/**
+ * `true` if the legacy dev-mode fallback is currently in effect: i.e. the
+ * CLI will read `<cwd>/.env` because `CEREFOX_CONFIG_DIR` is unset AND
+ * `~/.cerefox/.env` does not exist AND `<cwd>/.env` does exist.
+ *
+ * Distinct from `hasLegacyCwdEnv()` which reports whether the CWD `.env`
+ * exists regardless of whether it's actually in effect.
+ */
 export function isDevMode(opts: ResolverOptions = {}): boolean {
   if ((env.CEREFOX_CONFIG_DIR ?? "").trim()) return false;
+  if (existsSync(join(userStateDirAbs(opts), ".env"))) return false;
+  const here = opts.cwd ?? processCwd();
+  return existsSync(join(here, ".env"));
+}
+
+/**
+ * `true` if a CWD `.env` exists (regardless of whether it's actually in
+ * effect). Useful for doctor's "legacy env shadowed" reporting.
+ */
+export function hasLegacyCwdEnv(opts: ResolverOptions = {}): boolean {
   const here = opts.cwd ?? processCwd();
   return existsSync(join(here, ".env"));
 }

--- a/docs/guides/migration-v0.5.md
+++ b/docs/guides/migration-v0.5.md
@@ -196,6 +196,64 @@ explicit instead of "magic delegation".
 
 ---
 
+## v0.5.3 migrated `.env` from `<repo>/.env` to `~/.cerefox/.env`
+
+If you've been using the Python `cerefox` CLI, your `.env` lives in your
+repo root (`/path/to/cerefox/.env`). The TS CLI v0.5.2 also read that
+file, via a "CWD `.env` wins" precedence inherited from Python. v0.5.3
+flips that precedence: **once `~/.cerefox/.env` exists, the TS CLI reads
+from there**; the repo file becomes a legacy fallback for Python's
+`uv run cerefox …` workflows.
+
+**You see zero behavior change until you run `cerefox init`.** If your
+home dir doesn't have `~/.cerefox/.env`, the TS CLI keeps reading your
+existing repo `.env` (legacy dev-mode precedence). No action required.
+
+When you do run `cerefox init` with a repo `.env` already in place, the
+TS CLI offers a three-choice menu:
+
+```
+⚠ Found existing config at /path/to/cerefox/.env.
+
+  [c] Copy to /Users/you/.cerefox/.env  (recommended)
+      • TS reads the new home from now on
+      • Python keeps reading /path/to/cerefox/.env (backward compat)
+      • Edit ~/.cerefox/.env going forward; the repo .env is legacy
+
+  [u] Use /path/to/cerefox/.env as-is, skip writing anything
+      • Both TS and Python keep reading the existing file
+      • Defer the migration
+
+  [f] Fresh start — interactive prompts, write to /Users/you/.cerefox/.env
+      • Use if the existing file is stale or wrong
+```
+
+Pick **[c]** for the typical Python → TS upgrade. The TS CLI starts
+reading `~/.cerefox/.env`; your remaining Python `uv run cerefox …`
+commands keep reading the unchanged repo file. The two files diverge
+only if you start editing one of them — keep them in sync (or just edit
+`~/.cerefox/.env` and accept that Python uses a frozen snapshot until
+v0.9).
+
+After v0.9 (Python CLI removed), `cerefox doctor` will say "ok" if you
+delete the repo file. Until then, `doctor` reports it as
+`legacy env … (shadowed by ~/.cerefox/.env)` so you know it's harmless.
+
+### Python paths.py precedence (unchanged)
+
+`src/cerefox/paths.py` keeps the v0.5.2 precedence (CWD `.env` wins).
+Your existing `uv run cerefox …` invocations from inside the repo
+continue to read the repo file regardless of what's in `~/.cerefox/`.
+When this module goes away in v0.9+, the divergence resolves naturally.
+
+### `CEREFOX_CONFIG_DIR` is unchanged
+
+If you have `CEREFOX_CONFIG_DIR` set (e.g. for a non-standard install),
+it still wins over both home and repo `.env` files. Init writes there
+and skips the migration prompt.
+
+---
+
 ## Known gotchas
 
 ### `npx` from inside an npm workspace

--- a/packages/memory/README.md
+++ b/packages/memory/README.md
@@ -79,11 +79,19 @@ already provisioned (see "Before you install").
 > the deploy logic is ported to the TS CLI. For now, the setup-supabase
 > guide walks through it.
 
+> **Upgrading from the Python `cerefox` CLI?** If you have a working
+> `.env` in your repo clone, init detects it and offers to **copy** it to
+> `~/.cerefox/.env` so the TS CLI uses the new home while Python keeps
+> reading the repo file unchanged. See the migration-v0.5 guide for the
+> three-choice prompt. Existing users with no `~/.cerefox/.env` see zero
+> behavior change until they opt in.
+
 ---
 
 ## Connect an AI agent
 
 ```bash
+# Run the configure-agent commands that apply to your setup:
 cerefox configure-agent --tool claude-code          # writes ~/.claude/mcp.json
 cerefox configure-agent --tool claude-desktop       # writes Claude Desktop config
 ```

--- a/packages/memory/src/cli/commands/init.ts
+++ b/packages/memory/src/cli/commands/init.ts
@@ -1,10 +1,28 @@
 /**
  * `cerefox init` — interactive first-run bootstrap.
  *
- * Five-step flow that produces a working `~/.cerefox/.env` (or the
- * `CEREFOX_CONFIG_DIR`-pointed file), validates each entry against the
- * live service, and optionally ingests the bundled self-docs + wires up
- * an MCP client.
+ * Default target: `~/.cerefox/.env`. The CLI's path-resolution precedence
+ * (`_shared/config/paths.ts`) prefers this location once it exists, so
+ * writing here makes `~/.cerefox/.env` the canonical config from then on.
+ *
+ * Three resolution scenarios init handles:
+ *
+ *   1. **Fresh install** — neither `~/.cerefox/.env` nor `<cwd>/.env`
+ *      exists. Standard 5-step interactive flow, writes the home file.
+ *
+ *   2. **Migrating from Python** — `<cwd>/.env` exists but `~/.cerefox/.env`
+ *      doesn't. Init detects this and offers three choices:
+ *      `[c]` copy the existing file to `~/.cerefox/.env` (recommended —
+ *      TS reads the new home, Python keeps reading the repo file for
+ *      backward compat); `[u]` use the repo file as-is, skip writing
+ *      anything (defer the migration); `[f]` fresh start (ignore the
+ *      existing file, prompt for new answers, write to the home).
+ *
+ *   3. **Reconfiguring** — `~/.cerefox/.env` already exists. Standard
+ *      overwrite confirmation as before.
+ *
+ * `CEREFOX_CONFIG_DIR` honors the explicit override: when set, init writes
+ * there and skips the migration prompt entirely.
  *
  * Modes:
  *   - Interactive (default): prompts for each field with sensible
@@ -32,12 +50,14 @@
 import type { Command } from "commander";
 import {
   chmodSync,
+  copyFileSync,
   existsSync,
   mkdirSync,
   readFileSync,
   writeFileSync,
 } from "node:fs";
-import { dirname } from "node:path";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
 
 import {
   ask,
@@ -49,7 +69,10 @@ import {
   validators,
   warn,
 } from "../../../../../_shared/cli-core/index.ts";
-import { resolveEnvFile } from "../../../../../_shared/config/index.ts";
+import {
+  resolveEnvFile,
+  USER_STATE_DIR_NAME,
+} from "../../../../../_shared/config/index.ts";
 import { WRITERS, writeMcpConfig } from "../util/mcp-config-writers.ts";
 
 interface InitOptions {
@@ -98,6 +121,54 @@ async function readConfigFile(path: string): Promise<ConfigAnswers> {
     CEREFOX_DATABASE_URL: typeof obj.CEREFOX_DATABASE_URL === "string" ? obj.CEREFOX_DATABASE_URL : undefined,
     CEREFOX_AUTHOR_NAME: typeof obj.CEREFOX_AUTHOR_NAME === "string" ? obj.CEREFOX_AUTHOR_NAME : undefined,
     CEREFOX_AUTHOR_TYPE: typeof obj.CEREFOX_AUTHOR_TYPE === "string" ? obj.CEREFOX_AUTHOR_TYPE : undefined,
+  };
+}
+
+/**
+ * Tiny `KEY=VALUE` parser used to validate an existing `.env` (during
+ * the [c] copy or [u] use-as-is paths) without polluting `process.env`.
+ * Existing dotenv libraries set `process.env` as a side effect, which
+ * would shadow values from a subsequent re-read.
+ */
+function parseDotEnvFile(content: string): Record<string, string> {
+  const map: Record<string, string> = {};
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eqIdx = line.indexOf("=");
+    if (eqIdx === -1) continue;
+    const key = line.slice(0, eqIdx).trim();
+    let value = line.slice(eqIdx + 1).trim();
+    // Strip surrounding quotes if balanced.
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    map[key] = value;
+  }
+  return map;
+}
+
+function answersFromEnvFile(path: string): ConfigAnswers {
+  const parsed = parseDotEnvFile(readFileSync(path, "utf8"));
+  const required = ["CEREFOX_SUPABASE_URL", "CEREFOX_SUPABASE_KEY", "OPENAI_API_KEY"] as const;
+  for (const key of required) {
+    if (!parsed[key] || parsed[key].trim() === "") {
+      throw userError(
+        `Existing .env at ${path} is missing required key "${key}".`,
+        `Fix it manually or run \`cerefox init --force\` to start fresh.`,
+      );
+    }
+  }
+  return {
+    CEREFOX_SUPABASE_URL: parsed.CEREFOX_SUPABASE_URL,
+    CEREFOX_SUPABASE_KEY: parsed.CEREFOX_SUPABASE_KEY,
+    OPENAI_API_KEY: parsed.OPENAI_API_KEY,
+    CEREFOX_DATABASE_URL: parsed.CEREFOX_DATABASE_URL,
+    CEREFOX_AUTHOR_NAME: parsed.CEREFOX_AUTHOR_NAME,
+    CEREFOX_AUTHOR_TYPE: parsed.CEREFOX_AUTHOR_TYPE,
   };
 }
 
@@ -240,47 +311,43 @@ async function validateOpenAI(key: string): Promise<void> {
   }
 }
 
-async function action(options: InitOptions): Promise<void> {
-  const envPath = resolveEnvFile();
-
-  if (existsSync(envPath) && !options.force) {
-    println(
-      c.yellow(`⚠ Config already exists at ${envPath}.`),
-    );
-    const ok = await confirm("Overwrite?", true);
-    if (!ok) {
-      println(c.dim("Aborted. Use `--force` to skip this prompt next time."));
-      return;
-    }
-  }
-
-  const answers = options.config
-    ? await readConfigFile(options.config)
-    : await promptForAnswers();
-
+/** Print the [c]/[u]/[f] migration menu once. */
+function printMigrationMenu(cwdEnv: string, homeEnv: string): void {
   println("");
-  println(c.bold("Validating credentials…"));
-
-  await validateSupabase(answers.CEREFOX_SUPABASE_URL, answers.CEREFOX_SUPABASE_KEY);
-  println(c.green("  ✓ Supabase reachable"));
-  await validateOpenAI(answers.OPENAI_API_KEY);
-  println(c.green("  ✓ OpenAI key valid (test embedding succeeded)"));
-
-  // Write the .env (chmod 600).
-  mkdirSync(dirname(envPath), { recursive: true });
-  writeFileSync(envPath, buildEnvFile(answers), "utf8");
-  if (process.platform !== "win32") {
-    try {
-      chmodSync(envPath, 0o600);
-    } catch {
-      // Couldn't chmod — surface as warning, don't block.
-      warn(`Could not chmod 0600 ${envPath}.`);
-    }
-  }
+  println(c.yellow(`⚠ Found existing config at ${cwdEnv}.`));
   println("");
-  println(c.green(`✓ Wrote ${envPath}`));
+  println("This may be from a previous Python install. The TS CLI can use the");
+  println("same .env — env-var names are identical, no rewrite needed.");
   println("");
+  println("  " + c.bold("[c]") + " Copy to " + homeEnv + "  " + c.green("(recommended)"));
+  println(c.dim("      • TS reads the new home from now on"));
+  println(c.dim("      • Python keeps reading " + cwdEnv + " (backward compat)"));
+  println(c.dim("      • Edit ~/.cerefox/.env going forward; the repo .env is legacy"));
+  println("");
+  println("  " + c.bold("[u]") + " Use " + cwdEnv + " as-is, skip writing anything");
+  println(c.dim("      • Both TS and Python keep reading the existing file"));
+  println(c.dim("      • Defer the migration"));
+  println("");
+  println("  " + c.bold("[f]") + " Fresh start — interactive prompts, write to " + homeEnv);
+  println(c.dim("      • Use if the existing file is stale or wrong"));
+  println("");
+}
 
+async function promptMigrationChoice(): Promise<"c" | "u" | "f"> {
+  const choice = await ask({
+    type: "text",
+    name: "choice",
+    message: "Choice (c/u/f) [c]",
+    initial: "c",
+    validate: (v) => /^[cuf]?$/i.test(v.trim()) || "Expected c, u, or f.",
+  });
+  const ch = (choice.trim().toLowerCase() || "c") as "c" | "u" | "f";
+  return ch;
+}
+
+/** Continue the lifecycle steps (self-docs + MCP wiring) after the .env
+ * is in place. Shared by all three branches. */
+async function postWriteLifecycle(envPath: string, options: InitOptions): Promise<void> {
   // Schema deploy: v0.5 deferred.
   if (!options.skipSchema) {
     println(c.bold("Schema deploy"));
@@ -340,6 +407,155 @@ async function action(options: InitOptions): Promise<void> {
   println(c.dim("  cerefox doctor              # verify everything"));
   println(c.dim("  cerefox search \"…\"          # search the KB"));
   println(c.dim("  cerefox ingest <file>       # add a doc"));
+  // Help users locate the file we just touched.
+  println("");
+  println(c.dim(`  Config in effect: ${envPath}`));
+}
+
+function writeAnswersTo(target: string, answers: ConfigAnswers): void {
+  mkdirSync(dirname(target), { recursive: true });
+  writeFileSync(target, buildEnvFile(answers), "utf8");
+  if (process.platform !== "win32") {
+    try {
+      chmodSync(target, 0o600);
+    } catch {
+      warn(`Could not chmod 0600 ${target}.`);
+    }
+  }
+}
+
+async function action(options: InitOptions): Promise<void> {
+  const homeEnv = join(homedir(), USER_STATE_DIR_NAME, ".env");
+  const cwdEnv = join(process.cwd(), ".env");
+  const explicitDir = (process.env.CEREFOX_CONFIG_DIR ?? "").trim();
+
+  // ─── Path A: CEREFOX_CONFIG_DIR override ──────────────────────────────
+  // Advanced users with an explicit override skip the migration prompt
+  // entirely. resolveEnvFile() honors the override.
+  if (explicitDir) {
+    const target = resolveEnvFile();
+    if (existsSync(target) && !options.force) {
+      println(c.yellow(`⚠ Config already exists at ${target}.`));
+      const ok = await confirm("Overwrite?", true);
+      if (!ok) {
+        println(c.dim("Aborted. Use `--force` to skip this prompt next time."));
+        return;
+      }
+    }
+    const answers = options.config
+      ? await readConfigFile(options.config)
+      : await promptForAnswers();
+    println("");
+    println(c.bold("Validating credentials…"));
+    await validateSupabase(answers.CEREFOX_SUPABASE_URL, answers.CEREFOX_SUPABASE_KEY);
+    println(c.green("  ✓ Supabase reachable"));
+    await validateOpenAI(answers.OPENAI_API_KEY);
+    println(c.green("  ✓ OpenAI key valid (test embedding succeeded)"));
+    writeAnswersTo(target, answers);
+    println("");
+    println(c.green(`✓ Wrote ${target}`));
+    println("");
+    await postWriteLifecycle(target, options);
+    return;
+  }
+
+  // ─── Path B: ~/.cerefox/.env already exists (reconfigure) ─────────────
+  if (existsSync(homeEnv) && !options.force) {
+    println(c.yellow(`⚠ Config already exists at ${homeEnv}.`));
+    const ok = await confirm("Overwrite?", true);
+    if (!ok) {
+      println(c.dim("Aborted. Use `--force` to skip this prompt next time."));
+      return;
+    }
+    const answers = options.config
+      ? await readConfigFile(options.config)
+      : await promptForAnswers();
+    println("");
+    println(c.bold("Validating credentials…"));
+    await validateSupabase(answers.CEREFOX_SUPABASE_URL, answers.CEREFOX_SUPABASE_KEY);
+    println(c.green("  ✓ Supabase reachable"));
+    await validateOpenAI(answers.OPENAI_API_KEY);
+    println(c.green("  ✓ OpenAI key valid (test embedding succeeded)"));
+    writeAnswersTo(homeEnv, answers);
+    println("");
+    println(c.green(`✓ Wrote ${homeEnv}`));
+    println("");
+    await postWriteLifecycle(homeEnv, options);
+    return;
+  }
+
+  // ─── Path C: legacy <cwd>/.env exists, ~/.cerefox/.env doesn't ────────
+  // Migration scenario. Offer [c]opy / [u]se-as-is / [f]resh.
+  if (existsSync(cwdEnv) && !options.force && !options.config) {
+    printMigrationMenu(cwdEnv, homeEnv);
+    const ch = await promptMigrationChoice();
+    println("");
+
+    if (ch === "c") {
+      // Copy + validate + lifecycle.
+      mkdirSync(dirname(homeEnv), { recursive: true });
+      copyFileSync(cwdEnv, homeEnv);
+      if (process.platform !== "win32") {
+        try {
+          chmodSync(homeEnv, 0o600);
+        } catch {
+          warn(`Could not chmod 0600 ${homeEnv}.`);
+        }
+      }
+      println(c.green(`✓ Copied ${cwdEnv} → ${homeEnv}`));
+      println(c.dim(`  Repo file unchanged — Python still reads it during migration.`));
+      println("");
+
+      // Validate the copied config against live services.
+      const answers = answersFromEnvFile(homeEnv);
+      println(c.bold("Validating credentials…"));
+      await validateSupabase(answers.CEREFOX_SUPABASE_URL, answers.CEREFOX_SUPABASE_KEY);
+      println(c.green("  ✓ Supabase reachable"));
+      await validateOpenAI(answers.OPENAI_API_KEY);
+      println(c.green("  ✓ OpenAI key valid (test embedding succeeded)"));
+      println("");
+      await postWriteLifecycle(homeEnv, options);
+      return;
+    }
+
+    if (ch === "u") {
+      // Use-as-is — validate the existing file, skip the write entirely.
+      const answers = answersFromEnvFile(cwdEnv);
+      println(c.bold("Validating existing config…"));
+      await validateSupabase(answers.CEREFOX_SUPABASE_URL, answers.CEREFOX_SUPABASE_KEY);
+      println(c.green("  ✓ Supabase reachable"));
+      await validateOpenAI(answers.OPENAI_API_KEY);
+      println(c.green("  ✓ OpenAI key valid (test embedding succeeded)"));
+      println("");
+      println(c.green(`✓ Using existing config at ${cwdEnv}`));
+      println(c.dim(`  TS reads it via the legacy dev-mode fallback (~/.cerefox/.env not present).`));
+      println(c.dim(`  Run \`cerefox init\` again later to migrate to the new home.`));
+      println("");
+      await postWriteLifecycle(cwdEnv, options);
+      return;
+    }
+
+    // ch === "f" — fall through to fresh prompts targeting the home file.
+    println(c.dim(`Fresh start. Ignoring ${cwdEnv}; writing a new config to ${homeEnv}.`));
+    println("");
+  }
+
+  // ─── Path D: fresh install (no config anywhere) OR [f] fresh-start ───
+  const target = homeEnv;
+  const answers = options.config
+    ? await readConfigFile(options.config)
+    : await promptForAnswers();
+  println("");
+  println(c.bold("Validating credentials…"));
+  await validateSupabase(answers.CEREFOX_SUPABASE_URL, answers.CEREFOX_SUPABASE_KEY);
+  println(c.green("  ✓ Supabase reachable"));
+  await validateOpenAI(answers.OPENAI_API_KEY);
+  println(c.green("  ✓ OpenAI key valid (test embedding succeeded)"));
+  writeAnswersTo(target, answers);
+  println("");
+  println(c.green(`✓ Wrote ${target}`));
+  println("");
+  await postWriteLifecycle(target, options);
 }
 
 export function registerInit(program: Command): void {

--- a/packages/memory/src/cli/util/checks.ts
+++ b/packages/memory/src/cli/util/checks.ts
@@ -13,13 +13,17 @@
  * v0.6). The check stub reports "skipped (v0.6)".
  */
 
-import { existsSync, statSync } from "node:fs";
+import { existsSync, realpathSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
 import { PKG_VERSION } from "../../meta.ts";
 import { loadSettings } from "../../../../../_shared/config/index.ts";
-import { resolveConfigDir, resolveEnvFile } from "../../../../../_shared/config/index.ts";
+import {
+  resolveConfigDir,
+  resolveEnvFile,
+  USER_STATE_DIR_NAME,
+} from "../../../../../_shared/config/index.ts";
 
 export type CheckStatus = "ok" | "warn" | "error" | "skipped";
 
@@ -304,6 +308,36 @@ export function checkMcpConfigs(): CheckResult {
   };
 }
 
+/**
+ * v0.5.3: when `~/.cerefox/.env` exists AND a different `<cwd>/.env` exists,
+ * report the CWD file as a shadowed legacy config. The TS CLI reads the
+ * home file (new precedence), but Python's `uv run cerefox …` still reads
+ * the CWD file during the migration window — safe to delete in v0.9+.
+ *
+ * Returns `null` when there's nothing interesting to report (no shadowing,
+ * or the two paths resolve to the same physical file via symlink).
+ */
+export function checkLegacyShadowEnv(): CheckResult | null {
+  const home = homedir();
+  const homeEnv = join(home, USER_STATE_DIR_NAME, ".env");
+  const cwdEnv = join(process.cwd(), ".env");
+  if (!existsSync(homeEnv) || !existsSync(cwdEnv)) return null;
+  // Same file via symlink? Skip.
+  try {
+    if (realpathSync(homeEnv) === realpathSync(cwdEnv)) return null;
+  } catch {
+    // realpath failed on one of them — fall through to reporting.
+  }
+  return {
+    name: "legacy env",
+    status: "skipped",
+    detail: `${cwdEnv} (shadowed by ~/.cerefox/.env)`,
+    hint:
+      "Python `uv run cerefox …` still reads this file during the v0.5–v0.7 migration window. " +
+      "Safe to delete once Python support is removed (v0.9+).",
+  };
+}
+
 export function checkPostgres(): CheckResult {
   // v0.5: not yet ported. The Python CLI uses CEREFOX_DATABASE_URL for
   // DDL operations (schema deploy + migrations). For npm-installed users
@@ -327,11 +361,13 @@ export function checkPostgres(): CheckResult {
 
 /** Full diagnostic — what `cerefox doctor` runs. */
 export async function runAllChecks(): Promise<CheckResult[]> {
+  const legacy = checkLegacyShadowEnv();
   return [
     checkBinary(),
     checkRuntime(),
     checkVersion(),
     checkConfig(),
+    ...(legacy ? [legacy] : []),
     await checkSupabase(),
     await checkOpenAI(),
     await checkSchemaVersion(),

--- a/src/cerefox/paths.py
+++ b/src/cerefox/paths.py
@@ -14,10 +14,21 @@ The dev-mode branch (#2) makes existing ``cd /path/to/cerefox && uv run cerefox 
 workflows keep working unchanged. New users with no repo-local ``.env`` get the
 ``~/.cerefox/`` flow.
 
-**v1.0 revisit (planned)**: the dev-mode-wins precedence is defensive for the
-v0.x line. At v1.0 the natural default flips to ``~/.cerefox/`` first, with
-repo-local ``.env`` becoming an explicit opt-in (e.g. ``CEREFOX_CONFIG_DIR=.``).
-See ``docs/plan.md`` § Iteration 20 → "v1.0 revisit" for the rationale.
+**v0.5.3**: the TypeScript ``_shared/config/paths.ts`` brought the v1.0 flip
+forward — when ``~/.cerefox/.env`` exists, it wins over the CWD ``.env``.
+**This Python module deliberately stayed on the v0.5.2 precedence** (CWD
+wins) so existing ``uv run cerefox …`` workflows keep reading their repo
+``.env`` unchanged. The two precedences diverge until Python is fully
+retired in v0.9+, when this module goes with it. Users who run
+``cerefox init`` (TS) get a [c]opy path that writes ``~/.cerefox/.env``
+while leaving the repo file in place — TS reads the new home, Python
+keeps reading the repo. See the Cerefox Decision Log entry
+"2026-05-27 — v0.5.3 paths precedence inversion" for the full rationale.
+
+**v1.0 (still relevant)**: the dev-mode-wins precedence is defensive for the
+v0.x Python line. When this module is removed (v0.9+), there's nothing
+left to flip — TS already runs on the new rule. See ``docs/plan.md`` §
+Iteration 20 → "v1.0 revisit" for the original framing.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

- **`paths.ts` precedence inversion** — when `~/.cerefox/.env` exists, it now wins over `<cwd>/.env`. Brings forward the v1.0 flip documented in `paths.py`. **Existing users see zero behavior change** until they opt in by running `cerefox init` (the legacy CWD fallback still catches their case).
- **`cerefox init` migration-aware** — three-choice menu when CWD has `.env` but home doesn't:
  - `[c]` Copy to `~/.cerefox/.env` (default, recommended for Python → TS upgrades). Copies the file, chmods 0600, validates against Supabase + OpenAI, runs the lifecycle (self-docs + MCP config). Source file unchanged so Python keeps reading it.
  - `[u]` Use repo `.env` as-is. Validates the existing file, skips writing. Defers the migration.
  - `[f]` Fresh start. Standard 5-step prompts targeting `~/.cerefox/.env`. Ignores the existing file.
- **`cerefox doctor`** reports the shadowed legacy file (`ℹ legacy env`, status: skipped) when both `~/.cerefox/.env` and `<cwd>/.env` exist. Informational, doesn't fail doctor.
- **Python `paths.py`** deliberately stays on the v0.5.2 precedence through v0.9. Existing `uv run cerefox …` workflows keep reading the repo `.env` unchanged. Docstring updated to cross-reference the v0.5.3 TS change.
- **Docs**: migration-v0.5.md gains a new section explaining the three-choice menu and Python coexistence model. CHANGELOG `[Unreleased]` populated. packages/memory/README + root README get a brief upgrade-path callout. Decision Log Q2 Part 3 captures the design rationale.

## Why now (and not v1.0)

The migration window is happening now — users upgrading from Python `cerefox` to the npm-installed TS bin land on the surprising overwrite prompt today. Pulling the v1.0 paths flip forward costs ~590 LOC and gains a coherent migration story for every v0.5–v0.7 upgrade. See the Decision Log entry §5 for the longer rationale.

## Test plan

- [x] `cd _shared && bun test` — 72 pass (18 new precedence tests covering: env override wins, home wins over CWD, CWD wins when home absent, legacy fallback, dev-mode semantics)
- [x] `cd packages/memory && bun test` — 39 pass
- [x] `bun build packages/memory/src/bin/cerefox.ts` — clean bundle
- [ ] After merge: cut v0.5.3, npm publish, maintainer runs `bun update -g @cerefox/memory` and verifies the `[c]` migration flow against the live repo `.env`
- [ ] Clean-MacBook session against v0.5.3 — confirm the three-choice prompt doesn't appear for users with no existing `.env`

## Notes

- Decision Log Part 3 is now at 55,370 chars (over the 50K threshold). Per the split rule, the current entry stays in Part 3; the **next** Decision Log entry starts Part 4.
- `install.sh` end-of-install "Migration from v0.4" footer remains for now — slated for cleanup after v1 lands.
- "Tighten level-3 trigger to cerefox-shaped `.env` files only" deferred to v0.6 design discussion (footgun for users running `cerefox` from an unrelated project with a `.env`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)