### PR TITLE
0.8.2 fixes: deploy-server EF deploy (no link needed) + doctor EF baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,14 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
-Open roadmap.
+### Fixed
+
+- `cerefox doctor` no longer warns that the Edge Functions are "older than this
+  client" right after a fresh redeploy. The EF version check baselined the
+  deployed EF version against the npm package version (`PKG_VERSION`) instead of
+  the version of the Edge Functions the package actually bundles (`EF_VERSION`).
+  Because a client-only release bumps `PKG_VERSION` without changing the EFs,
+  doctor flagged up-to-date EFs as stale. Now baselined against `EF_VERSION`.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ### Fixed
 
+- **`cerefox deploy-server` Edge Function deploy now works without a
+  per-directory `supabase link`.** Two bugs: (1) the pre-flight detected
+  linkage by looking for `supabase/config.toml` (the `supabase init` marker),
+  so a correctly-linked project with no `config.toml` was reported as "not
+  linked"; (2) the actual `supabase functions deploy` ran from the
+  bundled-assets directory, which has no link state, so it couldn't resolve the
+  target project even when the pre-flight passed. Now the project ref is derived
+  from `CEREFOX_SUPABASE_URL` (override with `--project-ref <ref>`) and passed
+  explicitly to `supabase functions deploy`, making the deploy
+  directory-independent. The pre-flight checks that a ref is resolvable instead
+  of looking for `config.toml`; `supabase login` (a global token) is all that's
+  required.
 - `cerefox doctor` no longer warns that the Edge Functions are "older than this
   client" right after a fresh redeploy. The EF version check baselined the
   deployed EF version against the npm package version (`PKG_VERSION`) instead of

--- a/packages/memory/src/cli/commands/deploy-server.ts
+++ b/packages/memory/src/cli/commands/deploy-server.ts
@@ -19,8 +19,9 @@
  * Comprehensive pre-flight: every external prerequisite is probed up-front
  * and reported as a single all-or-nothing remediation list. Idempotent.
  *
- * Flags: --dry-run (plan only, no prompt), --schema-only, --functions-only.
- * There is deliberately NO --reset (drop-everything) here — a full wipe is a
+ * Flags: --dry-run (plan only, no prompt), --schema-only, --functions-only,
+ * --project-ref (override the ref derived from CEREFOX_SUPABASE_URL for EF
+ * deploys). There is deliberately NO --reset (drop-everything) here — a full wipe is a
  * contributor/recovery operation; use `bun scripts/db_deploy.ts --reset`
  * (repo clone, typed-`yes` guard) if you truly need it.
  */
@@ -51,6 +52,7 @@ interface DeployServerOptions {
   dryRun?: boolean;
   schemaOnly?: boolean;
   functionsOnly?: boolean;
+  projectRef?: string;
 }
 
 /** One pre-flight check + its remediation when failed. */
@@ -66,6 +68,28 @@ function commandSucceeds(cmd: string, args: string[]): boolean {
     return r.status === 0;
   } catch {
     return false;
+  }
+}
+
+/**
+ * Derive the Supabase project ref from CEREFOX_SUPABASE_URL
+ * (`https://<ref>.supabase.co` → `<ref>`). Refs are 20 lowercase
+ * alphanumerics. Returns null for custom domains / unparseable URLs — the
+ * caller then relies on the explicit `--project-ref` flag.
+ *
+ * We pass `--project-ref` to `supabase functions deploy` so the deploy works
+ * from the bundled-assets directory without a per-directory `supabase link`
+ * (link state lives in `supabase/.temp/` of whatever dir you linked, which is
+ * NOT the bundled-assets dir the CLI runs in).
+ */
+function parseProjectRef(supabaseUrl: string | undefined): string | null {
+  if (!supabaseUrl) return null;
+  try {
+    const host = new URL(supabaseUrl).hostname; // e.g. ljdz….supabase.co
+    const label = host.split(".")[0];
+    return /^[a-z0-9]{20}$/.test(label) ? label : null;
+  } catch {
+    return null;
   }
 }
 
@@ -86,6 +110,10 @@ async function action(options: DeployServerOptions): Promise<void> {
 
   const doSchema = !options.functionsOnly;
   const doFunctions = !options.schemaOnly;
+
+  // Project ref for `supabase functions deploy --project-ref` (see
+  // parseProjectRef). Explicit flag wins; otherwise derive from the URL.
+  const projectRef = options.projectRef ?? parseProjectRef(settings.supabaseUrl);
 
   // ── Pre-flight ────────────────────────────────────────────────────────────
   const checks: Preflight[] = [];
@@ -125,18 +153,19 @@ async function action(options: DeployServerOptions): Promise<void> {
         "Install Node 20+ (npx ships with it) from nodejs.org, then re-run. " +
         "`cerefox deploy-server` shells out to the Supabase CLI via npx.",
     });
-    // Linkage: a linked project writes supabase/config.toml in cwd. We can't
-    // see the user's cwd reliably from a global install, so we surface the
-    // requirement rather than hard-fail when we can't detect it.
+    // Project ref: we pass it explicitly to `functions deploy`, so we DON'T
+    // need a per-directory `supabase link` (that state lives in the dir you
+    // linked, not the bundled-assets dir the CLI runs in). We do need a
+    // resolvable ref + a logged-in CLI; login is global, so we just remind
+    // about it here and let the deploy surface a clear error if it's missing.
     checks.push({
-      label: "Supabase project linked (`npx supabase link`)",
-      ok: existsSync("supabase/config.toml") || existsSync(".supabase/config.toml"),
+      label: "Supabase project ref resolved (from CEREFOX_SUPABASE_URL)",
+      ok: Boolean(projectRef),
       remediation:
-        "Authenticate + link your project (one-time, from any working dir):\n" +
-        "      npx supabase login\n" +
-        "      npx supabase link --project-ref <your-project-ref>\n" +
-        "    Your project ref is in the dashboard URL: " +
-        "https://supabase.com/dashboard/project/<project-ref>",
+        "Could not derive the project ref from CEREFOX_SUPABASE_URL.\n" +
+        "    Set CEREFOX_SUPABASE_URL to your project URL " +
+        "(https://<project-ref>.supabase.co), or pass --project-ref <ref>.\n" +
+        "    Also make sure you're logged in once: npx supabase login",
     });
   }
 
@@ -192,7 +221,9 @@ async function action(options: DeployServerOptions): Promise<void> {
     }
   }
   if (doFunctions) {
-    planLines.push(`  • Deploy ${efNames.length} Edge Function(s): ${efNames.join(", ")}`);
+    planLines.push(
+      `  • Deploy ${efNames.length} Edge Function(s) to project ${projectRef}: ${efNames.join(", ")}`,
+    );
   }
 
   println(c.bold("\nPlan:"));
@@ -262,8 +293,13 @@ async function action(options: DeployServerOptions): Promise<void> {
       info(`   deploying ${ef}…`);
       // Run with cwd = the assets root's supabase parent so the CLI finds
       // supabase/functions/<ef>. functionsDir is <root>/supabase/functions.
+      // Pass --project-ref explicitly: the bundled-assets dir is not linked
+      // (link state lives in whatever dir the user ran `supabase link`), so a
+      // bare deploy here couldn't resolve the target project.
       const workdir = assets.functionsDir.replace(/\/functions$/, "").replace(/\/supabase$/, "");
-      const r = spawnSync("npx", ["--yes", "supabase", "functions", "deploy", ef], {
+      const args = ["--yes", "supabase", "functions", "deploy", ef];
+      if (projectRef) args.push("--project-ref", projectRef);
+      const r = spawnSync("npx", args, {
         encoding: "utf8",
         stdio: "inherit",
         cwd: workdir,
@@ -291,5 +327,9 @@ export function registerDeployServer(program: Command): void {
     .option("--dry-run", "Print the plan + pre-flight without deploying.")
     .option("--schema-only", "Deploy/update only the schema + RPCs (skip Edge Functions).")
     .option("--functions-only", "Deploy only the Edge Functions (skip the schema/RPCs).")
+    .option(
+      "--project-ref <ref>",
+      "Supabase project ref for Edge Function deploys (default: derived from CEREFOX_SUPABASE_URL).",
+    )
     .action(action);
 }

--- a/packages/memory/src/cli/util/checks.ts
+++ b/packages/memory/src/cli/util/checks.ts
@@ -17,6 +17,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 
 import { PKG_VERSION } from "../../meta.ts";
+import { EF_VERSION } from "../../../../../_shared/ef-meta/index.ts";
 import { loadSettings } from "../../../../../_shared/config/index.ts";
 import {
   resolveConfigDir,
@@ -484,7 +485,11 @@ export async function checkEdgeFunctionsCompat(): Promise<CheckResult> {
     compat = await checkServerCompatibility({
       aggregatorUrl: aggregatorUrlFor(settings.supabaseUrl),
       bearer: settings.supabaseAnonKey,
-      bundledEf: PKG_VERSION,
+      // Baseline against the EF version this package *bundles* (EF_VERSION),
+      // not the npm package version (PKG_VERSION). A client-only release bumps
+      // PKG_VERSION without changing the EFs, so using PKG_VERSION here made
+      // doctor warn "EFs older than client" even right after a fresh redeploy.
+      bundledEf: EF_VERSION,
     });
   } catch (err) {
     return {
@@ -515,7 +520,7 @@ export async function checkEdgeFunctionsCompat(): Promise<CheckResult> {
       return {
         name: "edge functions",
         status: "warn",
-        detail: `Deployed EF v${deployed} works but is older than this client (v${PKG_VERSION}).`,
+        detail: `Deployed EF v${deployed} works but is older than the bundled Edge Functions (v${EF_VERSION}).`,
         hint: "Update the Edge Functions (see remediation below).",
       };
     default:

--- a/packages/memory/src/web/server.ts
+++ b/packages/memory/src/web/server.ts
@@ -47,6 +47,7 @@ import {
   resolveStaticDir,
 } from "./static.ts";
 import { PKG_VERSION } from "../meta.ts";
+import { EF_VERSION } from "../../../../_shared/ef-meta/index.ts";
 import { localTimestamp } from "../../../../_shared/cli-core/index.ts";
 import { loadSettings } from "../../../../_shared/config/index.ts";
 import {
@@ -176,7 +177,10 @@ async function assertServerCompatible(): Promise<void> {
     compat = await checkServerCompatibility({
       aggregatorUrl: aggregatorUrlFor(settings.supabaseUrl),
       bearer: settings.supabaseAnonKey,
-      bundledEf: PKG_VERSION,
+      // EF version this package bundles, not the npm package version — see the
+      // note in checks.ts. (Web boot only refuses on `below-min`, which uses
+      // `min`, so this is for correctness/consistency rather than behavior.)
+      bundledEf: EF_VERSION,
     });
   } catch {
     return; // probe failure → tolerant boot

--- a/packages/memory/test/cli-deploy-server.test.ts
+++ b/packages/memory/test/cli-deploy-server.test.ts
@@ -44,6 +44,8 @@ describe("cerefox deploy-server CLI", () => {
     expect(stdout).toContain("--dry-run");
     expect(stdout).toContain("--schema-only");
     expect(stdout).toContain("--functions-only");
+    // v0.8.2: --project-ref overrides the ref derived from CEREFOX_SUPABASE_URL.
+    expect(stdout).toContain("--project-ref");
     // --reset was removed in v0.8.1 — it lives only in scripts/db_deploy.ts now.
     expect(stdout).not.toContain("--reset");
   });


### PR DESCRIPTION
Two `0.8.x` fixes bundled for a **v0.8.2** release. Both surfaced during the live v0.8.1 install walk.

## 1. `deploy-server` Edge Function deploy works without a per-directory `supabase link`

Found via `cerefox deploy-server --dry-run` after a successful `supabase link`: the pre-flight still said "not linked." Two bugs:

1. **Pre-flight checked the wrong file.** It detected linkage via `supabase/config.toml` — the `supabase init` marker — not the link marker. `supabase link` writes link state to `supabase/.temp/` (project-ref, linked-project.json) and does **not** create `config.toml`. So a correctly-linked project with no `config.toml` was reported "not linked."
2. **The deploy couldn't resolve the project anyway.** `supabase functions deploy` runs with `cwd` = the **bundled-assets** dir, which has no link state — so even past the pre-flight it couldn't tell which project to deploy to (link state is per-directory).

**Fix:** derive the project ref from `CEREFOX_SUPABASE_URL` (`https://<ref>.supabase.co`), override with `--project-ref <ref>`, and pass it explicitly to `supabase functions deploy`. The deploy is now directory-independent; only a global `supabase login` is required. Pre-flight now checks that a ref is resolvable.

## 2. `doctor` EF version check baselines against `EF_VERSION`, not `PKG_VERSION`

A client-only release (v0.8.1) bumps `PKG_VERSION` without changing the EFs, so doctor classified up-to-date EFs as `above-min-but-old` and nagged to redeploy — even right after a fresh `--functions-only`. Now baselined against the bundled `EF_VERSION` → green when deployed == bundled.

## Test plan

- [x] Full package suite green (154), `_shared` green (177), build clean
- [x] `deploy-server --functions-only --dry-run` resolves the ref + plans the deploy (no `config.toml`/link check); `--project-ref` override works; unparseable URL fails with clear remediation
- [x] `--help` advertises `--project-ref`; `--reset` still absent
- [ ] **Live (post-merge, v0.8.2 install):** `cerefox deploy-server --functions-only` deploys all 9 EFs to the project, then `cerefox doctor` shows the Edge Functions row **green**

🤖 Generated with [Claude Code](https://claude.com/claude-code)