### PR TITLE
deploy-server applies migrations on existing DBs (v0.8.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@ the server side.
   schema and/or Edge Functions are out of date, doctor prints a single
   consolidated remediation line: `cerefox deploy-server` when both are stale,
   or the matching `--schema-only` / `--functions-only` when only one is.
+- **`cerefox web` log lines now carry a local-time timestamp**
+  (`YYYY-MM-DD HH:mm:ss.SSS`) — both the per-request logger and the
+  start/shutdown lines. Makes the daemon log (`~/.cerefox/web.log`) readable
+  after the fact (previously lines like `Received SIGTERM; shutting down` had
+  no time).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,44 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
-Open roadmap.
+**v0.8.1 — deploy-server handles updates, not just fresh installs.** Fixes a
+gap in v0.8.0: `cerefox deploy-server` only ever did a *fresh* deploy (apply
+schema + RPCs, then stamp every migration as already-applied). Run against a
+database that already had a Cerefox schema, it silently re-stamped migrations
+without running them — so a release that shipped a new migration never applied
+it. `deploy-server` is now the catch-all for both standing up *and updating*
+the server side.
+
+### Changed
+
+- **`cerefox deploy-server` detects fresh vs. existing databases.** On a fresh
+  database it deploys schema + RPCs and stamps migrations (unchanged). On a
+  database that already has a Cerefox schema it applies any *pending*
+  migrations (each in its own transaction) and re-applies `rpcs.sql` to refresh
+  the RPCs — i.e. an in-place update. Re-running after a release that changes
+  RPCs and/or adds a migration now does the right thing; no separate migrate
+  step is needed. The dry-run plan shows which path will run and lists pending
+  migrations.
+- **`cerefox doctor`** relabels the `schema` row to `schema + RPCs` and now
+  classifies the deployed schema/RPC version against the client's required
+  minimum (error if below) and bundled version (warning if older). When the
+  schema and/or Edge Functions are out of date, doctor prints a single
+  consolidated remediation line: `cerefox deploy-server` when both are stale,
+  or the matching `--schema-only` / `--functions-only` when only one is.
+
+### Removed
+
+- **`cerefox deploy-server --reset`.** The destructive drop-everything flag is
+  gone from the user-facing command — a full wipe is a contributor/recovery
+  operation. It remains in the low-level `bun scripts/db_deploy.ts --reset`
+  (repo clone only, behind its typed-`yes` guard).
+
+### Internal
+
+- Extracted `runDbMigrate`, `migrationStatus`, `detectExistingSchema`, and
+  `applyRpcs` into `_shared/db-deploy/` so the `deploy-server` command and the
+  low-level `scripts/db_migrate.ts` share one implementation. `db_migrate.ts`
+  is now a thin wrapper (with a new `--status` flag).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ without running them — so a release that shipped a new migration never applied
 it. `deploy-server` is now the catch-all for both standing up *and updating*
 the server side.
 
+### Added
+
+- `cerefox delete-project <name-or-id>` — new CLI subcommand. Looks up by
+  UUID or exact name; refuses if documents are still linked unless `--force`;
+  `--yes` skips the prompt for scripts. Symmetric to the existing Projects page
+  DELETE action in the web UI. Used by `write-commands.test.ts` to reap the
+  `_e2e-v0.5` test project so prior runs don't leave stray projects behind.
+
 ### Changed
 
 - **`cerefox deploy-server` detects fresh vs. existing databases.** On a fresh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,8 @@ cerefox/
 │   ├── backup_restore.py      # Restore from a backup
 │   ├── cut_release.ts         # Cut/tag a release; optional --npm-publish
 │   ├── bundle_help.ts         # Bundle AGENT_QUICK_REFERENCE.md into _shared/mcp-tools/get-help-content.ts
+│   ├── db_deploy.ts           # Low-level fresh schema+RPC deploy (contributor; has --reset)
+│   ├── db_migrate.ts          # Low-level apply-pending-migrations (contributor; --status/--dry-run)
 │   └── *.ts                   # TS strangler-fig ports of legacy Python scripts
 ├── tests/
 │   ├── chunking/
@@ -269,6 +271,21 @@ Business logic lives **only in Postgres RPCs** wherever feasible. If you need to
 | `cerefox-mcp` | Remote MCP Streamable HTTP server; calls RPCs directly via shared tool handlers in `_shared/mcp-tools/` | Claude Code, Cursor, Claude Desktop (via supergateway) |
 
 The local `@cerefox/memory` npm package (entry point: the `cerefox` bin with `mcp` subcommand) exposes the **same 10 MCP tools** over stdio, importing the same `_shared/mcp-tools/` handlers. Users who want a local server (no network round-trip, no Edge Function billing) install it with `npx --package=@cerefox/memory cerefox mcp` and point their MCP client at it. See `docs/guides/connect-agents.md` and `docs/guides/migration-v0.5.md`.
+
+### Deploying the server side: `cerefox deploy-server`
+
+`cerefox deploy-server` is the **catch-all** for both standing up *and updating*
+the server side — schema + RPCs (in-process via `_shared/db-deploy/`) and all 9
+Edge Functions (`npx supabase functions deploy`), from assets bundled in the
+npm package (no repo clone). It detects fresh vs. existing databases: a fresh DB
+gets schema + RPCs deployed and migrations stamped; an existing DB gets *pending
+migrations applied* and `rpcs.sql` re-applied (an in-place update). So a release
+that changes RPCs or adds a migration ships by re-running this command. Flags:
+`--schema-only`, `--functions-only`, `--dry-run`. There is deliberately **no
+`--reset`** here — a destructive wipe lives only in the low-level
+`bun scripts/db_deploy.ts --reset` (contributor, repo clone, typed-`yes` guard).
+The migrate/deploy logic is shared with `scripts/db_migrate.ts` /
+`scripts/db_deploy.ts` via `_shared/db-deploy/`.
 
 ### Edge Function Model Config
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -81,14 +81,19 @@ bun scripts/cut_release.ts <version> --npm-publish
 ## Server-surface changes (schema / RPCs / Edge Functions)
 
 If the release changed the server side, the CHANGELOG **and** the migration
-guide must include the redeploy step prominently (not buried):
+guide must include the redeploy step prominently (not buried). For end users
+the single command covers everything:
 
 ```bash
-# From a repo clone of the matching tag:
-bun scripts/db_deploy.ts        # or db_migrate.ts for incremental schema changes
-# Then redeploy the Edge Functions (or use cerefox deploy-server):
-cerefox deploy-server
+cerefox deploy-server   # fresh DB → deploy schema+RPCs+EFs;
+                        # existing DB → apply pending migrations, refresh RPCs+EFs
 ```
+
+`deploy-server` is the catch-all: on an existing database it applies any
+*pending* migrations and re-applies `rpcs.sql`, so a release that changes RPCs
+or adds a migration is shipped just by re-running it. The low-level scripts
+(`bun scripts/db_deploy.ts` for a fresh deploy, `bun scripts/db_migrate.ts` for
+incremental migrations) remain for contributors working from a repo clone.
 
 ## If something is wrong after publish
 

--- a/_shared/cli-core/index.ts
+++ b/_shared/cli-core/index.ts
@@ -28,6 +28,7 @@ export {
   eprintln,
   errorln,
   info,
+  localTimestamp,
   ok,
   printJson,
   println,

--- a/_shared/cli-core/output.ts
+++ b/_shared/cli-core/output.ts
@@ -87,6 +87,19 @@ export function printTable(
   }
 }
 
+/**
+ * Local-time timestamp `YYYY-MM-DD HH:mm:ss.SSS` for log lines (web server
+ * daemon log). Local time (not UTC) so a maintainer tailing their own log
+ * reads wall-clock time directly.
+ */
+export function localTimestamp(d: Date = new Date()): string {
+  const p = (n: number, w = 2) => String(n).padStart(w, "0");
+  return (
+    `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())} ` +
+    `${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}.${p(d.getMilliseconds(), 3)}`
+  );
+}
+
 // ── stderr writers ──────────────────────────────────────────────────────────
 
 /** Write a single line of text + newline to stderr. */

--- a/_shared/db-deploy/index.ts
+++ b/_shared/db-deploy/index.ts
@@ -134,3 +134,152 @@ export async function runDbDeploy(opts: DbDeployOptions): Promise<DbDeployResult
 export function migrationPath(assets: ServerAssetPaths, file: string): string {
   return join(assets.migrationsDir, file);
 }
+
+// ── Incremental migrations (extracted from scripts/db_migrate.ts, v0.8.1) ────
+
+export const BOOTSTRAP_MIGRATIONS_SQL = `
+CREATE TABLE IF NOT EXISTS cerefox_migrations (
+    id         SERIAL      PRIMARY KEY,
+    filename   TEXT        NOT NULL UNIQUE,
+    applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+`;
+
+/**
+ * Does this database already have a Cerefox schema? Used by
+ * `cerefox deploy-server` to choose the fresh-deploy path vs the
+ * apply-pending-migrations path. Probes for the core documents table.
+ */
+export async function detectExistingSchema(dbUrl: string): Promise<boolean> {
+  const sql = postgres(dbUrl, { prepare: false, onnotice: () => {} });
+  try {
+    const rows = (await sql`SELECT to_regclass('public.cerefox_documents') AS t`) as Array<{
+      t: string | null;
+    }>;
+    return rows[0]?.t != null;
+  } finally {
+    await sql.end({ timeout: 5 }).catch(() => {});
+  }
+}
+
+export interface MigrationStatus {
+  all: string[];
+  applied: string[];
+  pending: string[];
+}
+
+/** Read which migration files exist vs are recorded as applied. */
+export async function migrationStatus(opts: {
+  dbUrl: string;
+  assets: ServerAssetPaths;
+}): Promise<MigrationStatus> {
+  const sql = postgres(opts.dbUrl, { prepare: false, onnotice: () => {} });
+  try {
+    await sql.unsafe(BOOTSTRAP_MIGRATIONS_SQL);
+    const all = listMigrationFiles(opts.assets.migrationsDir);
+    const appliedRows = (await sql`SELECT filename FROM cerefox_migrations ORDER BY filename`) as Array<{
+      filename: string;
+    }>;
+    const appliedSet = new Set(appliedRows.map((r) => r.filename));
+    return {
+      all,
+      applied: all.filter((f) => appliedSet.has(f)),
+      pending: all.filter((f) => !appliedSet.has(f)),
+    };
+  } finally {
+    await sql.end({ timeout: 5 }).catch(() => {});
+  }
+}
+
+export interface DbMigrateOptions {
+  dbUrl: string;
+  assets: ServerAssetPaths;
+  dryRun?: boolean;
+  log?: (line: string) => void;
+}
+
+export interface DbMigrateResult {
+  ok: boolean;
+  /** Filenames applied (empty in dry-run; that's what `pending` is for). */
+  applied: string[];
+  /** All pending migrations found at start. */
+  pending: string[];
+  failedFile?: string;
+  error?: string;
+}
+
+/**
+ * Apply pending migrations to an existing database, each in its own
+ * transaction (with the tracking-row insert in the same txn so a failure
+ * rolls both back). Bootstraps `cerefox_migrations` first. Returns a
+ * structured result; never calls process.exit.
+ */
+export async function runDbMigrate(opts: DbMigrateOptions): Promise<DbMigrateResult> {
+  const log = opts.log ?? (() => {});
+  const sql = postgres(opts.dbUrl, { prepare: false, onnotice: () => {} });
+  try {
+    await sql.unsafe(BOOTSTRAP_MIGRATIONS_SQL);
+    const allFiles = listMigrationFiles(opts.assets.migrationsDir);
+    const appliedRows = (await sql`SELECT filename FROM cerefox_migrations ORDER BY filename`) as Array<{
+      filename: string;
+    }>;
+    const appliedSet = new Set(appliedRows.map((r) => r.filename));
+    const pending = allFiles.filter((f) => !appliedSet.has(f));
+
+    if (pending.length === 0) return { ok: true, applied: [], pending: [] };
+    if (opts.dryRun) {
+      for (const f of pending) log(`Would apply ${f}`);
+      return { ok: true, applied: [], pending };
+    }
+
+    const applied: string[] = [];
+    for (const f of pending) {
+      const body = readFileSync(join(opts.assets.migrationsDir, f), "utf8");
+      log(`Applying ${f}…`);
+      try {
+        await sql.begin(async (tx) => {
+          await tx.unsafe(body);
+          await tx`INSERT INTO cerefox_migrations (filename) VALUES (${f}) ON CONFLICT DO NOTHING`;
+        });
+        applied.push(f);
+      } catch (err) {
+        return {
+          ok: false,
+          applied,
+          pending,
+          failedFile: f,
+          error: err instanceof Error ? err.message : String(err),
+        };
+      }
+    }
+    return { ok: true, applied, pending };
+  } finally {
+    await sql.end({ timeout: 5 }).catch(() => {});
+  }
+}
+
+/**
+ * Re-apply `rpcs.sql` to refresh the Postgres RPCs (CREATE OR REPLACE /
+ * DROP+CREATE — idempotent). Used by the existing-DB path of
+ * `cerefox deploy-server` so an update lands the latest RPC definitions.
+ */
+export async function applyRpcs(opts: {
+  dbUrl: string;
+  assets: ServerAssetPaths;
+  dryRun?: boolean;
+  log?: (line: string) => void;
+}): Promise<{ ok: boolean; error?: string }> {
+  const log = opts.log ?? (() => {});
+  log("Refresh RPCs (rpcs.sql)…");
+  if (opts.dryRun) return { ok: true };
+  const rpcsSql = readFileSync(opts.assets.rpcsFile, "utf8");
+  const sql = postgres(opts.dbUrl, { prepare: false, onnotice: () => {} });
+  try {
+    await sql.unsafe(rpcsSql);
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  } finally {
+    await sql.end({ timeout: 5 }).catch(() => {});
+  }
+}

--- a/docs/guides/connect-agents.md
+++ b/docs/guides/connect-agents.md
@@ -133,6 +133,26 @@ change.
 > make authenticated POST calls to the Edge Functions. The built-in local server is
 > the correct solution.
 
+### Fastest setup: `cerefox configure-agent`
+
+You don't have to hand-edit the per-client config files below. `cerefox configure-agent
+--tool <client>` writes the correct local-stdio entry (`npx -y --package=@cerefox/memory
+cerefox mcp`) into the right config file for you. Supported clients:
+
+```bash
+cerefox configure-agent --tool claude-code      # ~/.claude.json (via `claude mcp add`)
+cerefox configure-agent --tool claude-desktop   # Claude Desktop config
+cerefox configure-agent --tool cursor           # ~/.cursor/mcp.json
+cerefox configure-agent --tool codex            # ~/.codex/config.toml
+cerefox configure-agent --tool gemini           # ~/.gemini/settings.json
+```
+
+Useful flags: `--dry-run` (print the planned write without touching any file), `--json`
+(machine-readable result), `--config-path <path>` (override the target file), `--no-backup`
+(skip the `.pre-cerefox.bak` backup). The command is idempotent and backs up any existing
+config before writing. The per-client sections below document the same entries for anyone
+who prefers to edit by hand or needs the remote (`Path A-Remote`) HTTP transport instead.
+
 ### Path A MCP tools
 
 Once configured, every Path A client has these tools:

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -49,14 +49,18 @@ Cerefox usage guidance.
 # Run the commands that apply to your setup:
 cerefox configure-agent --tool claude-code      # Claude Code (~/.claude.json)
 cerefox configure-agent --tool claude-desktop   # Claude Desktop config
+cerefox configure-agent --tool cursor           # Cursor (~/.cursor/mcp.json)
+cerefox configure-agent --tool codex            # OpenAI Codex CLI (~/.codex/config.toml)
+cerefox configure-agent --tool gemini           # Gemini CLI (~/.gemini/settings.json)
 ```
 
 Then restart your client:
 - **Claude Code**: start a fresh session — running sessions cache the MCP tool list.
 - **Claude Desktop**: Cmd+Q to fully quit, then relaunch.
+- **Cursor / Codex CLI / Gemini CLI**: reload or restart the client/session.
 
-Cursor, OpenAI Codex CLI, and Gemini CLI ship in a follow-up (v0.6+).
-For manual setup of those today, see [`connect-agents.md`](connect-agents.md).
+All five writers configure the local stdio server. For the remote (Edge Function)
+HTTP transport, or to edit configs by hand, see [`connect-agents.md`](connect-agents.md).
 
 ## 4. Try it
 

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -2975,13 +2975,31 @@ find /tmp/cerefox-dump -name '*.md' | wc -l              # sanity count
 
 ---
 
+## Iteration 26.1: v0.8.1 — "deploy-server handles updates"
+
+**Goal**: Close a gap found right after v0.8.0 published: `cerefox deploy-server` only ever did a *fresh* deploy (apply schema + RPCs, then **stamp** every migration as applied without running it). Re-run against a database that already has a Cerefox schema, it never applied pending migrations and never refreshed RPCs — so a release that ships a new migration or changed RPCs wasn't actually deployed by re-running the catch-all command. v0.8.1 makes `deploy-server` the true catch-all for standing up **and updating** the server side.
+
+**Status**: Implemented on `feat/v0.8.1-deploy-server-migrations` (2026-05-29). **Cut deferred** until the clone-env walk validates the existing-DB migration path end-to-end (a fresh side-by-side Supabase account, side-by-side with the maintainer), which also refreshes `docs/guides/setup-supabase.md`.
+
+| Part | Description | Acceptance |
+|------|-------------|-----------|
+| **26.1-A** | Extract `runDbMigrate`, `migrationStatus`, `detectExistingSchema`, `applyRpcs` into `_shared/db-deploy/`. Refactor `scripts/db_migrate.ts` into a thin wrapper over the shared logic; add `--status`. | `_shared` + scripts-smoke green; `db_migrate.ts --status` lists applied/pending live. |
+| **26.1-B** | `deploy-server` detects fresh vs. existing DB (`detectExistingSchema`). Fresh → `runDbDeploy` (unchanged). Existing → `runDbMigrate` (apply pending, each in its own txn) + `applyRpcs` (refresh RPCs). Dry-run plan shows the chosen path + pending list. **Remove `--reset`** from the user-facing command (stays in `scripts/db_deploy.ts --reset`). `cerefox init`'s below-min-schema path now runs plain `deploy-server` (in-place update) instead of `--reset`. | `deploy-server --schema-only --dry-run` against a live existing DB reports "apply N pending migration(s) + refresh RPCs"; `--help` no longer advertises `--reset`; `cli-deploy-server.test.ts` green. |
+| **26.1-C** | `doctor` relabels `schema` → `schema + RPCs`; classifies deployed schema/RPC version against `COMPATIBILITY.minSchema` (error) + bundled `@version` (warn). Consolidated remediation footer: both stale → `deploy-server`; one stale → `--schema-only` / `--functions-only`. | `doctor` renders the new label + footer; full package suite green. |
+| **26.1-D** | Closeout: CHANGELOG [Unreleased] entry, RELEASING.md + CLAUDE.md note deploy-server as the migration-aware catch-all, this plan section, PR. Cut deferred to the clone-env walk. | Artifacts present; PR opened. |
+
+**Out of scope**: cutting/publishing the tag (deferred to the clone-env validation walk); any new migration files (none added in v0.8.1).
+
+---
+
 ## Iteration 27: v0.9.0 — "CLI Redesign + Python Web Deletion"
 
-**Goal**: Three themes for **v0.9.0**:
+**Goal**: Four themes for **v0.9.0**:
 
 1. **CLI ↔ web functional parity + verb normalization.** Audit every operation the web UI supports vs every CLI command; close gaps both ways. Then redesign the entire CLI verb structure to a resource-verb pattern matching cfcf's convention: `cerefox <resource> <verb> [args]`. E.g., `cerefox document get|delete|list|edit|ingest`, `cerefox project create|delete|list|edit`, `cerefox version list|archive`. Each old top-level verb (`get-doc`, `list-docs`, `delete-doc`, …) becomes a husk that prints "use `cerefox document <verb>` instead" and exits with a non-zero code (so muscle-memory scripts surface the rename loudly). v0.9.0 is the last release with the old verbs reachable at all.
 2. **Delete the Python web** (per Fotis-13 / D6). `src/cerefox/api/*` removed. The TS web has been canonical since v0.6; nobody chooses Python web as a fallback path (unlike Python MCP, which agents wire up deliberately via stdio).
 3. **Test-runner cutover phase 2 + subprocess-pattern tests for surviving Python.** Per design doc §19 rule 5: tests for the Python MCP server move to TS via subprocess pattern (TS test spawns `uv run cerefox mcp` and asserts JSON-RPC handshake + tools/list + sample tool call at the process boundary). New husk-CLI tests for every renamed-to-husk Python subcommand. After v0.9: zero `.py` in `tests/`; one test runner (`bun test`); `pyproject.toml` / `uv.lock` / `.python-version` STAY because Python the runtime stays (MCP server).
+4. **Two-install-path documentation overhaul** (Fotis, 2026-05-29). Since v0.8 the project has two distinct install audiences and the README / guides don't cleanly separate them. Restructure all user-facing docs around **two paths, both kept**: **(a) End user (no repo checkout)** — the install script + `cerefox` CLI commands (`init` → `deploy-server` → `configure-agent`); never needs to clone the repo. **(b) Contributor** — the existing README + `quickstart.md` repo-clone flow (uv, bun, repo scripts). The decision is to keep both, clearly labelled, so neither audience is led down the other's path. Touches README.md (top-level split), `quickstart.md`, `setup-supabase.md`, `connect-agents.md`, and the guide index.
 
 **Python MCP retention** (per Fotis-13): the Python MCP server (`src/cerefox/mcp_server.py`) stays **through v1.x at minimum**. Repo-clone users who `git pull && uv run cerefox mcp` without reading docs keep working. Removal considered post-v1.0 — probably v2.0 candidate or "kept indefinitely as a fallback path." The long-tail Python footprint is accepted.
 
@@ -3001,6 +3019,7 @@ find /tmp/cerefox-dump -name '*.md' | wc -l              # sanity count
 - **Migration guide update**: `docs/guides/migration-v0.5.md` gets a v0.9 section. May warrant a new `migration-v0.9.md` since the verb rename is the largest user-impact change since v0.5.
 - **CLAUDE.md update**: `CLI verb conventions` section codifying the resource-verb pattern so future commands follow it.
 - **Remove the `CEREFOX_NO_DEPRECATION_BANNER` opt-out** (added 2026-05-29 per Fotis): the Python CLI deprecation banner's suppress env var predates iter-26 (shipped v0.5.0). Fotis-19 leaned against having an opt-out at all; iter-26 kept it only to avoid breaking existing quiet-CI usage mid-stream. v0.9 turns the Python CLI subcommands into husks anyway, so the banner's role changes — drop the env var here so the husk message always prints (maximum nudge). Note in the CHANGELOG that the suppress var is gone.
+- **Two-install-path documentation overhaul** (Fotis, 2026-05-29): restructure README + guides around the two audiences (end user via install-script + CLI; contributor via repo clone). Both paths kept, clearly labelled. README gets a top-level "Choose your path" split near the top; `quickstart.md` framed explicitly as the contributor/repo-clone flow; the end-user path documents `install → cerefox init → cerefox deploy-server → cerefox configure-agent` with no `git clone`. Cross-link `setup-supabase.md` and `connect-agents.md` from both. Verify the install script exists / is referenced consistently.
 
 **Parts breakdown (27A–27J)**:
 
@@ -3015,7 +3034,8 @@ find /tmp/cerefox-dump -name '*.md' | wc -l              # sanity count
 | **27G** | Husk-CLI subprocess tests for every renamed verb. |
 | **27H** | Delete all surviving `.py` test files under `tests/` (except subprocess targets that genuinely run Python). pytest dep removed from pyproject.toml. |
 | **27I** | CHANGELOG v0.9.0 entry; migration-v0.9.md (or v0.5 update with v0.9 section); CLAUDE.md verb-conventions section. |
-| **27J** | Closeout: design doc §13 v0.9.0 updated; Decision Log entry; manual test plan update. |
+| **27J** | **Two-install-path documentation overhaul**: README top-level "Choose your path" split (end user via install-script + CLI vs contributor via repo clone); reframe `quickstart.md` as the contributor flow; document the end-user `init → deploy-server → configure-agent` path with no clone; cross-link `setup-supabase.md` + `connect-agents.md`; update the guide index. Both paths kept. |
+| **27K** | Closeout: design doc §13 v0.9.0 updated; Decision Log entry; manual test plan update. |
 
 **Risks**:
 

--- a/packages/memory/src/cli/commands/delete-project.ts
+++ b/packages/memory/src/cli/commands/delete-project.ts
@@ -1,0 +1,111 @@
+/**
+ * `cerefox delete-project <name-or-id>` — hard-delete an empty project.
+ *
+ * Symmetric to `cerefox list-projects`. Looks up by UUID or name. Refuses
+ * if the project still has documents unless `--force` is passed; in that
+ * case the document↔project links break but the documents themselves are
+ * untouched (only the row in `cerefox_projects` is removed). Use the
+ * soft-delete workflow for documents.
+ *
+ * Primary use cases:
+ *   - User-facing cleanup of stray projects (the Projects page in the web
+ *     UI exposes the same operation).
+ *   - Test-harness cleanup: write-commands.test.ts removes the
+ *     `_e2e-v0.5` project in its afterAll hook.
+ */
+
+import type { Command } from "commander";
+
+import {
+  c,
+  confirm,
+  notFound,
+  println,
+  systemError,
+  userError,
+} from "../../../../../_shared/cli-core/index.ts";
+import { getClient } from "../util/client.ts";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+interface DeleteProjectOptions {
+  yes?: boolean;
+  force?: boolean;
+}
+
+interface ProjectRow {
+  id: string;
+  name: string;
+  description: string | null;
+}
+
+async function action(target: string, options: DeleteProjectOptions): Promise<void> {
+  const client = getClient();
+  const isUuid = UUID_RE.test(target);
+
+  const lookup = isUuid
+    ? client.raw.from("cerefox_projects").select("id, name, description").eq("id", target).maybeSingle()
+    : client.raw.from("cerefox_projects").select("id, name, description").eq("name", target).maybeSingle();
+
+  const { data: project, error } = (await lookup) as {
+    data: ProjectRow | null;
+    error: { message: string } | null;
+  };
+
+  if (error) {
+    throw systemError(`Project lookup failed: ${error.message}`);
+  }
+  if (!project) {
+    throw notFound(`Project "${target}" not found.`);
+  }
+
+  const { count, error: countErr } = await client.raw
+    .from("cerefox_document_projects")
+    .select("*", { count: "exact", head: true })
+    .eq("project_id", project.id);
+
+  if (countErr) {
+    throw systemError(`Could not count documents in project: ${countErr.message}`);
+  }
+
+  const docCount = count ?? 0;
+  if (docCount > 0 && !options.force) {
+    throw userError(
+      `Project "${project.name}" still has ${docCount} document link(s).`,
+      "Pass --force to delete the project anyway (documents remain; only the project row is removed).",
+    );
+  }
+
+  println(c.yellow("About to delete project:"));
+  println(`  ${project.name}`);
+  println(c.dim(`  ${project.id} · ${docCount} doc link(s)`));
+
+  if (!options.yes) {
+    const ok = await confirm("Continue?", true);
+    if (!ok) {
+      println(c.dim("Aborted."));
+      return;
+    }
+  }
+
+  const { error: delErr } = await client.raw
+    .from("cerefox_projects")
+    .delete()
+    .eq("id", project.id);
+
+  if (delErr) {
+    throw systemError(`Delete failed: ${delErr.message}`);
+  }
+
+  println(c.green(`✓ Deleted project "${project.name}" (id: ${project.id}).`));
+}
+
+export function registerDeleteProject(program: Command): void {
+  program
+    .command("delete-project")
+    .description("Delete an empty project (use --force to remove a non-empty one).")
+    .argument("<name-or-id>", "Project name (exact match) or UUID.")
+    .option("--yes", "Skip the confirmation prompt.")
+    .option("--force", "Allow deletion when documents are still linked to the project.")
+    .action(action);
+}

--- a/packages/memory/src/cli/commands/deploy-server.ts
+++ b/packages/memory/src/cli/commands/deploy-server.ts
@@ -1,19 +1,28 @@
 /**
- * `cerefox deploy-server` — deploy the Cerefox server side to your Supabase
- * project (iter-26 Part 26D): the Postgres schema + RPCs (in-process via the
- * shared `runDbDeploy`) and the 9 Edge Functions (via `npx supabase
- * functions deploy`).
+ * `cerefox deploy-server` — the catch-all for standing up *and updating*
+ * the Cerefox server side on your Supabase project: the Postgres schema +
+ * RPCs (in-process) and the 9 Edge Functions (via `npx supabase functions
+ * deploy`).
  *
  * Eliminates the repo-clone step: the server assets (SQL + EF sources) ship
- * bundled in `dist/server-assets/` (Part 26A), so a fresh
- * `npm install -g @cerefox/memory` can stand up the whole server.
+ * bundled in `dist/server-assets/`, so a fresh `npm install -g
+ * @cerefox/memory` can stand up the whole server.
+ *
+ * Fresh vs. existing (v0.8.1): the DB half detects whether a Cerefox schema
+ * already exists.
+ *   - Fresh DB → apply schema.sql + rpcs.sql + stamp migrations (full deploy).
+ *   - Existing DB → apply pending migrations + refresh RPCs (an *update*).
+ * So a release that changes RPCs and/or adds a migration is deployed by
+ * re-running this command — no separate migrate step needed. (The low-level
+ * `scripts/db_deploy.ts` / `db_migrate.ts` remain for contributors.)
  *
  * Comprehensive pre-flight: every external prerequisite is probed up-front
- * and reported as a single all-or-nothing remediation list. The user fixes
- * what's missing and re-runs — the command is idempotent.
+ * and reported as a single all-or-nothing remediation list. Idempotent.
  *
- * Flags: --dry-run (plan only, no prompt), --reset (drop + redeploy),
- *        --schema-only, --functions-only.
+ * Flags: --dry-run (plan only, no prompt), --schema-only, --functions-only.
+ * There is deliberately NO --reset (drop-everything) here — a full wipe is a
+ * contributor/recovery operation; use `bun scripts/db_deploy.ts --reset`
+ * (repo clone, typed-`yes` guard) if you truly need it.
  */
 
 import type { Command } from "commander";
@@ -30,11 +39,16 @@ import {
 } from "../../../../../_shared/cli-core/index.ts";
 import { loadSettings } from "../../../../../_shared/config/index.ts";
 import { resolveServerAssets } from "../../../../../_shared/server-assets/index.ts";
-import { runDbDeploy } from "../../../../../_shared/db-deploy/index.ts";
+import {
+  applyRpcs,
+  detectExistingSchema,
+  migrationStatus,
+  runDbDeploy,
+  runDbMigrate,
+} from "../../../../../_shared/db-deploy/index.ts";
 
 interface DeployServerOptions {
   dryRun?: boolean;
-  reset?: boolean;
   schemaOnly?: boolean;
   functionsOnly?: boolean;
 }
@@ -143,14 +157,39 @@ async function action(options: DeployServerOptions): Promise<void> {
   }
   println(c.green("\n✓ All prerequisites satisfied."));
 
+  // ── Detect fresh vs existing (read-only probe) ───────────────────────────
+  let schemaMode: "fresh" | "existing" | "unknown" = "unknown";
+  let pending: string[] = [];
+  if (doSchema) {
+    try {
+      const exists = await detectExistingSchema(settings.databaseUrl);
+      schemaMode = exists ? "existing" : "fresh";
+      if (exists) {
+        pending = (await migrationStatus({ dbUrl: settings.databaseUrl, assets })).pending;
+      }
+    } catch (err) {
+      if (!options.dryRun) {
+        eprintln(c.red(`\n✗ Could not connect to the database: ${err instanceof Error ? err.message : String(err)}`));
+        eprintln(c.dim("   Verify CEREFOX_DATABASE_URL (Session Pooler, port 5432)."));
+        process.exit(1);
+      }
+      // dry-run tolerates a probe failure — just show a generic plan.
+    }
+  }
+
   // ── Plan + confirm ──────────────────────────────────────────────────────
   const planLines: string[] = [];
   if (doSchema) {
-    planLines.push(
-      `  • ${options.reset ? "RESET + redeploy" : "Deploy"} schema + RPCs to ${
-        settings.supabaseUrl || "your Supabase database"
-      }`,
-    );
+    if (schemaMode === "fresh") {
+      planLines.push(`  • Deploy fresh schema + RPCs to ${settings.supabaseUrl || "your Supabase database"}`);
+    } else if (schemaMode === "existing") {
+      planLines.push(
+        `  • Update existing schema: apply ${pending.length} pending migration(s) + refresh RPCs`,
+      );
+      for (const f of pending) planLines.push(c.dim(`      – ${f}`));
+    } else {
+      planLines.push(`  • Schema + RPCs (fresh or update — couldn't probe the DB)`);
+    }
   }
   if (doFunctions) {
     planLines.push(`  • Deploy ${efNames.length} Edge Function(s): ${efNames.join(", ")}`);
@@ -164,10 +203,7 @@ async function action(options: DeployServerOptions): Promise<void> {
     process.exit(0);
   }
 
-  const proceed = await confirm(
-    `\nProceed with deployment to Supabase${options.reset ? " (--reset DROPS existing data!)" : ""}?`,
-    true, // default No
-  );
+  const proceed = await confirm("\nProceed with deployment to Supabase?", true /* default No */);
   if (!proceed) {
     println(c.dim("Aborted."));
     process.exit(0);
@@ -175,18 +211,46 @@ async function action(options: DeployServerOptions): Promise<void> {
 
   // ── Schema ────────────────────────────────────────────────────────────────
   if (doSchema) {
-    println(c.bold("\n▶  Deploying schema + RPCs…"));
-    const result = await runDbDeploy({
-      dbUrl: settings.databaseUrl,
-      assets,
-      reset: options.reset,
-      log: (line) => println(c.dim(`   ${line}`)),
-    });
-    if (!result.ok) {
-      eprintln(c.red(`\n✗ Schema deploy failed at "${result.failedStep}": ${result.error}`));
-      process.exit(1);
+    if (schemaMode === "fresh") {
+      println(c.bold("\n▶  Deploying fresh schema + RPCs…"));
+      const result = await runDbDeploy({
+        dbUrl: settings.databaseUrl,
+        assets,
+        log: (line) => println(c.dim(`   ${line}`)),
+      });
+      if (!result.ok) {
+        eprintln(c.red(`\n✗ Schema deploy failed at "${result.failedStep}": ${result.error}`));
+        process.exit(1);
+      }
+      println(c.green(`   ✓ Fresh schema deployed (${result.stepsRun} steps).`));
+    } else {
+      // Existing DB: apply pending migrations, then refresh RPCs.
+      println(c.bold("\n▶  Updating existing schema (migrations + RPC refresh)…"));
+      const mig = await runDbMigrate({
+        dbUrl: settings.databaseUrl,
+        assets,
+        log: (line) => println(c.dim(`   ${line}`)),
+      });
+      if (!mig.ok) {
+        eprintln(c.red(`\n✗ Migration "${mig.failedFile}" failed: ${mig.error}`));
+        eprintln(c.dim("   Earlier migrations in this run were committed. Fix + re-run."));
+        process.exit(1);
+      }
+      const rpcs = await applyRpcs({
+        dbUrl: settings.databaseUrl,
+        assets,
+        log: (line) => println(c.dim(`   ${line}`)),
+      });
+      if (!rpcs.ok) {
+        eprintln(c.red(`\n✗ RPC refresh failed: ${rpcs.error}`));
+        process.exit(1);
+      }
+      println(
+        c.green(
+          `   ✓ Applied ${mig.applied.length} migration(s); RPCs refreshed.`,
+        ),
+      );
     }
-    println(c.green(`   ✓ Schema deployed (${result.stepsRun} steps).`));
   }
 
   // ── Edge Functions ──────────────────────────────────────────────────────
@@ -223,10 +287,9 @@ async function action(options: DeployServerOptions): Promise<void> {
 export function registerDeployServer(program: Command): void {
   program
     .command("deploy-server")
-    .description("Deploy the Cerefox server side (schema + RPCs + Edge Functions) to Supabase.")
+    .description("Deploy/update the Cerefox server side (schema + RPCs + Edge Functions) on Supabase.")
     .option("--dry-run", "Print the plan + pre-flight without deploying.")
-    .option("--reset", "DROP existing Cerefox tables before redeploying the schema (DESTRUCTIVE).")
-    .option("--schema-only", "Deploy only the schema + RPCs (skip Edge Functions).")
-    .option("--functions-only", "Deploy only the Edge Functions (skip the schema).")
+    .option("--schema-only", "Deploy/update only the schema + RPCs (skip Edge Functions).")
+    .option("--functions-only", "Deploy only the Edge Functions (skip the schema/RPCs).")
     .action(action);
 }

--- a/packages/memory/src/cli/commands/doctor.ts
+++ b/packages/memory/src/cli/commands/doctor.ts
@@ -67,6 +67,31 @@ async function action(options: { json?: boolean }): Promise<void> {
     println("");
   }
 
+  // Consolidated server-update remediation. The schema+RPC and Edge Function
+  // checks classify drift but deliberately leave the command to here so we
+  // emit a single suggestion: both stale → run the whole `deploy-server`;
+  // only one stale → the matching --schema-only / --functions-only flag.
+  if (!options.json) {
+    const stale = (name: string) => {
+      const r = results.find((x) => x.name === name);
+      return r != null && (r.status === "error" || r.status === "warn");
+    };
+    const needsSchema = stale("schema + RPCs");
+    const needsEf = stale("edge functions");
+    let remediation: string | null = null;
+    if (needsSchema && needsEf) {
+      remediation = "Update the server (schema + RPCs + Edge Functions): cerefox deploy-server";
+    } else if (needsSchema) {
+      remediation = "Update the schema + RPCs: cerefox deploy-server --schema-only";
+    } else if (needsEf) {
+      remediation = "Update the Edge Functions: cerefox deploy-server --functions-only";
+    }
+    if (remediation) {
+      println(cErr.yellow("→ " + remediation));
+      println("");
+    }
+  }
+
   const errCount = results.filter((r) => r.status === "error").length;
   const warnCount = results.filter((r) => r.status === "warn").length;
   if (errCount > 0) {

--- a/packages/memory/src/cli/commands/init.ts
+++ b/packages/memory/src/cli/commands/init.ts
@@ -379,8 +379,9 @@ function launchDeployServer(extraArgs: string[] = []): number {
 /**
  * iter-26 Part 26E: offer to deploy the server side when the schema is
  * missing (404) or below the client's minimum. Three cases:
- *   (a) no schema      → "Deploy now?" → deploy-server
- *   (b) below minSchema → "Redeploy now?" → deploy-server --reset
+ *   (a) no schema      → "Deploy now?" → deploy-server (fresh)
+ *   (b) below minSchema → "Update now?" → deploy-server (applies pending
+ *       migrations + refreshes RPCs in place; v0.8.1 — no longer --reset)
  *   (c) compatible      → silent pass
  * Declining at any prompt continues init; `cerefox doctor` nudges again.
  */
@@ -407,9 +408,9 @@ async function maybeOfferServerDeploy(): Promise<void> {
         `  Deployed schema v${deployed} is below the required v${COMPATIBILITY.minSchema}.`,
       ),
     );
-    const yes = await confirm("  Redeploy the server now (--reset DROPS existing data)?", true);
-    if (yes) launchDeployServer(["--reset"]);
-    else println(c.dim("  Skipped. Run `cerefox deploy-server --reset` when ready."));
+    const yes = await confirm("  Update the server now (applies pending migrations, refreshes RPCs + EFs)?", true);
+    if (yes) launchDeployServer();
+    else println(c.dim("  Skipped. Run `cerefox deploy-server` when ready."));
     println("");
     return;
   }

--- a/packages/memory/src/cli/commands/web.ts
+++ b/packages/memory/src/cli/commands/web.ts
@@ -16,7 +16,7 @@
 
 import type { Command } from "commander";
 
-import { c, eprintln, info, println } from "../../../../../_shared/cli-core/index.ts";
+import { c, eprintln, info, localTimestamp, println } from "../../../../../_shared/cli-core/index.ts";
 import { buildWebServer, CompatibilityError } from "../../web/server.ts";
 import {
   daemonPaths,
@@ -47,12 +47,14 @@ async function runForeground(host: string, port: number, watch?: boolean): Promi
   }
   try {
     const handle = await buildWebServer({ host, port });
-    info(`Cerefox web listening on http://${handle.host}:${handle.port}/`);
+    // Timestamped to match the request-logger lines in the daemon log
+    // (~/.cerefox/web.log); local time per maintainer preference.
+    println(`${localTimestamp()}  Cerefox web listening on http://${handle.host}:${handle.port}/`);
     println(`  Web UI:  http://${handle.host}:${handle.port}/app/`);
     println(`  API:     http://${handle.host}:${handle.port}/api/v1/`);
 
     const shutdown = async (signal: string) => {
-      info(`Received ${signal}; shutting down.`);
+      println(`${localTimestamp()}  Received ${signal}; shutting down.`);
       await handle.close().catch(() => {});
       process.exit(0);
     };

--- a/packages/memory/src/cli/program.ts
+++ b/packages/memory/src/cli/program.ts
@@ -25,6 +25,7 @@ import { registerConfigGet } from "./commands/config-get.ts";
 import { registerConfigSet } from "./commands/config-set.ts";
 import { registerConfigureAgent } from "./commands/configure-agent.ts";
 import { registerDeleteDoc } from "./commands/delete-doc.ts";
+import { registerDeleteProject } from "./commands/delete-project.ts";
 import { registerDeployServer } from "./commands/deploy-server.ts";
 import { registerDocs } from "./commands/docs.ts";
 import { registerDoctor } from "./commands/doctor.ts";
@@ -71,7 +72,7 @@ export function buildProgram(): Command {
       "\nCommand groups (each row in the list above falls into one):\n" +
         "  READS      search · get-doc · list-docs · list-versions · list-projects\n" +
         "             · list-metadata-keys · metadata-search · get-audit-log\n" +
-        "  WRITES     ingest · ingest-dir · delete-doc\n" +
+        "  WRITES     ingest · ingest-dir · delete-doc · delete-project\n" +
         "  SERVERS    mcp · web\n" +
         "  LIFECYCLE  init · doctor · status · configure-agent · self-update · upgrade · sync-self-docs · deploy-server\n" +
         "  OPS        backup · restore · sync-docs · docs · reindex · config-get · config-set · completion\n" +
@@ -98,6 +99,7 @@ export function buildProgram(): Command {
   registerIngest(program);
   registerIngestDir(program);
   registerDeleteDoc(program);
+  registerDeleteProject(program);
 
   // ── SERVERS ─────────────────────────────────────────────────────────────
   registerMcp(program);

--- a/packages/memory/src/cli/util/checks.ts
+++ b/packages/memory/src/cli/util/checks.ts
@@ -26,7 +26,10 @@ import {
 import {
   aggregatorUrlFor,
   checkServerCompatibility,
+  classifyCompat,
+  COMPATIBILITY,
 } from "../../../../../_shared/compatibility/index.ts";
+import { resolveServerAssets } from "../../../../../_shared/server-assets/index.ts";
 
 export type CheckStatus = "ok" | "warn" | "error" | "skipped";
 
@@ -231,11 +234,28 @@ export async function checkOpenAI(): Promise<CheckResult> {
   }
 }
 
+/** Matches the `-- @version: X.Y.Z` marker at the top of schema.sql. */
+const SCHEMA_VERSION_RE = /^--\s*@version:\s*(\S+)/m;
+
+/** Read the schema version this client bundles (from the schema.sql header). */
+function readBundledSchemaVersion(): string | null {
+  try {
+    const assets = resolveServerAssets();
+    if (!existsSync(assets.schemaFile)) return null;
+    const m = readFileSync(assets.schemaFile, "utf8").match(SCHEMA_VERSION_RE);
+    return m ? m[1] : null;
+  } catch {
+    return null;
+  }
+}
+
+const SCHEMA_CHECK_NAME = "schema + RPCs";
+
 export async function checkSchemaVersion(): Promise<CheckResult> {
   const settings = loadSettings();
   if (!settings.supabaseUrl || !settings.supabaseKey) {
     return {
-      name: "schema",
+      name: SCHEMA_CHECK_NAME,
       status: "skipped",
       detail: "Supabase config missing; skipped.",
     };
@@ -253,26 +273,44 @@ export async function checkSchemaVersion(): Promise<CheckResult> {
     });
     if (!resp.ok) {
       return {
-        name: "schema",
+        name: SCHEMA_CHECK_NAME,
         status: "error",
-        detail: `cerefox_schema_version returned ${resp.status}`,
-        hint: "Deploy the schema: `uv run python scripts/db_deploy.py`",
+        detail: `cerefox_schema_version returned ${resp.status} — schema not deployed.`,
+        hint: "Deploy the schema + RPCs (see remediation below).",
       };
     }
     const deployed = (await resp.json()) as string;
-    // Schema version is independent of the npm package version — they
-    // ratchet on different cadences. The web UI's mismatch banner
-    // (v0.3.0) is for "I rebuilt my server but forgot to redeploy the
-    // schema"; the doctor check here just surfaces the deployed value
-    // matter-of-factly.
-    return {
-      name: "schema",
-      status: "ok",
-      detail: `cerefox_schema_version() → "${deployed}"`,
-    };
+    // Classify the deployed Postgres schema/RPC version against this client's
+    // minimum (blocking) and bundled (informational) versions. The remediation
+    // command is owned by the doctor footer, which consolidates schema + EF
+    // suggestions into a single `cerefox deploy-server [--schema-only]` line.
+    const bundled = readBundledSchemaVersion();
+    const level = classifyCompat(deployed, COMPATIBILITY.minSchema, bundled);
+    switch (level) {
+      case "below-min":
+        return {
+          name: SCHEMA_CHECK_NAME,
+          status: "error",
+          detail: `Deployed schema v${deployed} is below the required minimum v${COMPATIBILITY.minSchema}.`,
+          hint: "Update the schema + RPCs (see remediation below).",
+        };
+      case "above-min-but-old":
+        return {
+          name: SCHEMA_CHECK_NAME,
+          status: "warn",
+          detail: `Deployed schema v${deployed} works but is older than this client's bundled v${bundled}.`,
+          hint: "Update the schema + RPCs (see remediation below).",
+        };
+      default:
+        return {
+          name: SCHEMA_CHECK_NAME,
+          status: "ok",
+          detail: `cerefox_schema_version() → "${deployed}"${bundled ? ` (bundled v${bundled})` : ""}`,
+        };
+    }
   } catch (err) {
     return {
-      name: "schema",
+      name: SCHEMA_CHECK_NAME,
       status: "error",
       detail: `Schema version probe failed: ${err instanceof Error ? err.message : String(err)}`,
     };
@@ -471,14 +509,14 @@ export async function checkEdgeFunctionsCompat(): Promise<CheckResult> {
         name: "edge functions",
         status: "error",
         detail: `Deployed EF v${deployed} is below the required minimum v${compat.edgeFunctions.min}.`,
-        hint: "Redeploy the Edge Functions: `cerefox deploy-server --functions-only`.",
+        hint: "Update the Edge Functions (see remediation below).",
       };
     case "above-min-but-old":
       return {
         name: "edge functions",
         status: "warn",
         detail: `Deployed EF v${deployed} works but is older than this client (v${PKG_VERSION}).`,
-        hint: "Consider redeploying: `cerefox deploy-server --functions-only`.",
+        hint: "Update the Edge Functions (see remediation below).",
       };
     default:
       return {
@@ -543,7 +581,7 @@ export async function runAllChecks(opts: RunChecksOptions = {}): Promise<CheckRe
     { name: "legacy env", phase: "Checking legacy env shadowing", run: () => checkLegacyShadowEnv() },
     { name: "supabase", phase: "Probing Supabase Data API", run: () => checkSupabase() },
     { name: "openai", phase: "Probing OpenAI embeddings", run: () => checkOpenAI() },
-    { name: "schema", phase: "Reading schema version", run: () => checkSchemaVersion() },
+    { name: "schema + RPCs", phase: "Reading schema + RPC version", run: () => checkSchemaVersion() },
     { name: "edge functions", phase: "Probing Edge Function versions", run: () => checkEdgeFunctionsCompat() },
     { name: "postgres", phase: "Probing Postgres DDL endpoint", run: () => checkPostgres() },
     { name: "mcp clients", phase: "Scanning MCP client configs", run: () => checkMcpConfigs() },

--- a/packages/memory/src/web/server.ts
+++ b/packages/memory/src/web/server.ts
@@ -47,6 +47,7 @@ import {
   resolveStaticDir,
 } from "./static.ts";
 import { PKG_VERSION } from "../meta.ts";
+import { localTimestamp } from "../../../../_shared/cli-core/index.ts";
 import { loadSettings } from "../../../../_shared/config/index.ts";
 import {
   aggregatorUrlFor,
@@ -67,11 +68,13 @@ export interface WebServerHandle {
 export function buildApp(ctx: WebContext | null = buildWebContext()): Hono {
   const app = new Hono();
 
-  // (0) Request logger — writes one line per request to stderr, matching the
-  // UX FastAPI/uvicorn provided on the Python web server. Skipped in test
-  // runs (NODE_ENV=test) so smoke tests stay quiet.
+  // (0) Request logger — writes one line per request, matching the UX
+  // FastAPI/uvicorn provided on the Python web server. Each line is prefixed
+  // with a local-time timestamp so the daemon log (~/.cerefox/web.log) is
+  // readable after the fact. Skipped in test runs (NODE_ENV=test) so smoke
+  // tests stay quiet.
   if (process.env.NODE_ENV !== "test") {
-    app.use(logger());
+    app.use(logger((message, ...rest) => console.log(`${localTimestamp()}  ${message}`, ...rest)));
   }
 
   // (1) JSON API — registered first.

--- a/packages/memory/test/cli-deploy-server.test.ts
+++ b/packages/memory/test/cli-deploy-server.test.ts
@@ -42,9 +42,10 @@ describe("cerefox deploy-server CLI", () => {
     const { stdout, status } = run(["deploy-server", "--help"]);
     expect(status).toBe(0);
     expect(stdout).toContain("--dry-run");
-    expect(stdout).toContain("--reset");
     expect(stdout).toContain("--schema-only");
     expect(stdout).toContain("--functions-only");
+    // --reset was removed in v0.8.1 — it lives only in scripts/db_deploy.ts now.
+    expect(stdout).not.toContain("--reset");
   });
 
   test("--schema-only --dry-run runs pre-flight + plan without deploying", () => {

--- a/packages/memory/test/cli-smoke.test.ts
+++ b/packages/memory/test/cli-smoke.test.ts
@@ -70,6 +70,7 @@ describe("cerefox CLI smoke (built bin)", () => {
       "ingest",
       "ingest-dir",
       "delete-doc",
+      "delete-project",
       // Servers
       "mcp",
       "web",
@@ -154,5 +155,13 @@ describe("cerefox CLI smoke (built bin)", () => {
     expect(stdout).toContain("--batch");
     expect(stdout).toContain("--dry-run");
     expect(stdout).toContain("--document-id");
+  });
+
+  test("`cerefox delete-project --help` advertises name-or-id + safety flags", () => {
+    const { stdout, status } = run(["delete-project", "--help"]);
+    expect(status).toBe(0);
+    expect(stdout).toContain("name-or-id");
+    expect(stdout).toContain("--yes");
+    expect(stdout).toContain("--force");
   });
 });

--- a/packages/memory/test/edge-functions/edge-functions.test.ts
+++ b/packages/memory/test/edge-functions/edge-functions.test.ts
@@ -379,16 +379,18 @@ describe("Edge Functions (live HTTP)", () => {
 
     test("document_id + update_if_exists=false still updates + returns a note", async () => {
       const title = uniqueTitle("ID Note");
+      // uniqueContent() (not fixed strings) so the global content_hash
+      // uniqueness constraint isn't tripped by leftovers from a prior run.
       const r1 = await invokeOk("cerefox-ingest", {
         title,
-        content: "# ID Note\n\nOriginal.",
+        content: uniqueContent(),
         author: "e2e-ef-test",
         author_type: "agent",
       });
       track(r1.document_id);
       const r2 = await invokeOk("cerefox-ingest", {
         title,
-        content: "# ID Note\n\nModified.",
+        content: uniqueContent(),
         document_id: r1.document_id,
         update_if_exists: false,
         author: "e2e-ef-test",

--- a/packages/memory/test/lifecycle-commands.test.ts
+++ b/packages/memory/test/lifecycle-commands.test.ts
@@ -320,11 +320,11 @@ describe("doctor / status (live)", () => {
     expect(status).toBe(0);
     const parsed = JSON.parse(stdout) as Array<{ name: string; status: string }>;
     expect(Array.isArray(parsed)).toBe(true);
-    // We expect at least binary, runtime, version, config, supabase, openai, schema.
+    // We expect at least binary, runtime, version, config, supabase, openai, schema + RPCs.
     const names = parsed.map((c) => c.name);
     expect(names).toContain("binary");
     expect(names).toContain("supabase");
-    expect(names).toContain("schema");
+    expect(names).toContain("schema + RPCs");
   });
 
   test("status --json returns a 3-element array", () => {

--- a/packages/memory/test/web-integration/meta.test.ts
+++ b/packages/memory/test/web-integration/meta.test.ts
@@ -116,7 +116,12 @@ describe("meta endpoints (HTTP boundary)", () => {
     const resp = await fetch(`${server.base}/api/v1/schema-version`);
     expect(resp.status).toBe(200);
     const body = await resp.json();
-    expect(Object.keys(body).sort()).toEqual(["bundled", "deployed", "mismatch"]);
+    // Core mismatch-banner contract: bundled / deployed / mismatch. iter-26C
+    // added compatibility classification fields (level, min) — assert the core
+    // keys are present rather than an exact set so the endpoint can grow.
+    for (const key of ["bundled", "deployed", "mismatch"]) {
+      expect(Object.keys(body)).toContain(key);
+    }
     expect(typeof body.mismatch).toBe("boolean");
     // bundled / deployed may be null if the schema.sql @version marker is
     // missing or the RPC isn't deployed; we don't assert specific values

--- a/packages/memory/test/write-commands.test.ts
+++ b/packages/memory/test/write-commands.test.ts
@@ -104,6 +104,10 @@ describe("cerefox write commands (live)", () => {
 
   afterAll(async () => {
     await hardPurgeE2eDocs();
+    // hardPurgeE2eDocs only removes documents; reap the `_e2e-v0.5` project
+    // row too so it doesn't leak across runs. `--force` deletes even if a
+    // doc link lingers (the project row goes; doc rows stay).
+    run(["delete-project", "_e2e-v0.5", "--yes", "--force"]);
   });
 
   test("ingest --paste: title required", () => {

--- a/scripts/db_migrate.ts
+++ b/scripts/db_migrate.ts
@@ -2,26 +2,25 @@
 /**
  * Apply pending database migrations to an existing Cerefox instance.
  *
- * Migration files live in src/cerefox/db/migrations/ and are named
- * with a numeric prefix (e.g. 0003_add_versions.sql). Applied in
- * filename order. Each file is applied exactly once; applied
- * filenames are recorded in `cerefox_migrations` so they're never
- * re-applied.
+ * Migration files live in src/cerefox/db/migrations/ and are named with a
+ * numeric prefix (e.g. 0003_add_versions.sql). Applied in filename order;
+ * each exactly once, recorded in `cerefox_migrations`.
  *
  * Usage:
  *   bun scripts/db_migrate.ts              # apply all pending migrations
  *   bun scripts/db_migrate.ts --dry-run    # show what would run
  *   bun scripts/db_migrate.ts --status     # list status, exit
+ *   bun scripts/db_migrate.ts --assets-dir <path>
  *
- * TS port of `scripts/db_migrate.py` (iter-25 Part 25H).
+ * Low-level contributor script. End users get the same effect (and more)
+ * from `cerefox deploy-server`, which runs pending migrations on existing
+ * databases. The migrate logic lives in `_shared/db-deploy/`
+ * (`runDbMigrate` / `migrationStatus`); this script is a thin wrapper.
  */
-
-import { existsSync, readFileSync, readdirSync } from "node:fs";
-import { join } from "node:path";
-import postgres from "postgres";
 
 import { loadEnv } from "../_shared/config/index.js";
 import { resolveServerAssets } from "../_shared/server-assets/index.js";
+import { migrationStatus, runDbMigrate } from "../_shared/db-deploy/index.js";
 import {
   EXIT_OK,
   EXIT_USER_ERROR,
@@ -32,14 +31,6 @@ import {
 } from "../_shared/cli-core/index.js";
 
 loadEnv();
-
-const BOOTSTRAP_SQL = `
-CREATE TABLE IF NOT EXISTS cerefox_migrations (
-    id         SERIAL      PRIMARY KEY,
-    filename   TEXT        NOT NULL UNIQUE,
-    applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);
-`;
 
 interface Args {
   dryRun: boolean;
@@ -71,13 +62,6 @@ function parseArgs(argv: string[]): Args {
   return out;
 }
 
-function listMigrationFiles(migrationsDir: string): string[] {
-  if (!existsSync(migrationsDir)) return [];
-  return readdirSync(migrationsDir)
-    .filter((n) => n.endsWith(".sql"))
-    .sort();
-}
-
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
   const dbUrl = process.env.CEREFOX_DATABASE_URL ?? "";
@@ -89,90 +73,51 @@ async function main(): Promise<void> {
   }
 
   const assets = resolveServerAssets({ assetsDir: args.assetsDir });
-  const migrationsDir = assets.migrationsDir;
 
   println(c.bold("╔══════════════════════════════════════╗"));
   println(c.bold("║  Cerefox DB Migrate                  ║"));
   println(c.bold("╚══════════════════════════════════════╝"));
 
-  const sql = postgres(dbUrl, { prepare: false, onnotice: () => {} });
-
-  // Bootstrap: ensure tracking table exists.
-  await sql.unsafe(BOOTSTRAP_SQL);
-
-  const allFiles = listMigrationFiles(migrationsDir);
-  const appliedRows = await sql<
-    { filename: string }[]
-  >`SELECT filename FROM cerefox_migrations ORDER BY filename`;
-  const applied = new Set(appliedRows.map((r) => r.filename));
-
   if (args.status) {
-    if (allFiles.length === 0) {
+    const status = await migrationStatus({ dbUrl, assets });
+    if (status.all.length === 0) {
       println("No migration files found.");
-      await sql.end({ timeout: 5 });
-      return;
+      process.exit(EXIT_OK);
     }
     println(`\n${"Filename".padEnd(50)}  Status`);
     println("─".repeat(60));
-    for (const f of allFiles) {
-      const status = applied.has(f) ? c.green("✓  applied") : c.yellow("○  pending");
-      println(`  ${f.padEnd(50)}  ${status}`);
+    const appliedSet = new Set(status.applied);
+    for (const f of status.all) {
+      const label = appliedSet.has(f) ? c.green("✓  applied") : c.yellow("○  pending");
+      println(`  ${f.padEnd(50)}  ${label}`);
     }
-    const pendingCount = allFiles.filter((f) => !applied.has(f)).length;
     println(
-      `\n${allFiles.length} total  |  ${allFiles.length - pendingCount} applied  |  ${pendingCount} pending`,
+      `\n${status.all.length} total  |  ${status.applied.length} applied  |  ${status.pending.length} pending`,
     );
-    await sql.end({ timeout: 5 });
-    return;
+    process.exit(EXIT_OK);
   }
 
-  const pending = allFiles.filter((f) => !applied.has(f));
-  if (pending.length === 0) {
+  const result = await runDbMigrate({
+    dbUrl,
+    assets,
+    dryRun: args.dryRun,
+    log: (line) => println(c.bold(`▶  ${line}`)),
+  });
+
+  if (!result.ok) {
+    errorln(`\n❌  ${result.failedFile} failed: ${result.error}`);
+    errorln("\nMigration stopped. Previous migrations in this run were committed.");
+    errorln("Fix the error in the migration file and re-run.");
+    process.exit(EXIT_SYSTEM_ERROR);
+  }
+
+  if (result.pending.length === 0) {
     println(c.green("\n✓  No pending migrations — database is up to date."));
-    await sql.end({ timeout: 5 });
-    return;
+  } else if (args.dryRun) {
+    println(c.yellow(`\n⚠️  Dry-run — ${result.pending.length} migration(s) would be applied.`));
+  } else {
+    println(c.green(`\n✓  Applied ${result.applied.length} migration(s) successfully.`));
   }
-
-  println(`\n${pending.length} pending migration(s):`);
-  for (const f of pending) println(`  • ${f}`);
-
-  if (args.dryRun) {
-    println(c.yellow("\n⚠️  Dry-run mode — no changes will be made."));
-    for (const f of pending) {
-      const body = readFileSync(join(migrationsDir, f), "utf8");
-      println(`\n── ${f} ──`);
-      println(c.dim(body.slice(0, 600) + (body.length > 600 ? "..." : "")));
-    }
-    await sql.end({ timeout: 5 });
-    return;
-  }
-
-  println("");
-  let appliedCount = 0;
-  for (const f of pending) {
-    const body = readFileSync(join(migrationsDir, f), "utf8");
-    println(c.bold(`▶  Applying ${f}…`));
-    try {
-      // Each migration runs in its own implicit transaction via
-      // `sql.begin`. Insert the tracking row in the SAME transaction so
-      // an error rolls both back.
-      await sql.begin(async (tx) => {
-        await tx.unsafe(body);
-        await tx`INSERT INTO cerefox_migrations (filename) VALUES (${f}) ON CONFLICT DO NOTHING`;
-      });
-      println(c.green("   ✓  Done"));
-      appliedCount++;
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      errorln(`\n❌  ${f} failed: ${msg}`);
-      errorln("\nMigration stopped. Previous migrations in this run were committed.");
-      errorln("Fix the error in the migration file and re-run db_migrate.ts.");
-      await sql.end({ timeout: 5 });
-      process.exit(EXIT_SYSTEM_ERROR);
-    }
-  }
-  println(c.green(`\n✓  Applied ${appliedCount} migration(s) successfully.`));
-  await sql.end({ timeout: 5 });
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary

Fixes a gap found right after v0.8.0 published: `cerefox deploy-server` only ever did a **fresh** deploy (apply schema + RPCs, then *stamp* every migration as already-applied). Run against a database that already had a Cerefox schema, it silently re-stamped pending migrations without running them — so a release shipping a new migration or changed RPCs was never actually deployed by re-running the catch-all command.

- **`deploy-server` detects fresh vs. existing databases.** Fresh → unchanged (schema + RPCs + stamp migrations). Existing → apply *pending* migrations (each in its own transaction) + re-apply `rpcs.sql` to refresh RPCs — an in-place update. Dry-run plan shows the chosen path and lists pending migrations.
- **Removed `--reset`** from the user-facing command (footgun; weaker guard than the script). It stays in the low-level `bun scripts/db_deploy.ts --reset` (repo clone, typed-`yes` guard). `cerefox init`'s below-min-schema path now runs plain `deploy-server` (in-place update) instead of `--reset`.
- **`doctor`**: relabel `schema` → `schema + RPCs`; classify the deployed schema/RPC version against the required minimum (error) and bundled version (warn); print a single consolidated remediation line — full `deploy-server` when both schema + EFs are stale, else the matching `--schema-only`/`--functions-only`.
- **Internal**: extracted `runDbMigrate` / `migrationStatus` / `detectExistingSchema` / `applyRpcs` into `_shared/db-deploy/` so `deploy-server` and `scripts/db_migrate.ts` share one implementation. `db_migrate.ts` is now a thin wrapper (adds `--status`).

Docs: CHANGELOG `[Unreleased]`, RELEASING.md + CLAUDE.md note deploy-server as the migration-aware catch-all, plan.md iter-26.1 section. Also queued a v0.9.0 doc-overhaul item (two install paths: end-user CLI vs contributor repo-clone).

> **Cut is deliberately deferred.** The existing-DB migration path is validated live during the upcoming clone-env walk (a fresh side-by-side Supabase account) before tagging/publishing v0.8.1.

## Test plan

- [x] `_shared` suite green (177 pass)
- [x] Full `@cerefox/memory` suite green (153 pass)
- [x] `deploy-server --help` no longer advertises `--reset`; `--reset` test inverted
- [x] `deploy-server --schema-only --dry-run` against the live existing DB reports "apply 0 pending migration(s) + refresh RPCs"
- [x] `db_migrate.ts --status` lists 9/9 applied live
- [x] `doctor` renders "schema + RPCs" with bundled version; footer suppressed when all OK
- [ ] **Clone-env walk**: validate existing-DB migration apply + RPC refresh end-to-end on a fresh side-by-side Supabase project (gates the cut)

🤖 Generated with [Claude Code](https://claude.com/claude-code)