### PR TITLE
0.8.3 polish: install.sh @latest, EF-test gating, Docker-warning doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,22 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
   forces bun/npm to re-resolve and upgrade. (Served from each GitHub release,
   so this takes effect for installs of the release *after* it ships.)
 
+### Changed
+
+- **Live Edge Function / remote-MCP test suites are now opt-in.** The TS suites
+  in `packages/memory/test/edge-functions/` and `.../mcp-remote/` make real
+  Edge Function calls; they're gated behind `CEREFOX_LIVE_E2E=1` (checked
+  before the reachability probe), so a default `bun test` makes zero EF calls
+  and doesn't consume free-tier quota. The suites also tag their calls with
+  `requestor: "e2e-test"` so usage-log rows are attributable instead of
+  appearing as "Unknown" in the Analytics view.
+
+### Docs
+
+- `setup-supabase.md`: noted that `WARNING: Docker is not running` during Edge
+  Function deploy is expected and harmless (the CLI bundles server-side);
+  Docker is not a prerequisite.
+
 ---
 
 ## [v0.8.2] -- 2026-05-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,14 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
-Open roadmap.
+### Fixed
+
+- The one-line install script now pins the `latest` dist-tag instead of
+  installing `@cerefox/memory` unversioned. A bare `bun install -g
+  @cerefox/memory` treats an already-installed global as satisfied and skips
+  the upgrade, so re-running the installer kept the old version; `@latest`
+  forces bun/npm to re-resolve and upgrade. (Served from each GitHub release,
+  so this takes effect for installs of the release *after* it ships.)
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,18 @@ cerefox/
 | API e2e | `uv run pytest -m e2e` | Hits live Supabase (REST API + Edge Functions) |
 | UI e2e | `uv run pytest -m ui` | Playwright browser tests against local web app |
 | All Python e2e | `uv run pytest -m "e2e or ui"` | Both API and UI e2e |
+| Live EF e2e (TS) | `CEREFOX_LIVE_E2E=1 bun test test/edge-functions/edge-functions.test.ts` | Hits the deployed primitive Edge Functions. **Opt-in** — skipped by default. |
+| Live remote-MCP e2e (TS) | `CEREFOX_LIVE_E2E=1 bun test test/mcp-remote/mcp-remote.test.ts` | Hits the deployed `cerefox-mcp` EF over JSON-RPC. **Opt-in** — skipped by default. |
+
+> **Conserve free-tier Edge Function quota.** The two live TS suites
+> (`packages/memory/test/edge-functions/`, `.../mcp-remote/`) make real Edge
+> Function calls and are **gated behind `CEREFOX_LIVE_E2E=1`** (checked before
+> the reachability probe, so a default `bun test` makes ZERO EF calls). Run
+> them only when changing EF code (`supabase/functions/**`,
+> `_shared/{mcp-tools,embeddings,ef-meta}`) or for pre-release validation — and
+> prefer the narrowest file. They tag their calls with `requestor: "e2e-test"`
+> so usage-log rows are attributable (not "Unknown"). `cerefox doctor` also
+> calls the `/version?peers=true` aggregator (several EF calls), so don't loop it.
 
 - **API e2e** (`tests/e2e/test_api_e2e.py`): Uses credentials from `.env`. Edge Function tests need `CEREFOX_SUPABASE_ANON_KEY` (JWT). Cleans up `[E2E]`-prefixed test data automatically.
 - **UI e2e** (`tests/e2e/test_ui_e2e.py`): Requires web app running at `http://127.0.0.1:8000/`. Uses Playwright + Chromium. Install browsers: `uv run playwright install chromium`.

--- a/docs/guides/setup-supabase.md
+++ b/docs/guides/setup-supabase.md
@@ -221,9 +221,17 @@ Deployed Functions on project <your-project-ref>: cerefox-ingest
 You can verify in the Supabase Dashboard → **Edge Functions** — all three functions should
 appear with a green "Active" status.
 
+> **`WARNING: Docker is not running` is expected and harmless.** The Supabase CLI checks for
+> Docker (its older local bundler ran in a container) but falls back to bundling the functions
+> server-side — it uploads the source assets (you'll see `Uploading asset (…)` lines) and
+> Supabase compiles them in the cloud. **Docker is not a prerequisite for deploying Cerefox's
+> Edge Functions.** A deploy succeeded as long as each function ends with
+> `Deployed Functions on project …`. This applies to both the manual commands here and
+> `cerefox deploy-server --functions-only`.
+
 > **Re-deploying after updates**: run the same `npx supabase functions deploy` commands
-> again from the project root. `npx supabase login` and `npx supabase link` only need to be
-> run once per machine.
+> again from the project root, or just `cerefox deploy-server --functions-only` (it deploys
+> all 9 from the bundled assets). `npx supabase login` only needs to be run once per machine.
 
 ---
 

--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,12 @@
 set -eu
 
 PACKAGE="@cerefox/memory"
-VERSION_HINT=""
+# Default to the `latest` dist-tag (not a bare name). A bare
+# `bun install -g @cerefox/memory` treats an already-installed global as
+# satisfied and skips the upgrade, so a re-install kept the old version;
+# pinning `@latest` forces bun/npm to re-resolve and upgrade. Overridden by
+# the VERSION env below.
+VERSION_HINT="@latest"
 
 # Allow opting into a specific version via env: VERSION=0.5.0-rc.1 sh install.sh
 if [ -n "${VERSION:-}" ]; then

--- a/packages/memory/test/edge-functions/edge-functions.test.ts
+++ b/packages/memory/test/edge-functions/edge-functions.test.ts
@@ -68,7 +68,11 @@ async function invoke(fn: string, body: Record<string, unknown> = {}): Promise<I
       apikey: anonKey,
       "Content-Type": "application/json",
     },
-    body: JSON.stringify(body),
+    // Tag every call with a `requestor` so usage-log rows from the test suite
+    // are attributable to "e2e-test" rather than NULL → "Unknown" in the
+    // Analytics word cloud. The primitive EFs log `body.requestor ?? null`.
+    // Individual bodies can still override it.
+    body: JSON.stringify({ requestor: "e2e-test", ...body }),
   });
   let parsed: unknown = null;
   try {
@@ -88,10 +92,18 @@ async function invokeOk(fn: string, body: Record<string, unknown> = {}): Promise
   return r.body;
 }
 
-// Probe reachability once. The deployed EFs answer POST; a network/credential
-// failure or missing anon key skips the whole suite.
+// Opt-in gate: these tests make real Edge Function invocations, which count
+// against the (low) Supabase free-tier quota. They're SKIPPED unless
+// CEREFOX_LIVE_E2E=1, and the env var is checked BEFORE the reachability
+// probe so a default `bun test` makes ZERO Edge Function calls. Run them only
+// when changing EF code or for pre-release validation:
+//   CEREFOX_LIVE_E2E=1 bun test test/edge-functions/edge-functions.test.ts
+const E2E_ENABLED = process.env.CEREFOX_LIVE_E2E === "1";
+
+// Probe reachability once (only when enabled). The deployed EFs answer POST; a
+// network/credential failure or missing anon key skips the whole suite.
 let LIVE_OK = false;
-if (anonKey && efBase) {
+if (E2E_ENABLED && anonKey && efBase) {
   try {
     const probe = await invoke("cerefox-metadata", {});
     LIVE_OK = probe.status >= 200 && probe.status < 500;
@@ -106,6 +118,10 @@ function track(id: unknown): void {
 }
 
 describe("Edge Functions (live HTTP)", () => {
+  if (!E2E_ENABLED) {
+    test.skip("opt-in only — set CEREFOX_LIVE_E2E=1 to run (hits live EFs; consumes free-tier quota)", () => {});
+    return;
+  }
   if (!LIVE_OK) {
     test.skip("Supabase / anon JWT not available — skipping EF e2e", () => {});
     return;

--- a/packages/memory/test/mcp-remote/mcp-remote.test.ts
+++ b/packages/memory/test/mcp-remote/mcp-remote.test.ts
@@ -71,9 +71,15 @@ function extractId(text: string): string | null {
   return m ? m[1] : null;
 }
 
+// Opt-in gate: these tests hit the live cerefox-mcp Edge Function (free-tier
+// quota). Skipped unless CEREFOX_LIVE_E2E=1, checked BEFORE the probe so a
+// default `bun test` makes ZERO Edge Function calls. See the EF e2e suite for
+// the rationale; run both with the same flag.
+const E2E_ENABLED = process.env.CEREFOX_LIVE_E2E === "1";
+
 // Probe: a tools/list handshake confirms the EF is reachable.
 let LIVE_OK = false;
-if (anonKey && mcpUrl) {
+if (E2E_ENABLED && anonKey && mcpUrl) {
   try {
     const resp = await rpc("tools/list");
     LIVE_OK = !resp.error && Array.isArray(resp.result?.tools);
@@ -88,6 +94,10 @@ function track(id: unknown): void {
 }
 
 describe("cerefox-mcp remote (JSON-RPC over HTTP)", () => {
+  if (!E2E_ENABLED) {
+    test.skip("opt-in only — set CEREFOX_LIVE_E2E=1 to run (hits live EFs; consumes free-tier quota)", () => {});
+    return;
+  }
   if (!LIVE_OK) {
     test.skip("Supabase / anon JWT not available — skipping MCP-remote e2e", () => {});
     return;


### PR DESCRIPTION
Post-0.8.2 polish bundle for the next cut (**0.8.3**). All changes are client/test/docs — **no EF or RPC deployment required** to ship them.

## 1. install.sh pins `@latest`
`bun install -g @cerefox/memory` (unversioned) treats an already-installed global as satisfied and skips the upgrade — re-running the one-liner kept the old version (observed: stuck on 0.8.1 after 0.8.2 published). Default `VERSION_HINT="@latest"`; `VERSION=…` still overrides. (Served as a release asset → helps installs of the release *after* it ships.)

## 2. Live EF / remote-MCP test suites are now opt-in
They made real Edge Function calls on every `bun test` — burning free-tier quota and (because the primitive EFs log `requestor ?? null` and the tests set none) flooding the usage log with NULL → **"Unknown"** rows, which were the top "caller" in Analytics. Now:
- Gated behind `CEREFOX_LIVE_E2E=1`, checked **before** the reachability probe → a default `bun test` makes **zero** EF calls (and is faster: 109 pass / 2 skip).
- Calls tagged `requestor: "e2e-test"` so opt-in runs are attributable, not "Unknown".
- Documented in CLAUDE.md's test table.

## 3. setup-supabase.md — Docker-warning note
`WARNING: Docker is not running` during EF deploy is expected/harmless (the CLI bundles server-side). Docker is not a prerequisite.

## Notes
- The MCP **read** requestor default was investigated and found to **already** default to `"mcp-agent"` (`_utils.ts logUsage`), so no code change was needed there. The "Unknown" rows traced to the test execution above, not the MCP path or the (20+ days unused) Custom GPT.

## Test plan
- [x] `sh -n install.sh`; `VERSION_HINT` defaults to `@latest`, `VERSION` overrides
- [x] Default `bun test`: live suites skip (109 pass / 2 skip / 0 fail), zero EF calls
- [x] `CEREFOX_LIVE_E2E=1 bun test test/edge-functions/...`: 19 pass, calls tagged `e2e-test`
- [x] `_shared` suite green
- [ ] Post-release: re-running the one-liner over an older global upgrades to newest

🤖 Generated with [Claude Code](https://claude.com/claude-code)