### PR TITLE
v0.7.2: docs honesty patch — server/client split in README, banner hint fix, v0.8 design entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,14 +16,25 @@ broken on npm installs, no request logging).
 
 ### Docs
 
-- npm `@cerefox/memory` README now distinguishes the server side (Postgres
-  schema + RPCs + Edge Functions, shipped with the source repo) from the
-  client side (this package). Adds the clone-and-deploy step explicitly —
-  a fresh `npm install -g @cerefox/memory` is not enough to stand up
-  Cerefox; the user also needs to clone the repo, run
-  `bun scripts/db_deploy.ts`, and deploy the 9 Edge Functions. Drops the
-  stale "Schema deploy (v0.5)" callout that promised v0.6 would port the
-  deploy logic (v0.7 actually did).
+- npm `@cerefox/memory` README rewrites for v0.7.2:
+  - Distinguishes the server side (Postgres schema + RPCs + Edge Functions,
+    shipped with the source repo) from the client side (this package). Adds
+    the clone-and-deploy step explicitly — a fresh `npm install -g
+    @cerefox/memory` is not enough to stand up Cerefox; the user also needs
+    to clone the repo, run `bun scripts/db_deploy.ts`, and deploy the 9 Edge
+    Functions.
+  - Adds a "Why cloud-backed?" paragraph explaining the design rationale —
+    same memory reachable from every agent on every device via hybrid
+    (semantic + full-text) search.
+  - Single-binary table now includes `cerefox web` (the in-process Hono
+    server + bundled React UI — was missing despite shipping in v0.6).
+  - `configure-agent` block lists all 5 writers (Claude Code, Claude
+    Desktop, Cursor, Codex CLI, Gemini CLI); drops the stale "Cursor /
+    Codex / Gemini ship in a follow-up" note (they shipped in v0.6).
+  - Drops the stale "Schema deploy (v0.5)" callout that promised v0.6
+    would port the deploy logic (v0.7 actually did).
+  - Minor fixes: `cerefox doctor` description completed; "Path C in the
+    architecture" parenthetical dropped (unexplained).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,26 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
-Open roadmap.
+**v0.7.2 — "Docs honesty patch".** Two doc fixes that change what users
+see, no code surface change:
+
+### Docs
+
+- npm `@cerefox/memory` README now distinguishes the server side (Postgres
+  schema + RPCs + Edge Functions, shipped with the source repo) from the
+  client side (this package). Adds the clone-and-deploy step explicitly —
+  a fresh `npm install -g @cerefox/memory` is not enough to stand up
+  Cerefox; the user also needs to clone the repo, run
+  `bun scripts/db_deploy.ts`, and deploy the 9 Edge Functions. Drops the
+  stale "Schema deploy (v0.5)" callout that promised v0.6 would port the
+  deploy logic (v0.7 actually did).
+
+### Fixed
+
+- Web UI's `SchemaVersionBanner` now points at `bun scripts/db_deploy.ts`
+  instead of the v0.7.0 husk `uv run python scripts/db_deploy.py`. The
+  banner only fires on schema mismatch (uncommon), but when it does the
+  hint should run.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
-**v0.7.2 — "Docs honesty patch".** Two doc fixes that change what users
-see, no code surface change:
+**v0.7.2 — "Docs honesty + web-server glitches".** README correction
+on npm, two SchemaVersionBanner/Layout fixes, plus three web-server
+glitches surfaced during v0.7.1 testing (favicon routing, in-app logo
+broken on npm installs, no request logging).
 
 ### Docs
 
@@ -25,6 +27,26 @@ see, no code surface change:
 
 ### Fixed
 
+- **Favicon now actually loads.** v0.7.1 added the asset and the
+  `<link rel="icon">` to `frontend/index.html`, but `cerefox web`'s
+  middleware order had `/app/*` catch-all returning `index.html` for
+  every `/app/*` path — including `/app/cerefox_icon.png`. The catch-all
+  ran before any file-serving middleware for the SPA root. A new
+  `serveStatic` for `spaDist` at the SPA root is registered before the
+  catch-all; Hono falls through on 404 so React-router paths like
+  `/app/projects` still hit the catch-all correctly.
+- **In-app logo loads on npm installs.** The header in `Layout.tsx`
+  referenced `/static/cerefox_logo.jpg`, which only resolves when the
+  repo's `web/static/` directory is reachable. The npm tarball doesn't
+  ship `web/static/`, so npm users saw a broken image. Switched the
+  reference to `/app/cerefox_icon.png` — the same asset bundled with
+  the SPA in v0.7.1 — so it works on both source and installed paths.
+- **`cerefox web` logs requests.** The Python web server logged each
+  HTTP request via uvicorn; the v0.6 Hono port had no logger
+  middleware so the foreground server was silent. Added Hono's
+  `logger()` middleware (writes one line per request to stderr,
+  matching the uvicorn UX). Skipped under `NODE_ENV=test` so smoke
+  tests stay quiet.
 - Web UI's `SchemaVersionBanner` now points at `bun scripts/db_deploy.ts`
   instead of the v0.7.0 husk `uv run python scripts/db_deploy.py`. The
   banner only fires on schema mismatch (uncommon), but when it does the

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -2782,6 +2782,103 @@ the 2026-05-28 daemon-mode design discussion:
 - **`pyproject.toml`, `uv.lock`, `.python-version` STAY** because the Python runtime stays. Pytest as a test runner goes away.
 - End state after v0.9: zero `.py` in `tests/`; one test runner (`bun test`); Python runtime minimised to MCP server + CLI husks (+ maybe web husk).
 
+**v0.8.0 design items added 2026-05-28 (post-v0.7.1 review)**:
+
+1. **Eliminate the repo-clone for end users (`cerefox deploy-server`).**
+   Today a fresh npm install of `@cerefox/memory` is not enough to stand
+   up Cerefox — the user also needs the repo for `schema.sql`, `rpcs.sql`,
+   `migrations/`, and `supabase/functions/`. Plan:
+   - **Bundle server assets into the npm tarball.** Add a
+     `prepublishOnly` step that copies `src/cerefox/db/schema.sql`,
+     `rpcs.sql`, `migrations/`, and `supabase/functions/` into
+     `dist/server-assets/`. Verified total footprint is ~272 KB
+     (schema 20K + rpcs 72K + migrations 84K + EFs 96K) — bundling
+     bumps the tarball from 1.9 MB → ~2.2 MB. Single package; no
+     `@cerefox/memory-server` split needed (the optimization only
+     earns its complexity if assets ever cross ~10 MB, which SQL +
+     Deno TS source won't).
+   - **New CLI command `cerefox deploy-server`.** Wraps the
+     `db_deploy.ts` logic + invokes `npx supabase functions deploy`
+     for each of the 9 EFs. Flags mirror the scripts: `--dry-run`,
+     `--reset`. Probe `CEREFOX_DATABASE_URL` + Supabase CLI presence
+     up-front; refuse with clear remediation if either is missing.
+   - **`cerefox init` calls `deploy-server` for fresh installs.**
+     Detection: after the user provides Supabase URL + key, call
+     `cerefox_schema_version()` — if it 404s (no schema yet),
+     offer to deploy. Existing installs unchanged.
+   - **Repo clone stays the contributor path.** End-users get the
+     all-npm path; contributors who edit `schema.sql` or EFs still
+     clone and run `bun scripts/db_deploy.ts` directly.
+   - **README + setup-supabase.md rewrite.** Once `deploy-server`
+     ships, drop the clone-and-deploy block from the npm README;
+     setup-supabase becomes the contributor reference.
+
+2. **Client ↔ server version compatibility matrix.** Today the schema
+   version is exposed (`cerefox_schema_version()`) but EF versions
+   aren't visible to clients, and nothing asserts a minimum-required
+   server. After v0.7 the gap is real — clients drift forward while
+   long-running Supabase deployments stay on older EF code. The
+   SchemaVersionBanner's "any difference → yellow" model is also too
+   coarse. Plan:
+   - **Schema + RPCs keep one version.** They deploy as an atomic
+     unit (`db_deploy.ts` applies `schema.sql` + `rpcs.sql` in one
+     transaction); the existing `@version:` marker covers both.
+     No change.
+   - **Each Edge Function gets `GET /version`.** Returns
+     `{name: "cerefox-mcp", version: "0.8.0"}`. Shared via a tiny
+     `_shared/ef-meta/` helper imported by each EF; the constant
+     bumped by `cut_release.ts` alongside the existing `PKG_VERSION`
+     bump.
+   - **Aggregator endpoint** (recommend on `cerefox-mcp`):
+     `GET /version?peers=true` returns
+     `{schema: "...", efs: {"cerefox-mcp": "...", "cerefox-search": "...", ...}}`.
+     One round-trip for `cerefox doctor` instead of nine.
+   - **Client-side compatibility matrix.** New module
+     `_shared/compatibility/index.ts`:
+     ```ts
+     export const COMPATIBILITY = {
+       minSchema: "0.3.0",          // bumped only on schema-breaking change
+       minEdgeFunctions: "0.6.0",   // bumped on EF response-shape changes
+     };
+     ```
+     Hand-updated when a client release requires a newer server.
+   - **`checkServerCompatibility()`** in `_shared/`, consumed by:
+     - `cerefox doctor` — promote from "info" to "error" when below
+       minimum; "warn" when above-min-but-old.
+     - `cerefox web` boot — refuse to bind if incompatible, with a
+       clear "redeploy your Supabase" message naming the failing
+       component and the required minimum.
+     - `SchemaVersionBanner` — two-tier signal: below-min → red
+       (blocking), above-min-but-old → yellow (nudge).
+   - **SemVer policy update in `CONTRIBUTING.md`.** Spell out when
+     each minimum bumps: schema/EF minimum bumps require a minor
+     client bump; client patch releases never raise minimums.
+
+3. **GPT Actions OpenAPI schema sync rule** (process item — applies to
+   every iteration that touches EFs, codified here in v0.8 because
+   that's when the EF contract changes for the `/version` work).
+   Every change to an EF's request/response contract must update the
+   OpenAPI block in `docs/guides/connect-agents.md` — that's the GPT
+   Actions schema reference ChatGPT users paste into their Custom
+   GPT. The OpenAPI doc's `info.version` field is its own ratchet
+   (currently `1.7.0`); bump on any request-body or response-shape
+   change.
+
+   This rule was missing through v0.5–v0.7 — the OpenAPI block may
+   already be out of sync with shipped EF behaviour. **Iter-26
+   Part 26X: audit the existing OpenAPI block** against each EF's
+   current request/response handling. Compare to the v0.6 ingest-
+   route changes and the v0.7 ingestion-pipeline swap (the EFs
+   weren't touched by the v0.7 pipeline migration, but worth
+   confirming). Document any drift found; fix in the same iter-26
+   commit that adds `/version` to each EF.
+
+   Going forward, **every PR that modifies an EF must include the
+   OpenAPI diff** alongside the EF change. Enforce by adding a CI
+   check that fails if `supabase/functions/cerefox-*/index.ts`
+   changed but `docs/guides/connect-agents.md` didn't (or vice
+   versa). Probably a small `scripts/check_gpt_actions_sync.ts`.
+
 **Design**: [`docs/specs/polish-and-distribution-design.md` §13 v0.8.0 + v0.9.0 + §19 test migration policy](specs/polish-and-distribution-design.md).
 
 ---

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -36,7 +36,7 @@ export function Layout() {
         <Group h="100%" px="md" justify="space-between">
           <Group gap="sm">
             <img
-              src="/static/cerefox_logo.jpg"
+              src="/app/cerefox_icon.png"
               alt="Cerefox"
               height={32}
               width={32}

--- a/frontend/src/components/SchemaVersionBanner.tsx
+++ b/frontend/src/components/SchemaVersionBanner.tsx
@@ -42,7 +42,7 @@ export function SchemaVersionBanner() {
         Run from the repo root:
       </Text>
       <Code block mt="xs">
-        uv run python scripts/db_deploy.py
+        bun scripts/db_deploy.ts
       </Code>
     </Alert>
   );

--- a/packages/memory/README.md
+++ b/packages/memory/README.md
@@ -5,12 +5,20 @@
 curated knowledge layer that multiple AI tools can read and write.
 
 > **Cerefox is BYO-storage.** This package is the *client* — the CLI + local
-> MCP server. The knowledge base itself lives in **your own Supabase project**
-> (Postgres + pgvector; free tier works). Installing this npm package does
-> **not** give you a working KB on its own; you also need a Supabase project +
-> an embedding API key. The first-run `cerefox init` wires everything together
-> in ~2 minutes once you have those in hand. **See "Before you install"
-> below.**
+> MCP server + local web UI. The knowledge base itself lives in **your own
+> Supabase project** (Postgres + pgvector; free tier works). Installing this
+> npm package does **not** give you a working KB on its own; you also need a
+> Supabase project + an embedding API key, and a one-time server-side deploy
+> from the source repo. **See "Before you install" below.**
+
+**Why cloud-backed?** Cerefox is designed as a *cloud-backed* memory layer so
+the same knowledge is reachable from every agent you run — Claude Code on
+your laptop, Cursor on a second machine, ChatGPT on the web, a script in CI.
+Postgres + pgvector deliver hybrid (semantic + full-text) search across that
+shared memory; Supabase provides the always-on endpoint that makes "same
+memory, any device, any agent" work. You own the data and the endpoint; this
+package bundles **everything you run locally** — CLI, MCP server, web UI,
+and the in-process ingestion + retrieval pipeline — that talks to it.
 
 This package contains a single binary, **`cerefox`**:
 
@@ -18,6 +26,7 @@ This package contains a single binary, **`cerefox`**:
 |---|---|
 | `cerefox <command>` | CLI — search, ingest, list, version-history, audit-log, lifecycle (`init`, `doctor`, `configure-agent`, `self-update`). Callable from any directory. |
 | `cerefox mcp` | Local stdio MCP server. Drop-in for Claude Code, Cursor, Claude Desktop, Codex CLI, Gemini CLI. Exposes the same 10 MCP tools as the remote `cerefox-mcp` Edge Function. |
+| `cerefox web` | Local web app at `http://localhost:8000` — React UI for browsing, searching, editing, and ingesting documents. Backed by an in-process Hono server that exposes the same `/api/v1/*` REST surface as the bundled Edge Functions. |
 
 > **What this package isn't:** the source of truth for Cerefox's architecture
 > or docs. Those live in the [GitHub repo](https://github.com/fstamatelopoulos/cerefox).
@@ -92,7 +101,7 @@ yarn global add @cerefox/memory
 ```bash
 cerefox init        # 5-step interactive bootstrap (asks for Supabase URL,
                     # Supabase key, OpenAI key, optional Postgres URL, identity)
-cerefox doctor      # verify everything reaches
+cerefox doctor      # end-to-end health check against the live services
 ```
 
 `cerefox init` prompts for the credentials you collected above, validates them
@@ -119,13 +128,15 @@ already provisioned (see "Before you install").
 
 ```bash
 # Run the configure-agent commands that apply to your setup:
-cerefox configure-agent --tool claude-code          # writes ~/.claude/mcp.json
-cerefox configure-agent --tool claude-desktop       # writes Claude Desktop config
+cerefox configure-agent --tool claude-code          # ~/.claude.json via `claude mcp add`
+cerefox configure-agent --tool claude-desktop       # Claude Desktop config
+cerefox configure-agent --tool cursor               # ~/.cursor/mcp.json
+cerefox configure-agent --tool codex                # ~/.codex/config.toml
+cerefox configure-agent --tool gemini               # ~/.gemini/settings.json
 ```
 
-Phase 1 supports Claude Code + Claude Desktop. Cursor, Codex CLI, and Gemini
-CLI ship in a follow-up. For manual configuration, the canonical MCP entry
-is:
+All five writers landed in v0.6. For manual configuration, the canonical MCP
+entry is:
 
 ```json
 {
@@ -174,9 +185,8 @@ its own. The rest of the `cerefox` CLI is useful for:
   `cerefox metadata-search --metadata-filter …`, `cerefox backup`.
 - **Setup + diagnostics**: `cerefox init`, `cerefox doctor`,
   `cerefox configure-agent`, `cerefox self-update`.
-- **Agents via local Bash tool** (Path C in the architecture): some
-  coding agents prefer running `cerefox <subcommand>` over a Bash tool
-  rather than configuring MCP.
+- **Agents via local Bash tool**: some coding agents prefer running
+  `cerefox <subcommand>` from a shell rather than configuring MCP.
 
 ---
 

--- a/packages/memory/README.md
+++ b/packages/memory/README.md
@@ -27,14 +27,42 @@ This package contains a single binary, **`cerefox`**:
 
 ## Before you install
 
-Cerefox is a self-hosted memory layer. To use it you need three things, none
-of which this npm package brings with it:
+Cerefox is a self-hosted memory layer with two halves you set up independently:
+
+**Server side** (lives in your Supabase project, runs ~24/7):
+- Postgres schema + RPCs (search, ingest, audit log, version history)
+- Edge Functions (server-side embedding, remote `cerefox-mcp` MCP server, Custom-GPT actions)
+
+**Client side** (this npm package, runs on your machine):
+- `cerefox` CLI + `cerefox mcp` (local stdio MCP) + `cerefox web` (local UI at `http://localhost:8000`)
+
+The server side ships with the source repo, not this npm package. Both halves are required for a working install.
+
+### What you need
 
 | Prerequisite | Why | How |
 |---|---|---|
-| A **Supabase project** | The knowledge base (documents + chunks + embeddings) lives in your Supabase project's Postgres database, with pgvector for semantic search. Free tier is enough for most personal use. | Sign up at [supabase.com](https://supabase.com), create a project, then follow the [Supabase setup guide](https://github.com/fstamatelopoulos/cerefox/blob/main/docs/guides/setup-supabase.md) — deploy the Cerefox schema (one script), then deploy the Edge Functions (one command). Estimate: 10–15 minutes the first time. |
-| An **embedding API key** | Cerefox embeds your documents for semantic search. OpenAI's `text-embedding-3-small` is the default; Fireworks AI is an alternative. | Get an [OpenAI API key](https://platform.openai.com/api-keys) — costs are pennies/month for typical personal use (see [operational-cost.md](https://github.com/fstamatelopoulos/cerefox/blob/main/docs/guides/operational-cost.md)). |
-| **Node ≥ 20** or **Bun ≥ 1.0** | Runtime for the `cerefox` bin (and the bundled `cerefox mcp` server). | [nodejs.org](https://nodejs.org) or [bun.sh](https://bun.sh). The one-line installer below bootstraps Bun for you if neither is present. |
+| A **Supabase project** | Hosts Postgres + pgvector + Edge Functions. Free tier is enough for most personal use. | [supabase.com](https://supabase.com) → New project |
+| An **embedding API key** | OpenAI `text-embedding-3-small` (default) or Fireworks AI. Pennies/month for typical personal use (see [operational-cost.md](https://github.com/fstamatelopoulos/cerefox/blob/main/docs/guides/operational-cost.md)). | Get an [OpenAI API key](https://platform.openai.com/api-keys). |
+| **Node ≥ 20** or **Bun ≥ 1.0** | Runtime for the `cerefox` bin (and the bundled `cerefox mcp` server). | [nodejs.org](https://nodejs.org) · [bun.sh](https://bun.sh). The one-line installer below bootstraps Bun if neither is present. |
+
+### One-time server-side setup (~10 min — clone required)
+
+The schema, RPCs, and Edge Functions ship with the source repo, not this npm package. Clone once, configure, deploy:
+
+```bash
+git clone https://github.com/fstamatelopoulos/cerefox.git
+cd cerefox && cp .env.example .env       # fill in CEREFOX_SUPABASE_* + OPENAI_API_KEY + CEREFOX_DATABASE_URL
+bun install                              # workspace deps for the deploy scripts
+bun scripts/db_deploy.ts                 # creates tables, indexes, RPCs in your Supabase
+npx supabase functions deploy cerefox-mcp cerefox-search cerefox-ingest \
+                              cerefox-metadata cerefox-get-document \
+                              cerefox-list-versions cerefox-get-audit-log \
+                              cerefox-metadata-search cerefox-list-projects
+npx supabase secrets set OPENAI_API_KEY=sk-...
+```
+
+Full walkthrough (connection-pooling quirks, Supabase API-key flavors, troubleshooting): [setup-supabase.md](https://github.com/fstamatelopoulos/cerefox/blob/main/docs/guides/setup-supabase.md).
 
 If you don't yet have Supabase + an OpenAI key, the [Cerefox
 quickstart](https://github.com/fstamatelopoulos/cerefox/blob/main/docs/guides/quickstart.md)
@@ -73,11 +101,10 @@ optionally wires up an MCP client. **It does not create the Supabase project
 for you** — you'll be asked for the URL + key, so make sure those are
 already provisioned (see "Before you install").
 
-> **Schema deploy (v0.5):** if your Supabase project is fresh, `cerefox init`
-> tells you to run `uv run python scripts/db_deploy.py` from a Cerefox repo
-> clone to install the schema. This last manual step goes away in v0.6 when
-> the deploy logic is ported to the TS CLI. For now, the setup-supabase
-> guide walks through it.
+> **Already ran the server-side setup above?** Then your schema is in place and
+> `cerefox init` only needs the URL + keys. If you skipped that step,
+> `cerefox doctor` will flag it and point you back to
+> `bun scripts/db_deploy.ts` from a repo clone.
 
 > **Upgrading from the Python `cerefox` CLI?** If you have a working
 > `.env` in your repo clone, init detects it and offers to **copy** it to

--- a/packages/memory/src/web/server.ts
+++ b/packages/memory/src/web/server.ts
@@ -30,6 +30,7 @@ import { existsSync } from "node:fs";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { Hono } from "hono";
+import { logger } from "hono/logger";
 
 import { buildWebContext, type WebContext } from "./context.ts";
 import { registerAuditUsageRoutes } from "./routes/audit-usage.ts";
@@ -59,6 +60,13 @@ export interface WebServerHandle {
 
 export function buildApp(ctx: WebContext | null = buildWebContext()): Hono {
   const app = new Hono();
+
+  // (0) Request logger — writes one line per request to stderr, matching the
+  // UX FastAPI/uvicorn provided on the Python web server. Skipped in test
+  // runs (NODE_ENV=test) so smoke tests stay quiet.
+  if (process.env.NODE_ENV !== "test") {
+    app.use(logger());
+  }
 
   // (1) JSON API — registered first.
   registerMetaRoutes(app, ctx);
@@ -103,10 +111,11 @@ export function buildApp(ctx: WebContext | null = buildWebContext()): Hono {
     );
   }
 
-  // (3) + (4) SPA — only when a usable dist is available.
+  // (3) + (4) + (5) SPA — only when a usable dist is available.
   const spaDist = resolveSpaDist();
   if (spaDist) {
-    // (3) Vite assets — explicit prefix BEFORE the catch-all.
+    // (3) Vite hashed JS/CSS — explicit prefix BEFORE the public-asset
+    //     middleware so they always go through the assets directory.
     app.use(
       "/app/assets/*",
       serveStatic({
@@ -115,7 +124,19 @@ export function buildApp(ctx: WebContext | null = buildWebContext()): Hono {
       }),
     );
 
-    // (4) SPA catch-all for client-side routing.
+    // (4) SPA public/ assets at the SPA root (favicon, icons, anything Vite
+    //     copies from frontend/public/). Hono's serveStatic calls next() on
+    //     a 404, so React-router paths like /app/projects fall through to
+    //     the catch-all below and correctly return index.html.
+    app.use(
+      "/app/*",
+      serveStatic({
+        root: spaDist,
+        rewriteRequestPath: (path) => path.replace(/^\/app/, "") || "/",
+      }),
+    );
+
+    // (5) SPA catch-all for client-side routing.
     const indexPath = join(spaDist, "index.html");
     if (existsSync(indexPath)) {
       const indexHtml = readFileSync(indexPath, "utf8");


### PR DESCRIPTION
## Summary

Five commits. Three doc-honesty fixes + three web-server glitch fixes + plan.md design entries for v0.8.

1. **`packages/memory/README.md` rewrite** — `npm install -g @cerefox/memory` alone isn't enough to stand up Cerefox; the server-side schema/RPCs/EFs ship with the source repo. The "Before you install" section now distinguishes server-side from client-side explicitly and shows the actual clone-and-deploy commands inline. Also drops the stale "Schema deploy (v0.5)" callout that promised v0.6 would port the deploy logic (v0.7 actually did).

2. **`SchemaVersionBanner` hint fix** — points at `bun scripts/db_deploy.ts` instead of the v0.7.0 husk `uv run python scripts/db_deploy.py`.

3. **`docs/plan.md` § Iteration 26** — three locked design items added for v0.8:
   - **Eliminate the repo-clone for end users** via `cerefox deploy-server` + bundling server assets (~272 KB total, fits in the single npm package).
   - **Client ↔ server compatibility matrix**: per-EF `GET /version` + aggregator endpoint + `_shared/compatibility/` matrix + checks in doctor / web boot / SchemaVersionBanner. Schema + RPCs continue to share one version (atomic deploy); only EFs need per-function versions.
   - **GPT Actions OpenAPI sync rule** — every EF contract change must update the OpenAPI block in `connect-agents.md`. **Existing block may already be drifted from v0.5–v0.7 EF changes — Part 26X audit needed.** Also tracking `scripts/check_gpt_actions_sync.ts` as a CI gate.

4. **CHANGELOG entry** for v0.7.2 under `[Unreleased]`, ready for `cut_release.ts`.

5. **Three v0.7.1 web-server glitches fixed** (added after maintainer testing):
   - **Favicon route**: middleware order had `/app/*` catch-all returning `index.html` for `/app/cerefox_icon.png`. New `serveStatic` for `spaDist` at the SPA root registered before the catch-all. Hono falls through on 404 so React-router paths like `/app/projects` still hit the catch-all.
   - **In-app logo on npm installs**: `Layout.tsx` referenced `/static/cerefox_logo.jpg`, which only resolves when the repo's `web/static/` is reachable. Switched to `/app/cerefox_icon.png` (the same v0.7.1 asset bundled with the SPA).
   - **Request logging**: added Hono's `logger()` middleware — one line per request to stderr, matching the FastAPI/uvicorn UX. Skipped under `NODE_ENV=test`.

## Why a v0.7.2 release

The README correction is user-visible on npmjs.com (npm only refreshes the README on publish). Folding into v0.8 means weeks of stale README. v0.7.2 is a small patch: doc fixes + three web-server glitches that were already shipped broken in v0.7.1.

## Test plan

- [x] `bun run build` in `frontend/` — clean
- [x] `bun run build` in `packages/memory/` — clean
- [x] `bun test` in `packages/memory/` — no regression (1 pre-existing iter-25 state-flake unchanged)
- [x] Smoke against running server: `GET /app/cerefox_icon.png` → `image/png` 535,426 bytes; `GET /app/` → HTML with new favicon ref; `GET /app/projects` → HTML fallthrough; logger fires on every request
- [ ] Manual after cut + publish: open `cerefox web` in browser, verify (a) favicon on tab, (b) logo in header, (c) request log lines in terminal
- [ ] After publish: `npm view @cerefox/memory@0.7.2` shows the new README on the package page

🤖 Generated with [Claude Code](https://claude.com/claude-code)