### PR TITLE
docs: migration-v0.5.md is now the canonical upgrade entry

### DIFF
--- a/docs/guides/connect-agents.md
+++ b/docs/guides/connect-agents.md
@@ -112,19 +112,22 @@ The local Cerefox MCP server runs on your machine and exposes the same 10 tools 
 Edge Function, communicating with clients over stdio.
 
 As of **v0.4.0** the local server ships as an npm package — **[`@cerefox/memory`](https://www.npmjs.com/package/@cerefox/memory)** — built with the official `@modelcontextprotocol/sdk`.
-The bin entry is `cerefox` (run as `cerefox mcp`). The recommended client config is `npx -y --package=@cerefox/memory cerefox mcp`.
+The bin entry is `cerefox` (run as `cerefox mcp`). The recommended client config is `npx -y --package=@cerefox/memory cerefox mcp`, or if you've installed the package globally, just `cerefox mcp`.
 
-The legacy `uv run cerefox mcp` invocation **still works** and is preserved as a soft
-wrapper: it tries `npx --no-install @cerefox/memory cerefox mcp` first and falls back to the
-Python MCP server if npm is unavailable or `@cerefox/memory` isn't installed. New users
-should prefer the npm-native config; existing users don't have to change anything.
+The Python `uv run cerefox mcp` invocation **still works** and remains the right choice if
+you've installed Cerefox from a source checkout. v0.4 through v0.5.1 advertised a
+"soft wrapper" that tried to auto-delegate to the npm package, but the probe was unreliable
+under MCP-client launch environments — v0.5.2 removed it. The two paths (Python via
+`uv run`, TS via `cerefox mcp` on PATH or via `npx`) are now **fully independent**.
+Pick one explicitly in your MCP client config.
 
 - Embeddings are computed locally using your `.env` key (no extra credentials)
 - Works offline except for the OpenAI embedding API call per query
 - One setup, all compatible local clients (Claude Desktop, Cursor, Claude Code, Codex CLI, …)
 
-See [`docs/guides/migration-v0.4.md`](migration-v0.4.md) for before/after config snippets
-per client.
+See [`docs/guides/migration-v0.5.md`](migration-v0.5.md) for the per-client config
+snippets, the v0.5.2 soft-wrapper removal explainer, and the v0.5.3 `.env` location
+change.
 
 > **Why not `mcp-server-fetch`?** The generic fetch MCP only supports GET requests and cannot
 > make authenticated POST calls to the Edge Functions. The built-in local server is

--- a/docs/guides/migration-v0.4.md
+++ b/docs/guides/migration-v0.4.md
@@ -1,6 +1,23 @@
-# Migrating to Cerefox v0.4.0
+# Migrating to Cerefox v0.4.0 (historical)
 
-**TL;DR**: nothing urgent. Your existing `cerefox mcp` configs keep
+> ## ⚠ Historical document — do not use the snippets in this file
+>
+> This guide documents the **v0.4.0 → v0.4.3 migration window** (May 2026).
+> The `cerefox-mcp` bin name referenced throughout was dropped in **v0.5.1**;
+> the soft-wrapper described in some sections was removed in **v0.5.2**.
+> The per-client config snippets below **will not work on @cerefox/memory v0.5+**.
+>
+> **If you're upgrading today, use the current guide instead:**
+> → [`migration-v0.5.md`](migration-v0.5.md) — covers Python `cerefox` → v0.5.x
+>   AND v0.4.x → v0.5.x in a single document, with the v0.5.0/v0.5.1/v0.5.2/v0.5.3
+>   transitions all explained.
+>
+> This file is preserved so historical CHANGELOG entries that reference it
+> still resolve. It's not maintained.
+
+---
+
+**Original TL;DR (preserved verbatim)**: nothing urgent. Your existing `cerefox mcp` configs keep
 working unchanged. The Python `cerefox mcp` command is now a soft
 wrapper that transparently uses the new TypeScript MCP server if it's
 installed, falling back to the legacy Python implementation otherwise.

--- a/docs/guides/migration-v0.5.md
+++ b/docs/guides/migration-v0.5.md
@@ -1,4 +1,22 @@
-# Migrating to Cerefox v0.5.0
+# Migrating to Cerefox v0.5.x
+
+**This is the canonical upgrade guide for any user landing on Cerefox v0.5+.**
+It covers the v0.4 → v0.5 transition, the v0.5.x patch trail (v0.5.1, v0.5.2,
+v0.5.3), and the Python `cerefox` → TS `cerefox` migration path.
+
+## Where to start
+
+| Coming from | Read |
+|---|---|
+| Never used Cerefox before | [`quickstart.md`](quickstart.md) first, then come back here only if you hit a `.env` / config question |
+| Python `cerefox` (any version through v0.5.x) | "What changed" → "Install paths" → "v0.5.3 migrated `.env`" sections below |
+| `@cerefox/memory` v0.4.x (npm) | "Upgrading an existing MCP client config" → "v0.5.2 fixed the soft wrapper" → "v0.5.3 migrated `.env`" |
+| `@cerefox/memory` v0.5.0 or v0.5.1 (npm) | "v0.5.2 fixed the soft wrapper" + "v0.5.3 migrated `.env`" |
+| `@cerefox/memory` v0.5.2 (npm) | "v0.5.3 migrated `.env`" — the rest is unchanged |
+
+> Looking for `migration-v0.4.md`? It's been demoted to a historical
+> record (the bin names it documents no longer exist). Everything you
+> need to know about the v0.4 → v0.5 transition lives in this file.
 
 **TL;DR:** the Cerefox CLI is now a TypeScript binary published to npm.
 You can keep using the Python CLI through v0.7.x (it just prints a

--- a/docs/guides/upgrading.md
+++ b/docs/guides/upgrading.md
@@ -1,8 +1,27 @@
 # Upgrading Cerefox
 
-This guide covers upgrading an existing Cerefox installation to the latest version. All steps are idempotent and safe to re-run.
+This guide covers upgrading an existing Cerefox installation. All steps are idempotent and safe to re-run.
 
-## Standard Upgrade Checklist
+## Pick your path
+
+Cerefox has two install paths since v0.4.0 (npm) and v0.5.0 (TS CLI). The right
+upgrade procedure depends on how you installed Cerefox:
+
+| You installed via | Upgrade with |
+|---|---|
+| **npm / Bun** (`@cerefox/memory` global) | `bun update -g @cerefox/memory` (or `npm update -g @cerefox/memory`), then read [`migration-v0.5.md`](migration-v0.5.md) for any breaking-change notes per version. **`cerefox doctor`** verifies the install. |
+| **Source checkout** (`git clone` + `uv sync`) | The "Standard Upgrade Checklist" below — Python deps, schema migrations, Edge Functions, frontend build, the works. |
+| **Both** (you contribute AND have the npm bin globally) | Both flows. The two paths share the same Supabase + `.env`; just keep them updated in lockstep. |
+
+> If you're upgrading from Python `cerefox` to the npm-installed TS CLI for the first
+> time, [`migration-v0.5.md`](migration-v0.5.md) is the canonical guide — it covers
+> `cerefox init`'s coexistence flow (`[c]opy` your existing `.env` to `~/.cerefox/.env`),
+> the v0.5.2 soft-wrapper removal, and the v0.5.3 paths precedence change.
+
+The rest of this document covers the **source checkout** path (Python + frontend + Edge
+Functions). If you're an npm-installed user, you've already got everything you need.
+
+## Standard Upgrade Checklist (source-checkout users)
 
 Run these steps every time you pull a new version:
 
@@ -60,6 +79,30 @@ open http://localhost:8000/app/
 ## Version-Specific Notes
 
 Most upgrades require no special steps beyond the standard checklist above. Notes below only apply when upgrading across specific version boundaries.
+
+### Upgrading to v0.5.x (from any v0.4.x or earlier)
+
+The v0.4 → v0.5 transition is a milestone — the CLI itself moved from Python
+to TypeScript. The full migration guide is [`migration-v0.5.md`](migration-v0.5.md);
+the short version for source-checkout users is:
+
+- The Python `cerefox` CLI **still works** through v0.7.x — `uv sync` is enough
+  to pull it. It prints a one-line ⚠ deprecation banner on every invocation.
+- The new npm CLI lives alongside: `bun install -g @cerefox/memory` (or
+  `npm install -g @cerefox/memory`). `cerefox doctor` from any directory will
+  verify it.
+- **v0.5.2** stripped the Python `cerefox mcp` soft-wrapper. If your MCP
+  client config uses `uv run --directory /path/to/cerefox cerefox mcp`,
+  nothing changes — that path runs the Python MCP server directly. If you
+  want the TS server instead, point your client at `cerefox mcp`
+  (npm-installed) or `npx -y --package=@cerefox/memory cerefox mcp`.
+- **v0.5.3** changed the TS CLI's `.env` precedence: `~/.cerefox/.env` now
+  wins over `<repo>/.env` when both exist. Your existing `<repo>/.env` keeps
+  working until you run `cerefox init` and pick the `[c]opy` migration
+  option. Python `paths.py` is unchanged.
+
+No schema migration, no Edge Function redeploy, no chunk reindex required
+for the v0.4 → v0.5.3 arc.
 
 ### Upgrading to v0.1.20 (from v0.1.19) -- Multi-Project Preservation Fix
 


### PR DESCRIPTION
## Summary

Companion doc cleanup for v0.5.3 (PR #51 merged). Surfaced during the maintainer's own upgrade test: searching "cerefox upgrade" or "cerefox migrate" lands on three different docs (`upgrading.md`, `migration-v0.4.md`, `migration-v0.5.md`) with overlapping content, and `migration-v0.4.md`'s config snippets still use the **`cerefox-mcp` bin name** that was dropped in v0.5.1 (broken if copy-pasted onto v0.5+).

Four narrow updates, no restructuring:

- **`migration-v0.4.md`** — strong "Historical document — do not use the snippets" banner at the top. File stays put because of CHANGELOG/plan.md cross-refs and `scripts/bundle_package_docs.ts` bundles it into the npm package.
- **`migration-v0.5.md`** — "Where to start" preamble (small matrix: "coming from version X → read section Y"). This is now the canonical entry for any user on v0.4 or newer.
- **`upgrading.md`** — "Pick your path" intro distinguishing npm-installed users from source-checkout contributors. New "Upgrading to v0.5.x" section in Version-Specific Notes covering the v0.4 → v0.5.3 arc.
- **`connect-agents.md`** — drops the stale "soft wrapper" claim (removed in v0.5.2). Re-points its migration cross-ref from v0.4 to v0.5.

## Why a separate PR

PR #51 was code + tests + the v0.5.3 Decision Log + the user-facing CHANGELOG + the touched-by-changes docs (`migration-v0.5.md`, READMEs). These four edits surfaced *after* the maintainer asked me to do a broader sweep, and merging them into the already-merged-and-CI-passed #51 would require a force-push and re-cut. Cheaper to land them as a small follow-up.

## What was deliberately deferred

- **`quickstart.md`** doesn't mention the npm path at all — it routes new users straight to the Python source-checkout flow. This is a real gap but a bigger restructure; needs its own design pass (probably bundled with v0.6's "web in TS" work). Not blocking v0.5.3.
- **Full consolidation of `migration-v0.4.md` and `migration-v0.5.md` into a single `MIGRATING.md`** — v1.0 chore.
- **Removing `migration-v0.4.md` from the npm bundle** (`scripts/bundle_package_docs.ts`) — kept for now; the banner is sufficient to redirect users, and removing it would mean rebuilding the npm tarball without it. Defer to a future cut.

## Test plan

- [x] No code changes; no tests affected
- [x] Eyeballed Markdown rendering of all four files
- [ ] After merge: maintainer cuts v0.5.3 (the docs flow to npm via `bundle_package_docs.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)