### PR TITLE
fix(v0.6): build-frontend via bun install (npm 11 workspace bug)

### DIFF
--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -61,7 +61,7 @@
     "build": "bun build src/bin/cerefox.ts --outdir dist/bin --target node --format esm",
     "clean": "rm -rf dist docs AGENT_GUIDE.md AGENT_QUICK_REFERENCE.md",
     "bundle-docs": "bun run ../../scripts/bundle_package_docs.ts",
-    "build-frontend": "cd ../../frontend && npm install && npm run build",
+    "build-frontend": "cd ../../frontend && bun install && bun run build",
     "bundle-frontend": "rm -rf dist/frontend && mkdir -p dist/frontend && cp -R ../../frontend/dist/. dist/frontend/",
     "prepublishOnly": "bun run clean && bun run bundle-docs && bun run build-frontend && bun run bundle-frontend && bun run build",
     "smoke": "node dist/bin/cerefox.js --help && node dist/bin/cerefox.js mcp --help"


### PR DESCRIPTION
## Summary

The v0.6.0 publish workflow failed at the `npm install` step in `frontend/`. Root cause: npm 11's peer-dep resolver hits a null-pointer bug when invoked from inside a workspace subdir given the repo-root `workspaces: ["_shared", "packages/*", "frontend"]` config.

Fix: switch `build-frontend` from `npm install && npm run build` to `bun install && bun run build`. Consistent with the rest of the prepublishOnly chain (Bun is already a CI prerequisite). Bun's workspace resolver doesn't share npm's bug.

`frontend/package-lock.json` stays unchanged — Bun reads it for version pinning when no `bun.lock` is present, so the install is deterministic.

## Verification

- `cd packages/memory && bun run prepublishOnly` runs the full chain locally without error.
- `cd frontend && rm -rf node_modules && bun install && bun run build` works from scratch (581ms build).
- `npm pack --dry-run` lists the expected `dist/frontend/index.html` + hashed JS/CSS bundles + source-map; 1.9 MB tarball.

## Recovery path for the failed v0.6.0 publish

The v0.6.0 git tag (and likely the GitHub Release) was already created by `cut_release.ts` before the workflow's npm-publish step failed. **No `@cerefox/memory@0.6.0` exists on npm yet** — the workflow failed before producing/uploading the tarball.

Per the project's force-move policy (Decision Log Q2 Part 2, 2026-05-25): "force-moving published tags is reserved for cases where the originally-tagged commit is wrong (typo, missed file, broken release)." This is the **broken release** case explicitly cited; force-move is policy-compliant.

After merging this PR, here's the recovery sequence:

```bash
# 1. Switch to main + pull the fix
git checkout main && git pull origin main

# 2. Delete the v0.6.0 tag locally and on remote
git tag -d v0.6.0
git push --delete origin v0.6.0

# 3. (Optional) Delete the v0.6.0 GitHub Release if it was created
# Check first:
gh release view v0.6.0 2>&1 | head -5
# If it exists:
gh release delete v0.6.0 --yes

# 4. Re-tag main HEAD (which now has the fix) as v0.6.0
#    cut_release.ts can do this cleanly now that the tag is gone:
bun scripts/cut_release.ts v0.6.0 --npm-publish
```

`cut_release.ts` will refuse to re-cut if the tag still exists (the `checkTagDoesNotExist` guard from v0.2.0). The delete-then-recreate sequence above clears that guard.

**Alternative**: cut v0.6.1 instead of force-moving. Cleaner SemVer history but leaves the v0.6.0 tag pointing at a broken commit with no npm artifact (anyone trying `npm install @cerefox/memory@0.6.0` gets "not found"). My read is that force-move is the cleaner end state for this specific case — the v0.6.0 artifact never reached the public; force-moving is the project's documented exception path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)