### PR TITLE
Web UI redesign (v0.9.6)

### DIFF
--- a/_shared/schemas/discovery.ts
+++ b/_shared/schemas/discovery.ts
@@ -114,8 +114,10 @@ export type DashboardDoc = z.infer<typeof DashboardDoc>;
 
 export const DashboardResponse = z.object({
   doc_count: z.number().int(),
-  total_chunks: z.number().int(),
-  total_chars: z.number().int(),
+  // TS-only additions (the live route always sends them); default keeps the
+  // schema parsing older/Python-parity payloads that predate these fields.
+  total_chunks: z.number().int().default(0),
+  total_chars: z.number().int().default(0),
   project_count: z.number().int(),
   recent_docs: z.array(DashboardDoc),
   projects: z.array(ProjectResponse),

--- a/_shared/schemas/discovery.ts
+++ b/_shared/schemas/discovery.ts
@@ -107,6 +107,8 @@ export const DashboardDoc = z.object({
   review_status: z.string(),
   updated_at: z.string(),
   project_ids: z.array(z.string()).default([]),
+  author: z.string().nullable().default(null),
+  author_type: z.string().nullable().default(null),
 });
 export type DashboardDoc = z.infer<typeof DashboardDoc>;
 

--- a/_shared/schemas/discovery.ts
+++ b/_shared/schemas/discovery.ts
@@ -112,6 +112,8 @@ export type DashboardDoc = z.infer<typeof DashboardDoc>;
 
 export const DashboardResponse = z.object({
   doc_count: z.number().int(),
+  total_chunks: z.number().int(),
+  total_chars: z.number().int(),
   project_count: z.number().int(),
   recent_docs: z.array(DashboardDoc),
   projects: z.array(ProjectResponse),

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,16 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/app/cerefox_icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap"
+    />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&display=swap"
+    />
     <title>Cerefox</title>
   </head>
   <body>

--- a/frontend/src/api/preferences.ts
+++ b/frontend/src/api/preferences.ts
@@ -1,0 +1,18 @@
+import { apiFetch } from "./client";
+
+export type ThemePref = "auto" | "light" | "dark";
+
+export interface Preferences {
+  theme: ThemePref;
+}
+
+export async function fetchPreferences(): Promise<Preferences> {
+  return apiFetch<Preferences>("/preferences");
+}
+
+export async function savePreferences(prefs: Preferences): Promise<void> {
+  await apiFetch("/preferences", {
+    method: "PUT",
+    body: JSON.stringify(prefs),
+  });
+}

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -149,6 +149,9 @@ export interface DashboardDoc {
   review_status: string;
   updated_at: string | null;
   project_ids: string[];
+  /** Latest audit author (who last touched the doc); null until deployed/known. */
+  author?: string | null;
+  author_type?: string | null;
 }
 
 export interface DashboardResponse {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -153,6 +153,10 @@ export interface DashboardDoc {
 
 export interface DashboardResponse {
   doc_count: number;
+  /** Global count of current (non-archived) chunks across active documents. */
+  total_chunks: number;
+  /** Sum of total_chars across active (non-deleted) documents. */
+  total_chars: number;
   project_count: number;
   recent_docs: DashboardDoc[];
   projects: Project[];

--- a/frontend/src/components/CliHint.tsx
+++ b/frontend/src/components/CliHint.tsx
@@ -1,32 +1,37 @@
-import { IconCopy, IconTerminal2 } from "@tabler/icons-react";
+import { IconCopy } from "@tabler/icons-react";
 import { useNavigate } from "react-router-dom";
 
 import ui from "../styles/redesign.module.css";
 
 /**
- * Compact CLI-parity hint: shows the equivalent `cerefox` command for the
- * current page/query, copies it on click, and links to the CLI docs. Lighter
- * than the full CLI-mirror card — meant for page headers (top-right).
+ * Compact CLI-parity hint for page headers: a mini terminal snippet styled
+ * like the dashboard's CLI-mirror card ($ prompt in primary, args in green),
+ * that copies the command on click, plus a "cli docs" link. Lighter than the
+ * full CLI card.
  */
-export function CliHint({ command, docPath = "guides/cli.md" }: { command: string; docPath?: string }) {
+export function CliHint({
+  cmd,
+  args,
+  docPath = "guides/cli.md",
+}: {
+  cmd: string;
+  args?: string;
+  docPath?: string;
+}) {
   const navigate = useNavigate();
+  const full = args ? `${cmd} ${args}` : cmd;
   return (
     <span style={{ display: "inline-flex", alignItems: "center", gap: 8, flexWrap: "wrap", justifyContent: "flex-end" }}>
       <button
         type="button"
-        className={`${ui.btn} ${ui.btnSubtle}`}
-        style={{ fontSize: 12 }}
+        className={ui.cliHintBlock}
         title="Copy command to clipboard"
-        onClick={() => navigator.clipboard?.writeText(command)}
+        onClick={() => navigator.clipboard?.writeText(full)}
       >
-        <IconTerminal2 size={14} />
-        <span
-          className={ui.mono}
-          style={{ fontSize: 12, maxWidth: 360, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
-        >
-          {command}
-        </span>
-        <IconCopy size={13} />
+        <span style={{ color: "var(--primary)" }}>$</span>
+        <span>{cmd}</span>
+        {args && <span className={ui.cliHintArgs}>{args}</span>}
+        <IconCopy size={12} style={{ color: "var(--text-faint)", flexShrink: 0 }} />
       </button>
       <button type="button" className={ui.whatis} onClick={() => navigate(`/help/${docPath}`)}>
         cli docs

--- a/frontend/src/components/CliHint.tsx
+++ b/frontend/src/components/CliHint.tsx
@@ -1,0 +1,36 @@
+import { IconCopy, IconTerminal2 } from "@tabler/icons-react";
+import { useNavigate } from "react-router-dom";
+
+import ui from "../styles/redesign.module.css";
+
+/**
+ * Compact CLI-parity hint: shows the equivalent `cerefox` command for the
+ * current page/query, copies it on click, and links to the CLI docs. Lighter
+ * than the full CLI-mirror card — meant for page headers (top-right).
+ */
+export function CliHint({ command, docPath = "guides/cli.md" }: { command: string; docPath?: string }) {
+  const navigate = useNavigate();
+  return (
+    <span style={{ display: "inline-flex", alignItems: "center", gap: 8, flexWrap: "wrap", justifyContent: "flex-end" }}>
+      <button
+        type="button"
+        className={`${ui.btn} ${ui.btnSubtle}`}
+        style={{ fontSize: 12 }}
+        title="Copy command to clipboard"
+        onClick={() => navigator.clipboard?.writeText(command)}
+      >
+        <IconTerminal2 size={14} />
+        <span
+          className={ui.mono}
+          style={{ fontSize: 12, maxWidth: 360, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+        >
+          {command}
+        </span>
+        <IconCopy size={13} />
+      </button>
+      <button type="button" className={ui.whatis} onClick={() => navigate(`/help/${docPath}`)}>
+        cli docs
+      </button>
+    </span>
+  );
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -2,13 +2,13 @@ import {
   ActionIcon,
   AppShell,
   Group,
+  Menu,
   Text,
-  Title,
   UnstyledButton,
-  useMantineColorScheme,
 } from "@mantine/core";
-import { IconMoon, IconSun } from "@tabler/icons-react";
+import { IconCheck, IconDeviceDesktop, IconMoon, IconSun } from "@tabler/icons-react";
 import { Outlet, useLocation, useNavigate } from "react-router-dom";
+import { useThemePreference } from "../hooks/useThemePreference";
 import { SchemaVersionBanner } from "./SchemaVersionBanner";
 import { VersionFooter } from "./VersionFooter";
 
@@ -24,15 +24,22 @@ const NAV_ITEMS = [
   { label: "Help", path: "/help" },
 ];
 
+const THEME_OPTIONS = [
+  { value: "light", label: "Light", icon: IconSun },
+  { value: "dark", label: "Dark", icon: IconMoon },
+  { value: "auto", label: "System", icon: IconDeviceDesktop },
+] as const;
+
 export function Layout() {
   const navigate = useNavigate();
   const location = useLocation();
-  const { colorScheme, toggleColorScheme } = useMantineColorScheme();
-  const dark = colorScheme === "dark";
+  const { theme, setTheme } = useThemePreference();
+  const CurrentThemeIcon =
+    theme === "light" ? IconSun : theme === "dark" ? IconMoon : IconDeviceDesktop;
 
   return (
     <AppShell header={{ height: 56 }} padding="md">
-      <AppShell.Header>
+      <AppShell.Header style={{ position: "relative" }}>
         <Group h="100%" px="md" justify="space-between">
           <Group gap="sm">
             <img
@@ -42,21 +49,24 @@ export function Layout() {
               width={32}
               style={{ borderRadius: 4 }}
             />
-            <Title
-              order={4}
-              style={{ cursor: "pointer" }}
+            <Text
+              component="span"
               onClick={() => navigate("/")}
+              style={{
+                fontFamily: "var(--font-display)",
+                fontSize: 18,
+                fontWeight: 600,
+                letterSpacing: "-0.01em",
+                cursor: "pointer",
+              }}
             >
-              Cerefox
-            </Title>
+              Cere<span style={{ color: "var(--primary)" }}>fox</span>
+            </Text>
           </Group>
 
           <Group gap="lg">
             {NAV_ITEMS.map((item) => (
-              <UnstyledButton
-                key={item.label}
-                onClick={() => navigate(item.path)}
-              >
+              <UnstyledButton key={item.label} onClick={() => navigate(item.path)}>
                 <Text
                   size="sm"
                   fw={location.pathname === item.path ? 700 : 400}
@@ -66,16 +76,45 @@ export function Layout() {
                 </Text>
               </UnstyledButton>
             ))}
-            <ActionIcon
-              variant="subtle"
-              size="lg"
-              onClick={toggleColorScheme}
-              title={dark ? "Switch to light mode" : "Switch to dark mode"}
-            >
-              {dark ? <IconSun size={18} /> : <IconMoon size={18} />}
-            </ActionIcon>
+
+            <Menu position="bottom-end" withArrow shadow="md" width={150}>
+              <Menu.Target>
+                <ActionIcon variant="subtle" size="lg" title="Color theme" aria-label="Color theme">
+                  <CurrentThemeIcon size={18} />
+                </ActionIcon>
+              </Menu.Target>
+              <Menu.Dropdown>
+                <Menu.Label>Theme</Menu.Label>
+                {THEME_OPTIONS.map((opt) => {
+                  const OptIcon = opt.icon;
+                  return (
+                    <Menu.Item
+                      key={opt.value}
+                      leftSection={<OptIcon size={16} />}
+                      rightSection={theme === opt.value ? <IconCheck size={14} /> : null}
+                      onClick={() => setTheme(opt.value)}
+                    >
+                      {opt.label}
+                    </Menu.Item>
+                  );
+                })}
+              </Menu.Dropdown>
+            </Menu>
           </Group>
         </Group>
+
+        {/* 2px gradient accent line under the header */}
+        <div
+          style={{
+            position: "absolute",
+            left: 0,
+            right: 0,
+            bottom: 0,
+            height: 2,
+            background:
+              "linear-gradient(90deg, var(--primary), var(--violet) 60%, transparent)",
+          }}
+        />
       </AppShell.Header>
 
       <AppShell.Main>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -38,7 +38,7 @@ export function Layout() {
     theme === "light" ? IconSun : theme === "dark" ? IconMoon : IconDeviceDesktop;
 
   return (
-    <AppShell header={{ height: 56 }} padding="md">
+    <AppShell header={{ height: 56 }} padding="xs">
       <AppShell.Header style={{ position: "relative" }}>
         <Group h="100%" px="md" justify="space-between">
           <Group gap="sm">

--- a/frontend/src/components/ListPage.module.css
+++ b/frontend/src/components/ListPage.module.css
@@ -1,0 +1,140 @@
+/* Reusable list/table page — toolbar + styled table + pagination.
+   Shared primitives in styles/redesign.module.css; tokens in tokens.css. */
+
+.wrap {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 8px 24px 80px;
+}
+
+/* ---- toolbar ---- */
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+.search {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  height: 38px;
+  padding: 0 13px;
+  flex: 1;
+  min-width: 220px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  color: var(--text-faint);
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+.search:focus-within {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px var(--primary-soft);
+}
+.search input {
+  flex: 1;
+  min-width: 0;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  font-family: var(--font-ui);
+  font-size: 14px;
+  color: var(--text);
+}
+.search input::placeholder {
+  color: var(--text-faint);
+}
+.count {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-faint);
+  margin-left: 2px;
+  white-space: nowrap;
+}
+
+/* ---- table ---- */
+.tbl {
+  width: 100%;
+  border-collapse: collapse;
+}
+.tbl th {
+  text-align: left;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+  padding: 14px 14px 10px;
+  border-bottom: 1px solid var(--border-soft);
+}
+.tbl td {
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border-soft);
+  font-size: 13.5px;
+  vertical-align: middle;
+}
+.tbl tbody tr {
+  transition: background 0.12s;
+}
+.tbl tbody tr:hover {
+  background: var(--surface-2);
+}
+.tbl tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+/* ---- row actions (reveal on hover) ---- */
+.actions {
+  display: flex;
+  gap: 6px;
+  justify-content: flex-end;
+  opacity: 0;
+  transition: opacity 0.12s;
+}
+.tbl tbody tr:hover .actions {
+  opacity: 1;
+}
+
+/* ---- pagination foot ---- */
+.foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-top: 1px solid var(--border-soft);
+  background: var(--surface-2);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-dim);
+}
+.pgBtn {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 7px;
+  border: 1px solid var(--border-soft);
+  background: var(--surface);
+  color: var(--text-dim);
+  cursor: pointer;
+  transition: all 0.12s;
+}
+.pgBtn:hover:not(:disabled) {
+  border-color: var(--border);
+  color: var(--text);
+}
+.pgBtn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.emptyRow {
+  text-align: center;
+  padding: 44px;
+  color: var(--text-faint);
+}
+.faint {
+  color: var(--text-faint);
+}

--- a/frontend/src/components/ListPage.tsx
+++ b/frontend/src/components/ListPage.tsx
@@ -1,0 +1,168 @@
+import { IconChevronLeft, IconChevronRight, IconSearch } from "@tabler/icons-react";
+import { type ReactNode, useMemo, useState } from "react";
+
+import ui from "../styles/redesign.module.css";
+import styles from "./ListPage.module.css";
+
+export interface ListColumn<T> {
+  key: string;
+  label: string;
+  width?: number;
+  align?: "left" | "right";
+  render: (row: T) => ReactNode;
+}
+
+interface ListPageProps<T> {
+  eyebrow: string;
+  title: string;
+  subtitle?: string;
+  /** Right side of the page head — primary action and/or CLI hint. */
+  headerRight?: ReactNode;
+  /** Page-specific toolbar controls (selects, date inputs) rendered after the search box. */
+  toolbarExtra?: ReactNode;
+  searchValue: string;
+  onSearchChange: (v: string) => void;
+  searchPlaceholder?: string;
+  /** When provided, rows are client-filtered by this text against the search value. */
+  searchText?: (row: T) => string;
+  columns: ListColumn<T>[];
+  rows: T[];
+  rowKey: (row: T) => string;
+  rowClick?: (row: T) => void;
+  actions?: (row: T) => ReactNode;
+  pageSize?: number;
+  loading?: boolean;
+  emptyText?: string;
+}
+
+export function ListPage<T>({
+  eyebrow,
+  title,
+  subtitle,
+  headerRight,
+  toolbarExtra,
+  searchValue,
+  onSearchChange,
+  searchPlaceholder = "Filter…",
+  searchText,
+  columns,
+  rows,
+  rowKey,
+  rowClick,
+  actions,
+  pageSize = 10,
+  loading = false,
+  emptyText = "No matching rows.",
+}: ListPageProps<T>) {
+  const [page, setPage] = useState(0);
+
+  const filtered = useMemo(() => {
+    const q = searchValue.trim().toLowerCase();
+    if (!q || !searchText) return rows;
+    return rows.filter((r) => searchText(r).toLowerCase().includes(q));
+  }, [rows, searchValue, searchText]);
+
+  const total = filtered.length;
+  const pages = Math.max(1, Math.ceil(total / pageSize));
+  const cur = Math.min(page, pages - 1);
+  const paged = filtered.slice(cur * pageSize, cur * pageSize + pageSize);
+  const hasActions = !!actions;
+  const colSpan = columns.length + (hasActions ? 1 : 0);
+
+  return (
+    <div className={styles.wrap}>
+      <div className={ui.pageHead}>
+        <div>
+          <p className={ui.eyebrow}>{eyebrow}</p>
+          <h1 className={ui.pageTitle}>{title}</h1>
+          {subtitle && <p className={ui.pageSub}>{subtitle}</p>}
+        </div>
+        {headerRight}
+      </div>
+
+      <div className={styles.toolbar}>
+        <span className={styles.search}>
+          <IconSearch size={16} />
+          <input
+            value={searchValue}
+            onChange={(e) => {
+              onSearchChange(e.currentTarget.value);
+              setPage(0);
+            }}
+            placeholder={searchPlaceholder}
+          />
+        </span>
+        {toolbarExtra}
+        <span className={styles.count}>
+          {total} {total === 1 ? "row" : "rows"}
+        </span>
+      </div>
+
+      <div className={`${ui.card} ${ui.rise}`} style={{ overflow: "hidden" }}>
+        <table className={styles.tbl}>
+          <thead>
+            <tr>
+              {columns.map((c) => (
+                <th key={c.key} style={{ width: c.width, textAlign: c.align ?? "left" }}>
+                  {c.label}
+                </th>
+              ))}
+              {hasActions && <th style={{ width: 1 }} />}
+            </tr>
+          </thead>
+          <tbody>
+            {loading ? (
+              <tr>
+                <td colSpan={colSpan} className={styles.emptyRow}>
+                  Loading…
+                </td>
+              </tr>
+            ) : paged.length === 0 ? (
+              <tr>
+                <td colSpan={colSpan} className={styles.emptyRow}>
+                  {emptyText}
+                </td>
+              </tr>
+            ) : (
+              paged.map((r) => (
+                <tr
+                  key={rowKey(r)}
+                  style={rowClick ? { cursor: "pointer" } : undefined}
+                  onClick={rowClick ? () => rowClick(r) : undefined}
+                >
+                  {columns.map((c) => (
+                    <td key={c.key} style={{ textAlign: c.align ?? "left" }}>
+                      {c.render(r)}
+                    </td>
+                  ))}
+                  {hasActions && (
+                    <td onClick={(e) => e.stopPropagation()}>
+                      <div className={styles.actions}>{actions!(r)}</div>
+                    </td>
+                  )}
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+        <div className={styles.foot}>
+          <span className={styles.faint}>
+            {total === 0 ? "0" : `${cur * pageSize + 1}–${Math.min(total, cur * pageSize + pageSize)}`} of{" "}
+            {total}
+          </span>
+          <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+            <button type="button" className={styles.pgBtn} disabled={cur === 0} onClick={() => setPage(cur - 1)} aria-label="Previous page">
+              <IconChevronLeft size={14} />
+            </button>
+            <span className={styles.faint}>
+              page {cur + 1} / {pages}
+            </span>
+            <button type="button" className={styles.pgBtn} disabled={cur >= pages - 1} onClick={() => setPage(cur + 1)} aria-label="Next page">
+              <IconChevronRight size={14} />
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/MarkdownViewer.tsx
+++ b/frontend/src/components/MarkdownViewer.tsx
@@ -11,7 +11,7 @@ interface MarkdownViewerProps {
   /** Which tab to show by default: "rendered" or "raw". */
   defaultView?: "rendered" | "raw";
   /** Max height for the content area (overflows with scroll). */
-  maxHeight?: number;
+  maxHeight?: number | string;
   /** Whether to show the Rendered/Raw toggle. Defaults to true. */
   showToggle?: boolean;
   /**

--- a/frontend/src/components/ScoreRing.tsx
+++ b/frontend/src/components/ScoreRing.tsx
@@ -1,0 +1,41 @@
+/** Semantic-relevance score ring (SVG donut). ≥70% green, ≥40% yellow, else faint. */
+export function ScoreRing({ score, size = 38 }: { score: number; size?: number }) {
+  const clamped = Math.max(0, Math.min(1, score));
+  const pct = Math.round(clamped * 100);
+  const r = (size - 5) / 2;
+  const circ = 2 * Math.PI * r;
+  const col = pct >= 70 ? "var(--green)" : pct >= 40 ? "var(--yellow)" : "var(--text-faint)";
+  return (
+    <div style={{ position: "relative", width: size, height: size, flexShrink: 0 }}>
+      <svg width={size} height={size} style={{ transform: "rotate(-90deg)" }}>
+        <circle cx={size / 2} cy={size / 2} r={r} fill="none" stroke="var(--border)" strokeWidth={2.5} />
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={r}
+          fill="none"
+          stroke={col}
+          strokeWidth={2.5}
+          strokeLinecap="round"
+          strokeDasharray={circ}
+          strokeDashoffset={circ * (1 - clamped)}
+          style={{ transition: "stroke-dashoffset .6s cubic-bezier(.2,.7,.3,1)" }}
+        />
+      </svg>
+      <span
+        style={{
+          position: "absolute",
+          inset: 0,
+          display: "grid",
+          placeItems: "center",
+          fontFamily: "var(--font-mono)",
+          fontSize: size > 34 ? 11 : 9.5,
+          fontWeight: 600,
+          color: col,
+        }}
+      >
+        {pct}
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/components/SearchControls.tsx
+++ b/frontend/src/components/SearchControls.tsx
@@ -188,23 +188,20 @@ export function SearchControls({
         </div>
 
         {localGranularity === "chunks" ? (
-          <div className={ui.seg}>
-            {RANKERS.map((m) => {
-              const Ico = m.icon;
-              return (
-                <button
-                  key={m.v}
-                  type="button"
-                  title={m.desc}
-                  className={`${ui.segBtn} ${localRanker === m.v ? ui.segBtnOn : ""}`}
-                  onClick={() => changeRanker(m.v)}
-                >
-                  <Ico size={14} />
+          <span className={ui.selectWrap} title="Ranking method">
+            <select
+              className={ui.selectEl}
+              value={localRanker}
+              onChange={(e) => changeRanker(e.currentTarget.value as Ranker)}
+            >
+              {RANKERS.map((m) => (
+                <option key={m.v} value={m.v}>
                   {m.label}
-                </button>
-              );
-            })}
-          </div>
+                </option>
+              ))}
+            </select>
+            <IconChevronDown size={14} />
+          </span>
         ) : (
           <span className={`${ui.faint} ${ui.mono}`} style={{ fontSize: 11.5 }}>
             whole documents · hybrid-ranked

--- a/frontend/src/components/SearchControls.tsx
+++ b/frontend/src/components/SearchControls.tsx
@@ -5,6 +5,7 @@ import {
   IconChevronDown,
   IconFileText,
   IconFolder,
+  IconList,
   IconSearch,
   IconSparkles,
   IconStack2,
@@ -17,8 +18,13 @@ import { useMetadataKeys, useProjects } from "../hooks/useProjects";
 import ui from "../styles/redesign.module.css";
 import styles from "../pages/SearchPage.module.css";
 
-const MODES: { v: SearchMode; label: string; icon: typeof IconSearch; desc: string }[] = [
-  { v: "docs", label: "Documents", icon: IconFileText, desc: "Full documents, ranked" },
+type Granularity = "documents" | "chunks";
+type Ranker = "hybrid" | "fts" | "semantic";
+
+// Granularity and ranker are separate concerns. The API encodes them in one
+// SearchMode: "docs" = whole documents (hybrid-ranked, one entry per doc);
+// the other three return matching chunks with the chosen ranker.
+const RANKERS: { v: Ranker; label: string; icon: typeof IconSearch; desc: string }[] = [
   { v: "hybrid", label: "Hybrid", icon: IconStack2, desc: "BM25 + embeddings" },
   { v: "fts", label: "Keyword", icon: IconSearch, desc: "Exact full-text" },
   { v: "semantic", label: "Semantic", icon: IconSparkles, desc: "Meaning-based" },
@@ -58,7 +64,10 @@ export function SearchControls({
   onSearch,
 }: SearchControlsProps) {
   const [localQuery, setLocalQuery] = useState(query);
-  const [localMode, setLocalMode] = useState<SearchMode>(mode);
+  const [localGranularity, setLocalGranularity] = useState<Granularity>(
+    mode === "docs" ? "documents" : "chunks",
+  );
+  const [localRanker, setLocalRanker] = useState<Ranker>(mode === "docs" ? "hybrid" : mode);
   const [localProjectId, setLocalProjectId] = useState(projectId);
   const [localCount, setLocalCount] = useState(count);
   const [localReviewStatus, setLocalReviewStatus] = useState(reviewStatus);
@@ -80,9 +89,10 @@ export function SearchControls({
 
   const apply = useCallback(
     (overrides: Partial<{ q: string; mode: SearchMode; projectId: string; count: number; reviewStatus: string }>) => {
+      const mode: SearchMode = localGranularity === "documents" ? "docs" : localRanker;
       onSearch({
         q: localQuery,
-        mode: localMode,
+        mode,
         projectId: localProjectId,
         count: localCount,
         reviewStatus: localReviewStatus,
@@ -90,12 +100,17 @@ export function SearchControls({
         ...overrides,
       });
     },
-    [localQuery, localMode, localProjectId, localCount, localReviewStatus, buildMf, onSearch],
+    [localQuery, localGranularity, localRanker, localProjectId, localCount, localReviewStatus, buildMf, onSearch],
   );
 
-  const changeMode = (m: SearchMode) => {
-    setLocalMode(m);
-    apply({ mode: m });
+  const changeGranularity = (g: Granularity) => {
+    setLocalGranularity(g);
+    apply({ mode: g === "documents" ? "docs" : localRanker });
+  };
+  const changeRanker = (r: Ranker) => {
+    setLocalRanker(r);
+    setLocalGranularity("chunks");
+    apply({ mode: r });
   };
   const changeProject = (id: string) => {
     setLocalProjectId(id);
@@ -152,22 +167,49 @@ export function SearchControls({
 
       <div className={styles.searchControls}>
         <div className={ui.seg}>
-          {MODES.map((m) => {
-            const Ico = m.icon;
-            return (
-              <button
-                key={m.v}
-                type="button"
-                title={m.desc}
-                className={`${ui.segBtn} ${localMode === m.v ? ui.segBtnOn : ""}`}
-                onClick={() => changeMode(m.v)}
-              >
-                <Ico size={14} />
-                {m.label}
-              </button>
-            );
-          })}
+          <button
+            type="button"
+            title="Whole documents — one entry per document, hybrid-ranked"
+            className={`${ui.segBtn} ${localGranularity === "documents" ? ui.segBtnOn : ""}`}
+            onClick={() => changeGranularity("documents")}
+          >
+            <IconFileText size={14} />
+            Documents
+          </button>
+          <button
+            type="button"
+            title="Matching chunks — pick a ranker"
+            className={`${ui.segBtn} ${localGranularity === "chunks" ? ui.segBtnOn : ""}`}
+            onClick={() => changeGranularity("chunks")}
+          >
+            <IconList size={14} />
+            Chunks
+          </button>
         </div>
+
+        {localGranularity === "chunks" ? (
+          <div className={ui.seg}>
+            {RANKERS.map((m) => {
+              const Ico = m.icon;
+              return (
+                <button
+                  key={m.v}
+                  type="button"
+                  title={m.desc}
+                  className={`${ui.segBtn} ${localRanker === m.v ? ui.segBtnOn : ""}`}
+                  onClick={() => changeRanker(m.v)}
+                >
+                  <Ico size={14} />
+                  {m.label}
+                </button>
+              );
+            })}
+          </div>
+        ) : (
+          <span className={`${ui.faint} ${ui.mono}`} style={{ fontSize: 11.5 }}>
+            whole documents · hybrid-ranked
+          </span>
+        )}
 
         <div className={styles.controlsRight}>
           <span className={ui.selectWrap}>

--- a/frontend/src/components/SearchControls.tsx
+++ b/frontend/src/components/SearchControls.tsx
@@ -1,41 +1,35 @@
+import { ActionIcon, Select, TextInput } from "@mantine/core";
 import {
-  ActionIcon,
-  Button,
-  Collapse,
-  Group,
-  Select,
-  Stack,
-  TextInput,
-} from "@mantine/core";
-import { IconFilter, IconSearch, IconX } from "@tabler/icons-react";
+  IconAdjustmentsHorizontal,
+  IconCheck,
+  IconChevronDown,
+  IconFileText,
+  IconFolder,
+  IconSearch,
+  IconSparkles,
+  IconStack2,
+  IconX,
+} from "@tabler/icons-react";
 import { useCallback, useState } from "react";
 
 import type { SearchMode } from "../api/types";
 import { useMetadataKeys, useProjects } from "../hooks/useProjects";
+import ui from "../styles/redesign.module.css";
+import styles from "../pages/SearchPage.module.css";
 
-const MODE_OPTIONS = [
-  { value: "docs", label: "Documents (full)" },
-  { value: "hybrid", label: "Hybrid chunks" },
-  { value: "fts", label: "Keyword (FTS)" },
-  { value: "semantic", label: "Semantic" },
+const MODES: { v: SearchMode; label: string; icon: typeof IconSearch; desc: string }[] = [
+  { v: "docs", label: "Documents", icon: IconFileText, desc: "Full documents, ranked" },
+  { v: "hybrid", label: "Hybrid", icon: IconStack2, desc: "BM25 + embeddings" },
+  { v: "fts", label: "Keyword", icon: IconSearch, desc: "Exact full-text" },
+  { v: "semantic", label: "Semantic", icon: IconSparkles, desc: "Meaning-based" },
 ];
 
-const COUNT_OPTIONS = [
-  { value: "5", label: "5 results" },
-  { value: "10", label: "10 results" },
-  { value: "20", label: "20 results" },
-];
+const COUNT_OPTIONS = [5, 10, 20];
 
 interface MetadataFilterPair {
   key: string;
   value: string;
 }
-
-const REVIEW_OPTIONS = [
-  { value: "", label: "All statuses" },
-  { value: "approved", label: "Approved" },
-  { value: "pending_review", label: "Pending Review" },
-];
 
 interface SearchControlsProps {
   query: string;
@@ -66,173 +60,218 @@ export function SearchControls({
   const [localQuery, setLocalQuery] = useState(query);
   const [localMode, setLocalMode] = useState<SearchMode>(mode);
   const [localProjectId, setLocalProjectId] = useState(projectId);
-  const [localCount, setLocalCount] = useState(String(count));
+  const [localCount, setLocalCount] = useState(count);
   const [localReviewStatus, setLocalReviewStatus] = useState(reviewStatus);
-  const [filterPairs, setFilterPairs] = useState<MetadataFilterPair[]>(() => {
-    const pairs = Object.entries(metadataFilter).map(([key, value]) => ({
-      key,
-      value,
-    }));
-    return pairs.length > 0 ? pairs : [];
-  });
+  const [filterPairs, setFilterPairs] = useState<MetadataFilterPair[]>(() =>
+    Object.entries(metadataFilter).map(([key, value]) => ({ key, value })),
+  );
   const [filtersOpen, setFiltersOpen] = useState(filterPairs.length > 0);
 
   const { data: projects } = useProjects();
   const { data: metadataKeys } = useMetadataKeys();
 
-  const projectOptions = [
-    { value: "", label: "All projects" },
-    ...(projects?.map((p) => ({ value: p.id, label: p.name })) || []),
-  ];
-
-  const handleSubmit = useCallback(() => {
+  const buildMf = useCallback(() => {
     const mf: Record<string, string> = {};
     for (const pair of filterPairs) {
-      if (pair.key.trim() && pair.value.trim()) {
-        mf[pair.key.trim()] = pair.value.trim();
-      }
+      if (pair.key.trim() && pair.value.trim()) mf[pair.key.trim()] = pair.value.trim();
     }
-    onSearch({
-      q: localQuery,
-      mode: localMode,
-      projectId: localProjectId,
-      count: Number(localCount),
-      reviewStatus: localReviewStatus,
-      metadataFilter: mf,
-    });
-  }, [localQuery, localMode, localProjectId, localCount, localReviewStatus, filterPairs, onSearch]);
+    return mf;
+  }, [filterPairs]);
 
-  const addFilterPair = () => {
-    setFilterPairs((prev) => [...prev, { key: "", value: "" }]);
+  const apply = useCallback(
+    (overrides: Partial<{ q: string; mode: SearchMode; projectId: string; count: number; reviewStatus: string }>) => {
+      onSearch({
+        q: localQuery,
+        mode: localMode,
+        projectId: localProjectId,
+        count: localCount,
+        reviewStatus: localReviewStatus,
+        metadataFilter: buildMf(),
+        ...overrides,
+      });
+    },
+    [localQuery, localMode, localProjectId, localCount, localReviewStatus, buildMf, onSearch],
+  );
+
+  const changeMode = (m: SearchMode) => {
+    setLocalMode(m);
+    apply({ mode: m });
   };
-
-  const removeFilterPair = (index: number) => {
-    setFilterPairs((prev) => prev.filter((_, i) => i !== index));
+  const changeProject = (id: string) => {
+    setLocalProjectId(id);
+    apply({ projectId: id });
   };
-
-  const updateFilterPair = (
-    index: number,
-    field: "key" | "value",
-    val: string,
-  ) => {
-    setFilterPairs((prev) =>
-      prev.map((pair, i) => (i === index ? { ...pair, [field]: val } : pair)),
-    );
+  const changeCount = (n: number) => {
+    setLocalCount(n);
+    apply({ count: n });
+  };
+  const togglePending = () => {
+    const next = localReviewStatus === "pending_review" ? "" : "pending_review";
+    setLocalReviewStatus(next);
+    apply({ reviewStatus: next });
   };
 
   const keyOptions =
-    metadataKeys?.map((mk) => ({
-      value: mk.key,
-      label: `${mk.key} (${mk.doc_count})`,
-    })) || [];
+    metadataKeys?.map((mk) => ({ value: mk.key, label: `${mk.key} (${mk.doc_count})` })) ?? [];
 
   return (
-    <Stack gap="sm">
+    <div className={`${ui.card} ${styles.searchBar} ${ui.rise}`}>
       <form
+        className={styles.searchInputRow}
         onSubmit={(e) => {
           e.preventDefault();
-          handleSubmit();
+          apply({});
         }}
       >
-        <Group gap="sm" align="flex-end">
-          <TextInput
-            placeholder="Search your knowledge base..."
-            value={localQuery}
-            onChange={(e) => setLocalQuery(e.currentTarget.value)}
-            flex={1}
-            size="md"
-            leftSection={<IconSearch size={18} />}
-          />
-          <Select
-            data={MODE_OPTIONS}
-            value={localMode}
-            onChange={(v) => setLocalMode((v as SearchMode) || "docs")}
-            w={180}
-            size="md"
-          />
-          {projectOptions.length > 1 && (
-            <Select
-              data={projectOptions}
-              value={localProjectId}
-              onChange={(v) => setLocalProjectId(v || "")}
-              w={180}
-              size="md"
-              placeholder="All projects"
-              clearable
-            />
-          )}
-          <Select
-            data={COUNT_OPTIONS}
-            value={localCount}
-            onChange={(v) => setLocalCount(v || "10")}
-            w={120}
-            size="md"
-          />
-          <Button type="submit" size="md">
-            Search
-          </Button>
-        </Group>
+        <IconSearch size={20} />
+        <input
+          className={styles.searchInput}
+          value={localQuery}
+          onChange={(e) => setLocalQuery(e.currentTarget.value)}
+          placeholder="Search your knowledge base…"
+        />
+        {localQuery && (
+          <button
+            type="button"
+            className={ui.iconBtn}
+            style={{ width: 30, height: 30 }}
+            aria-label="Clear"
+            onClick={() => {
+              setLocalQuery("");
+            }}
+          >
+            <IconX size={16} />
+          </button>
+        )}
+        <button type="submit" className={`${ui.btn} ${ui.btnPrimary}`}>
+          Search
+        </button>
       </form>
 
-      <Group gap="xs">
-        <Button
-          variant="subtle"
-          size="xs"
-          leftSection={<IconFilter size={14} />}
-          onClick={() => setFiltersOpen((o) => !o)}
-        >
-          Metadata filters {filterPairs.length > 0 && `(${filterPairs.length})`}
-        </Button>
-        {localMode === "docs" && (
-          <Select
-            data={REVIEW_OPTIONS}
-            value={localReviewStatus}
-            onChange={(v) => setLocalReviewStatus(v || "")}
-            w={160}
-            size="xs"
-            placeholder="All statuses"
-            clearable
-          />
-        )}
-      </Group>
+      <div className={ui.divider} />
 
-      <Collapse in={filtersOpen}>
-        <Stack gap="xs" pl="sm">
+      <div className={styles.searchControls}>
+        <div className={ui.seg}>
+          {MODES.map((m) => {
+            const Ico = m.icon;
+            return (
+              <button
+                key={m.v}
+                type="button"
+                title={m.desc}
+                className={`${ui.segBtn} ${localMode === m.v ? ui.segBtnOn : ""}`}
+                onClick={() => changeMode(m.v)}
+              >
+                <Ico size={14} />
+                {m.label}
+              </button>
+            );
+          })}
+        </div>
+
+        <div className={styles.controlsRight}>
+          <span className={ui.selectWrap}>
+            <IconFolder size={14} />
+            <select
+              className={ui.selectEl}
+              value={localProjectId}
+              onChange={(e) => changeProject(e.currentTarget.value)}
+            >
+              <option value="">All projects ({projects?.length ?? 0})</option>
+              {projects?.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+            <IconChevronDown size={14} />
+          </span>
+
+          <span className={ui.selectWrap}>
+            <select
+              className={ui.selectEl}
+              value={String(localCount)}
+              onChange={(e) => changeCount(Number(e.currentTarget.value))}
+            >
+              {COUNT_OPTIONS.map((n) => (
+                <option key={n} value={n}>
+                  {n} results
+                </option>
+              ))}
+            </select>
+            <IconChevronDown size={14} />
+          </span>
+
+          <button
+            type="button"
+            className={`${ui.chip} ${localReviewStatus === "pending_review" ? ui.chipOn : ""}`}
+            onClick={togglePending}
+          >
+            <IconCheck size={13} />
+            Pending review
+          </button>
+
+          <button
+            type="button"
+            className={`${ui.chip} ${filtersOpen ? ui.chipOn : ""}`}
+            onClick={() => setFiltersOpen((o) => !o)}
+          >
+            <IconAdjustmentsHorizontal size={13} />
+            Filters{filterPairs.length > 0 ? ` (${filterPairs.length})` : ""}
+          </button>
+        </div>
+      </div>
+
+      {filtersOpen && (
+        <div className={styles.filterRow}>
           {filterPairs.map((pair, idx) => (
-            <Group key={idx} gap="xs">
+            <div key={idx} style={{ display: "flex", gap: 8, alignItems: "center" }}>
               <Select
                 placeholder="Key"
                 data={keyOptions}
-                value={pair.key}
-                onChange={(v) => updateFilterPair(idx, "key", v || "")}
+                value={pair.key || null}
+                onChange={(v) =>
+                  setFilterPairs((prev) =>
+                    prev.map((p, i) => (i === idx ? { ...p, key: v || "" } : p)),
+                  )
+                }
                 searchable
-                w={200}
                 size="xs"
+                w={190}
               />
               <TextInput
                 placeholder="Value"
                 value={pair.value}
                 onChange={(e) =>
-                  updateFilterPair(idx, "value", e.currentTarget.value)
+                  setFilterPairs((prev) =>
+                    prev.map((p, i) => (i === idx ? { ...p, value: e.currentTarget.value } : p)),
+                  )
                 }
-                w={200}
                 size="xs"
+                w={190}
               />
               <ActionIcon
                 variant="subtle"
                 color="red"
                 size="sm"
-                onClick={() => removeFilterPair(idx)}
+                onClick={() => setFilterPairs((prev) => prev.filter((_, i) => i !== idx))}
               >
                 <IconX size={14} />
               </ActionIcon>
-            </Group>
+            </div>
           ))}
-          <Button variant="light" size="xs" w={140} onClick={addFilterPair}>
+          <button
+            type="button"
+            className={`${ui.btn} ${ui.btnSubtle}`}
+            onClick={() => setFilterPairs((prev) => [...prev, { key: "", value: "" }])}
+          >
             + Add filter
-          </Button>
-        </Stack>
-      </Collapse>
-    </Stack>
+          </button>
+          <button type="button" className={`${ui.btn} ${ui.btnGhost}`} onClick={() => apply({})}>
+            Apply filters
+          </button>
+        </div>
+      )}
+    </div>
   );
 }

--- a/frontend/src/components/SearchResults.tsx
+++ b/frontend/src/components/SearchResults.tsx
@@ -1,23 +1,35 @@
+import { Alert, Loader } from "@mantine/core";
 import {
-  Accordion,
-  Alert,
-  Anchor,
-  Badge,
-  Code,
-  Group,
-  Loader,
-  Stack,
-  Text,
-} from "@mantine/core";
-import { IconAlertCircle } from "@tabler/icons-react";
+  IconAlertCircle,
+  IconChevronDown,
+  IconChevronRight,
+  IconFileText,
+  IconLink,
+  IconSearch,
+  IconTerminal2,
+} from "@tabler/icons-react";
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
-import type {
-  ChunkSearchResult,
-  DocSearchResult,
-  SearchResponse,
-} from "../api/types";
+import type { ChunkSearchResult, DocSearchResult, SearchMode, SearchResponse } from "../api/types";
 import { isDocResult } from "../api/types";
+import { ScoreRing } from "./ScoreRing";
+import ui from "../styles/redesign.module.css";
+import styles from "../pages/SearchPage.module.css";
+
+const PROJECT_COLORS = ["--primary", "--violet", "--blue", "--green", "--yellow", "--red"];
+function colorForProject(name: string): string {
+  let h = 0;
+  for (let i = 0; i < name.length; i++) h = (h * 31 + name.charCodeAt(i)) >>> 0;
+  return `var(${PROJECT_COLORS[h % PROJECT_COLORS.length]})`;
+}
+
+const MODE_LABEL: Record<SearchMode, string> = {
+  docs: "documents",
+  hybrid: "hybrid",
+  fts: "keyword",
+  semantic: "semantic",
+};
 
 interface SearchResultsProps {
   data: SearchResponse | undefined;
@@ -26,194 +38,198 @@ interface SearchResultsProps {
   hasQuery: boolean;
 }
 
-export function SearchResults({
-  data,
-  isLoading,
-  error,
-  hasQuery,
-}: SearchResultsProps) {
+export function SearchResults({ data, isLoading, error, hasQuery }: SearchResultsProps) {
+  const navigate = useNavigate();
+  const [expanded, setExpanded] = useState<string | null>(null);
+
   if (!hasQuery) {
     return (
-      <Text c="dimmed" ta="center" mt="xl">
-        Enter a query or select a project to browse.
-      </Text>
+      <div className={`${ui.card} ${styles.emptyState}`} style={{ marginTop: 22 }}>
+        <IconSearch size={28} />
+        <p style={{ marginTop: 10 }}>Enter a query or pick a project to browse your memory.</p>
+      </div>
     );
   }
-
   if (isLoading) {
     return (
-      <Group justify="center" mt="xl">
-        <Loader />
-        <Text c="dimmed">Searching...</Text>
-      </Group>
+      <div style={{ display: "flex", gap: 12, justifyContent: "center", marginTop: 40 }}>
+        <Loader size="sm" />
+        <span className={ui.dim}>Searching…</span>
+      </div>
     );
   }
-
   if (error) {
     return (
-      <Alert
-        icon={<IconAlertCircle size={16} />}
-        title="Search failed"
-        color="red"
-        mt="md"
-      >
+      <Alert icon={<IconAlertCircle size={16} />} title="Search failed" color="red" mt="md">
         {error.message}
       </Alert>
     );
   }
-
   if (!data || data.results.length === 0) {
     return (
-      <Text c="dimmed" ta="center" mt="xl">
-        No results found.
-      </Text>
+      <div className={`${ui.card} ${styles.emptyState}`} style={{ marginTop: 22 }}>
+        <IconSearch size={28} />
+        <p style={{ marginTop: 10 }}>No results. Try widening your search or switching mode.</p>
+      </div>
     );
   }
 
-  const isDocView = data.results.length > 0 && isDocResult(data.results[0]);
+  const kb = (data.response_bytes / 1024).toFixed(1);
 
-  return (
-    <Stack gap="md" mt="md">
-      <Group justify="space-between">
-        <Text size="sm" c="dimmed">
-          {data.total_found} result{data.total_found !== 1 ? "s" : ""} found
-        </Text>
-        {data.truncated && (
-          <Badge color="yellow" variant="light" size="sm">
-            Results truncated
-          </Badge>
-        )}
-      </Group>
-
-      {isDocView ? (
-        <DocResults results={data.results as DocSearchResult[]} />
-      ) : (
-        <ChunkResults results={data.results as ChunkSearchResult[]} />
-      )}
-    </Stack>
+  // Docs/FTS scores aren't 0–1 (raw rank can exceed 1); semantic/hybrid are.
+  // Normalize relative to the set only when the scale is clearly >1, so the
+  // ring shows ranking strength without inflating already-normalized scores.
+  const rawScores = data.results.map((r) =>
+    isDocResult(r) ? (r as DocSearchResult).best_score : (r as ChunkSearchResult).score,
   );
-}
+  const maxScore = Math.max(0, ...rawScores);
+  const normScore = (s: number) => (maxScore > 1 ? s / maxScore : Math.max(0, Math.min(1, s)));
 
-function DocResults({ results }: { results: DocSearchResult[] }) {
-  const navigate = useNavigate();
   return (
-    <Accordion variant="separated" multiple>
-      {results.map((r) => (
-        <Accordion.Item key={r.document_id} value={r.document_id}>
-          <Accordion.Control>
-            <Group justify="space-between" wrap="nowrap" gap="sm">
-              <Group gap="xs" wrap="nowrap" style={{ minWidth: 0, flex: 1 }}>
-                <ScoreBadge score={r.best_score} />
-                <Anchor
-                  href={`/app/document/${r.document_id}`}
-                  onClick={(e) => { e.preventDefault(); e.stopPropagation(); navigate(`/document/${r.document_id}`); }}
-                  fw={600}
-                  size="sm"
-                  truncate
-                >
-                  {r.doc_title || "Untitled"}
-                </Anchor>
-              </Group>
-              <Group gap="xs" wrap="nowrap">
-                {r.is_partial ? (
-                  <Badge color="yellow" variant="light" size="xs">
-                    Excerpt
-                  </Badge>
-                ) : (
-                  <Badge color="green" variant="light" size="xs">
-                    Full
-                  </Badge>
-                )}
-              </Group>
-            </Group>
-            <Group gap="xs" mt={4}>
-              <Text size="xs" c="dimmed">
-                {r.chunk_count} chunks | {r.total_chars.toLocaleString()} chars
-              </Text>
-              {r.doc_updated_at && (
-                <Text size="xs" c="dimmed">
-                  Updated {new Date(r.doc_updated_at).toLocaleDateString()}
-                </Text>
+    <>
+      <div className={styles.resultMeta}>
+        <span>
+          <b className={ui.mono} style={{ color: "var(--text)" }}>
+            {data.total_found}
+          </b>{" "}
+          result{data.total_found !== 1 ? "s" : ""} · ranked by{" "}
+          <span className={ui.mono} style={{ color: "var(--primary)" }}>
+            {MODE_LABEL[data.mode]}
+          </span>{" "}
+          relevance
+        </span>
+        <span className={`${ui.faint} ${ui.mono}`} style={{ fontSize: 12 }}>
+          {data.truncated ? "truncated · " : ""}
+          {kb} KB
+        </span>
+      </div>
+
+      <div className={styles.results}>
+        {data.results.map((r) => {
+          const isDoc = isDocResult(r);
+          const id = isDoc ? (r as DocSearchResult).document_id : (r as ChunkSearchResult).chunk_id;
+          const docId = r.document_id;
+          const score = isDoc ? (r as DocSearchResult).best_score : (r as ChunkSearchResult).score;
+          const title = r.doc_title || "Untitled";
+          const headingPath = isDoc
+            ? (r as DocSearchResult).best_chunk_heading_path
+            : (r as ChunkSearchResult).heading_path;
+          const snippet = isDoc
+            ? (r as DocSearchResult).full_content
+            : (r as ChunkSearchResult).content;
+          const projectNames = r.doc_project_names ?? [];
+          const open = expanded === id;
+
+          return (
+            <article
+              key={id}
+              className={`${ui.card} ${styles.resultCard} ${open ? styles.resultCardOpen : ""} ${ui.rise}`}
+            >
+              <div className={styles.resultHead} onClick={() => setExpanded(open ? null : id)}>
+                <ScoreRing score={normScore(score)} />
+                <div className={styles.resultTitleWrap}>
+                  <div className={ui.row} style={{ gap: 8, marginBottom: 5 }}>
+                    <h3 className={styles.resultTitle}>{title}</h3>
+                    {isDoc ? (
+                      (r as DocSearchResult).is_partial ? (
+                        <span className={`${ui.badge} ${ui.bYellow}`}>excerpt</span>
+                      ) : (
+                        <span className={`${ui.badge} ${ui.bGreen}`}>full</span>
+                      )
+                    ) : (
+                      <span className={`${ui.badge} ${ui.bNeutral}`}>chunk</span>
+                    )}
+                  </div>
+                  {headingPath.length > 0 && (
+                    <div className={styles.breadcrumb}>
+                      {headingPath.map((h, j) => (
+                        <span key={j}>
+                          {j > 0 && <IconChevronRight size={11} />}
+                          <span>{h}</span>
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </div>
+                <div className={styles.resultMetaR}>
+                  {projectNames.map((pn) => (
+                    <span key={pn} className={`${ui.badge} ${ui.bNeutral}`}>
+                      <span
+                        className={styles.dot}
+                        style={{ background: colorForProject(pn), width: 6, height: 6 }}
+                      />
+                      {pn}
+                    </span>
+                  ))}
+                  <span className={`${styles.chev} ${open ? styles.chevOpen : ""}`}>
+                    <IconChevronDown size={16} />
+                  </span>
+                </div>
+              </div>
+
+              <div className={`${styles.resultSnippet} ${open ? styles.resultSnippetOpen : ""}`}>
+                {snippet.slice(0, open ? 4000 : 600)}
+              </div>
+
+              {open && (
+                <div className={styles.resultExpand}>
+                  <div className={styles.resultStats}>
+                    {isDoc ? (
+                      <>
+                        <span>{(r as DocSearchResult).chunk_count} chunks</span>
+                        <span>·</span>
+                        <span>{(r as DocSearchResult).total_chars.toLocaleString()} chars</span>
+                        {(r as DocSearchResult).doc_updated_at && (
+                          <>
+                            <span>·</span>
+                            <span>
+                              updated{" "}
+                              {new Date(
+                                (r as DocSearchResult).doc_updated_at as string,
+                              ).toLocaleDateString()}
+                            </span>
+                          </>
+                        )}
+                      </>
+                    ) : (
+                      <>
+                        <span>chunk #{(r as ChunkSearchResult).chunk_index}</span>
+                        <span>·</span>
+                        <span>{(r as ChunkSearchResult).content.length.toLocaleString()} chars</span>
+                      </>
+                    )}
+                  </div>
+                  <div className={ui.row} style={{ gap: 8 }}>
+                    <button
+                      type="button"
+                      className={`${ui.btn} ${ui.btnGhost}`}
+                      onClick={() => navigate(`/document/${docId}`)}
+                    >
+                      <IconFileText size={14} />
+                      Open document
+                    </button>
+                    <button
+                      type="button"
+                      className={`${ui.btn} ${ui.btnSubtle}`}
+                      onClick={() => navigator.clipboard?.writeText(`cerefox document get ${docId}`)}
+                    >
+                      <IconLink size={14} />
+                      Copy reference
+                    </button>
+                    <span
+                      className={`${ui.mono} ${ui.faint}`}
+                      style={{ marginLeft: "auto", fontSize: 12, display: "inline-flex", alignItems: "center", gap: 6 }}
+                    >
+                      <IconTerminal2 size={14} />
+                      cerefox document get {docId.slice(0, 8)}…
+                    </span>
+                  </div>
+                </div>
               )}
-              {r.best_chunk_heading_path.length > 0 && (
-                <Text size="xs" c="dimmed" fs="italic">
-                  Best match: {r.best_chunk_heading_path.join(" > ")}
-                </Text>
-              )}
-            </Group>
-            {r.doc_project_names && r.doc_project_names.length > 0 && (
-              <Group gap={4} mt={4}>
-                {r.doc_project_names.map((name) => (
-                  <Badge key={name} size="xs" variant="filled" color="blue">
-                    {name}
-                  </Badge>
-                ))}
-              </Group>
-            )}
-          </Accordion.Control>
-          <Accordion.Panel>
-            <Code block style={{ whiteSpace: "pre-wrap", maxHeight: 400, overflow: "auto" }}>
-              {r.full_content || "(no content)"}
-            </Code>
-          </Accordion.Panel>
-        </Accordion.Item>
-      ))}
-    </Accordion>
-  );
-}
-
-function ChunkResults({ results }: { results: ChunkSearchResult[] }) {
-  const navigate = useNavigate();
-  return (
-    <Stack gap="sm">
-      {results.map((r) => (
-        <div
-          key={r.chunk_id}
-          style={{
-            border: "1px solid var(--mantine-color-gray-3)",
-            borderRadius: 8,
-            padding: 12,
-          }}
-        >
-          <Group gap="xs" mb={4}>
-            {r.heading_path.length > 0 && (
-              <Text size="xs" c="dimmed" style={{ fontFamily: "monospace" }}>
-                {r.heading_path.join(" > ")}
-              </Text>
-            )}
-          </Group>
-          <Group gap="xs" mb={8}>
-            <ScoreBadge score={r.score} />
-            <Anchor href={`/app/document/${r.document_id}`}
-                  onClick={(e) => { e.preventDefault(); e.stopPropagation(); navigate(`/document/${r.document_id}`); }} fw={600} size="sm">
-              {r.doc_title || "Untitled"}
-            </Anchor>
-            {r.title && r.title !== r.doc_title && (
-              <Text size="sm" c="dimmed">
-                / {r.title}
-              </Text>
-            )}
-          </Group>
-          <Text
-            size="sm"
-            lineClamp={4}
-            style={{ whiteSpace: "pre-wrap" }}
-          >
-            {r.content.slice(0, 400)}
-          </Text>
-        </div>
-      ))}
-    </Stack>
-  );
-}
-
-function ScoreBadge({ score }: { score: number }) {
-  if (score <= 0) return null;
-  const pct = Math.round(score * 100);
-  const color = pct >= 70 ? "green" : pct >= 40 ? "yellow" : "gray";
-  return (
-    <Badge color={color} variant="light" size="xs">
-      {pct}%
-    </Badge>
+            </article>
+          );
+        })}
+      </div>
+    </>
   );
 }

--- a/frontend/src/components/SearchResults.tsx
+++ b/frontend/src/components/SearchResults.tsx
@@ -3,8 +3,8 @@ import {
   IconAlertCircle,
   IconChevronDown,
   IconChevronRight,
+  IconCopy,
   IconFileText,
-  IconLink,
   IconSearch,
   IconTerminal2,
 } from "@tabler/icons-react";
@@ -129,7 +129,18 @@ export function SearchResults({ data, isLoading, error, hasQuery }: SearchResult
                 <ScoreRing score={normScore(score)} />
                 <div className={styles.resultTitleWrap}>
                   <div className={ui.row} style={{ gap: 8, marginBottom: 5 }}>
-                    <h3 className={styles.resultTitle}>{title}</h3>
+                    <h3 className={styles.resultTitle}>
+                      <span
+                        className={ui.link}
+                        style={{ cursor: "pointer" }}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          navigate(`/document/${docId}`);
+                        }}
+                      >
+                        {title}
+                      </span>
+                    </h3>
                     {isDoc ? (
                       (r as DocSearchResult).is_partial ? (
                         <span className={`${ui.badge} ${ui.bYellow}`}>excerpt</span>
@@ -211,18 +222,16 @@ export function SearchResults({ data, isLoading, error, hasQuery }: SearchResult
                     <button
                       type="button"
                       className={`${ui.btn} ${ui.btnSubtle}`}
+                      style={{ marginLeft: "auto" }}
+                      title="Copy CLI command to clipboard"
                       onClick={() => navigator.clipboard?.writeText(`cerefox document get ${docId}`)}
                     >
-                      <IconLink size={14} />
-                      Copy reference
-                    </button>
-                    <span
-                      className={`${ui.mono} ${ui.faint}`}
-                      style={{ marginLeft: "auto", fontSize: 12, display: "inline-flex", alignItems: "center", gap: 6 }}
-                    >
                       <IconTerminal2 size={14} />
-                      cerefox document get {docId.slice(0, 8)}…
-                    </span>
+                      <span className={ui.mono} style={{ fontSize: 12 }}>
+                        cerefox document get {docId.slice(0, 8)}…
+                      </span>
+                      <IconCopy size={13} />
+                    </button>
                   </div>
                 </div>
               )}

--- a/frontend/src/hooks/useThemePreference.ts
+++ b/frontend/src/hooks/useThemePreference.ts
@@ -1,0 +1,42 @@
+import { useMantineColorScheme } from "@mantine/core";
+import { useEffect } from "react";
+
+import { fetchPreferences, savePreferences, type ThemePref } from "../api/preferences";
+
+/**
+ * Color-scheme state with two storage layers (mirrors cfcf's useTheme):
+ *   1. Mantine's own localStorage — per-browser fast path; drives the
+ *      first paint with no flash before this hook runs.
+ *   2. ~/.cerefox/web-prefs.json (via /api/v1/preferences) — durable,
+ *      machine-local source reconciled on mount; survives cache clears.
+ *
+ * "auto" follows the OS. Server wins on mount when the two disagree.
+ */
+export function useThemePreference(): { theme: ThemePref; setTheme: (t: ThemePref) => void } {
+  const { colorScheme, setColorScheme } = useMantineColorScheme();
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchPreferences()
+      .then((p) => {
+        if (!cancelled && p.theme && p.theme !== colorScheme) setColorScheme(p.theme);
+      })
+      .catch(() => {
+        /* offline / not configured: keep the localStorage value */
+      });
+    return () => {
+      cancelled = true;
+    };
+    // Run once on mount; later changes go through setTheme.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const setTheme = (next: ThemePref) => {
+    setColorScheme(next);
+    savePreferences({ theme: next }).catch(() => {
+      /* ignore: localStorage already captured the choice */
+    });
+  };
+
+  return { theme: colorScheme as ThemePref, setTheme };
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,5 +1,6 @@
 import "@mantine/core/styles.css";
 import "@mantine/notifications/styles.css";
+import "./theme.css";
 
 import { MantineProvider } from "@mantine/core";
 import { Notifications } from "@mantine/notifications";
@@ -9,6 +10,7 @@ import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 
 import { App } from "./App";
+import { theme } from "./theme";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -22,7 +24,7 @@ const queryClient = new QueryClient({
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <MantineProvider defaultColorScheme="auto">
+      <MantineProvider theme={theme} defaultColorScheme="auto">
         <Notifications position="top-right" />
         <BrowserRouter basename="/app">
           <App />

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,5 +1,6 @@
 import "@mantine/core/styles.css";
 import "@mantine/notifications/styles.css";
+import "./tokens.css";
 import "./theme.css";
 
 import { MantineProvider } from "@mantine/core";

--- a/frontend/src/pages/AnalyticsPage.tsx
+++ b/frontend/src/pages/AnalyticsPage.tsx
@@ -29,6 +29,7 @@ import {
   type UsageSummary,
 } from "../api/analytics";
 import { fetchProjects } from "../api/projects";
+import { showSuccess } from "../utils/notifications";
 import { WordCloudChart } from "../components/WordCloudChart";
 import { HEBChart } from "../components/HEBChart";
 import { HEBOperationChart } from "../components/HEBOperationChart";
@@ -144,8 +145,14 @@ export function AnalyticsPage() {
   const toggleMutation = useMutation({
     mutationFn: (enabled: boolean) =>
       setConfig("usage_tracking_enabled", enabled ? "true" : "false"),
-    onSuccess: () => {
+    onSuccess: (_, enabled) => {
       queryClient.invalidateQueries({ queryKey: ["config"] });
+      showSuccess(
+        `Usage tracking ${enabled ? "enabled" : "disabled"}`,
+        enabled
+          ? "Reads and writes will now be recorded in the usage log."
+          : "Operations will no longer be recorded.",
+      );
     },
   });
 
@@ -169,7 +176,15 @@ export function AnalyticsPage() {
     <Container size="xl">
       <Group justify="space-between" mb="md">
         <Title order={2}>Analytics</Title>
-        <Group gap="xs">
+        <Group gap="md">
+          <Switch
+            label="Usage tracking"
+            checked={isEnabled}
+            onChange={(e) => toggleMutation.mutate(e.currentTarget.checked)}
+            size="sm"
+            color="green"
+            disabled={toggleMutation.isPending}
+          />
           <Button
             variant="subtle"
             leftSection={<IconDownload size={16} />}
@@ -228,15 +243,6 @@ export function AnalyticsPage() {
             w={150}
             clearable
           />
-          <Stack gap={2} justify="flex-end" style={{ paddingTop: 20 }}>
-            <Switch
-              label="Tracking"
-              checked={isEnabled}
-              onChange={(e) => toggleMutation.mutate(e.currentTarget.checked)}
-              size="sm"
-              color={isEnabled ? "green" : "gray"}
-            />
-          </Stack>
           <Stack gap={2} justify="flex-end" style={{ paddingTop: 20 }}>
             <Button
               leftSection={<IconPlayerPlay size={16} />}

--- a/frontend/src/pages/AnalyticsPage.tsx
+++ b/frontend/src/pages/AnalyticsPage.tsx
@@ -30,6 +30,7 @@ import {
 } from "../api/analytics";
 import { fetchProjects } from "../api/projects";
 import { showSuccess } from "../utils/notifications";
+import ui from "../styles/redesign.module.css";
 import { WordCloudChart } from "../components/WordCloudChart";
 import { HEBChart } from "../components/HEBChart";
 import { HEBOperationChart } from "../components/HEBOperationChart";
@@ -174,6 +175,7 @@ export function AnalyticsPage() {
 
   return (
     <Container size="xl">
+      <p className={ui.eyebrow}>Usage</p>
       <Group justify="space-between" mb="md">
         <Title order={2}>Analytics</Title>
         <Group gap="md">

--- a/frontend/src/pages/AuditLogPage.tsx
+++ b/frontend/src/pages/AuditLogPage.tsx
@@ -36,15 +36,20 @@ export function AuditLogPage() {
   const [operation, setOperation] = useState(searchParams.get("operation") || "");
   const [author, setAuthor] = useState(searchParams.get("author") || "");
   const [documentId] = useState(searchParams.get("document_id") || "");
+  const [fromDate, setFromDate] = useState("");
+  const [toDate, setToDate] = useState("");
+  const [limit, setLimit] = useState("100");
 
   const { data: entries, isLoading } = useQuery({
-    queryKey: ["audit-log", operation, author, documentId],
+    queryKey: ["audit-log", operation, author, documentId, fromDate, toDate, limit],
     queryFn: () =>
       fetchAuditLog({
         operation: operation || undefined,
         author: author || undefined,
         document_id: documentId || undefined,
-        limit: 100,
+        since: fromDate ? `${fromDate}T00:00:00` : undefined,
+        until: toDate ? `${toDate}T23:59:59` : undefined,
+        limit: Number(limit),
       }),
   });
 
@@ -67,26 +72,52 @@ export function AuditLogPage() {
         Audit Log
       </Title>
 
-      <Group mb="md" gap="sm">
+      <Group mb="md" gap="sm" align="flex-end">
         <Select
-          placeholder="Filter by operation"
+          label="Operation"
+          placeholder="All operations"
           data={OPERATIONS}
           value={operation}
           onChange={(v) => setOperation(v || "")}
           clearable
-          w={200}
+          w={180}
           size="sm"
         />
         <TextInput
+          label="Author"
           placeholder="Filter by author"
           value={author}
           onChange={(e) => setAuthor(e.currentTarget.value)}
           leftSection={<IconSearch size={14} />}
-          w={200}
+          w={180}
           size="sm"
         />
-        <Text size="sm" c="dimmed">
-          {entries?.length ?? 0} entries
+        <TextInput
+          label="From"
+          type="date"
+          value={fromDate}
+          onChange={(e) => setFromDate(e.currentTarget.value)}
+          w={150}
+          size="sm"
+        />
+        <TextInput
+          label="To"
+          type="date"
+          value={toDate}
+          onChange={(e) => setToDate(e.currentTarget.value)}
+          w={150}
+          size="sm"
+        />
+        <Select
+          label="Max entries"
+          data={["100", "250", "500", "1000"]}
+          value={limit}
+          onChange={(v) => setLimit(v || "100")}
+          w={120}
+          size="sm"
+        />
+        <Text size="sm" c="dimmed" pb={6}>
+          {entries?.length ?? 0} shown
         </Text>
       </Group>
 

--- a/frontend/src/pages/AuditLogPage.tsx
+++ b/frontend/src/pages/AuditLogPage.tsx
@@ -1,23 +1,15 @@
-import {
-  Anchor,
-  Badge,
-  Container,
-  Group,
-  Loader,
-  Select,
-  Table,
-  Text,
-  TextInput,
-  Title,
-} from "@mantine/core";
-import ui from "../styles/redesign.module.css";
-import { IconSearch } from "@tabler/icons-react";
+import { Select, TextInput } from "@mantine/core";
+import { IconMapPin, IconSparkles } from "@tabler/icons-react";
 import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 
+import type { AuditEntry } from "../api/types";
 import { fetchAuditLog } from "../api/audit";
+import { CliHint } from "../components/CliHint";
+import { ListPage, type ListColumn } from "../components/ListPage";
 import { formatDateTime } from "../utils/dates";
+import ui from "../styles/redesign.module.css";
 
 const OPERATIONS = [
   { value: "", label: "All operations" },
@@ -30,23 +22,32 @@ const OPERATIONS = [
   { value: "unarchive", label: "Unarchive" },
 ];
 
+const OP_TONE: Record<string, string> = {
+  create: ui.bGreen,
+  "update-content": ui.bBlue,
+  "update-metadata": ui.bViolet,
+  "status-change": ui.bYellow,
+  archive: ui.bPrimary,
+  unarchive: ui.bPrimary,
+  delete: ui.bRed,
+};
+
 export function AuditLogPage() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
 
   const [operation, setOperation] = useState(searchParams.get("operation") || "");
-  const [author, setAuthor] = useState(searchParams.get("author") || "");
   const [documentId] = useState(searchParams.get("document_id") || "");
   const [fromDate, setFromDate] = useState("");
   const [toDate, setToDate] = useState("");
   const [limit, setLimit] = useState("100");
+  const [query, setQuery] = useState("");
 
   const { data: entries, isLoading } = useQuery({
-    queryKey: ["audit-log", operation, author, documentId, fromDate, toDate, limit],
+    queryKey: ["audit-log", operation, documentId, fromDate, toDate, limit],
     queryFn: () =>
       fetchAuditLog({
         operation: operation || undefined,
-        author: author || undefined,
         document_id: documentId || undefined,
         since: fromDate ? `${fromDate}T00:00:00` : undefined,
         until: toDate ? `${toDate}T23:59:59` : undefined,
@@ -54,161 +55,124 @@ export function AuditLogPage() {
       }),
   });
 
-  const operationColor = (op: string) => {
-    switch (op) {
-      case "create": return "green";
-      case "update-content": return "blue";
-      case "update-metadata": return "cyan";
-      case "delete": return "red";
-      case "status-change": return "yellow";
-      case "archive": return "violet";
-      case "unarchive": return "orange";
-      default: return "gray";
-    }
-  };
+  const columns: ListColumn<AuditEntry>[] = [
+    {
+      key: "time",
+      label: "Time",
+      width: 150,
+      render: (e) => (
+        <span className={`${ui.faint} ${ui.mono}`} style={{ fontSize: 12, whiteSpace: "nowrap" }}>
+          {formatDateTime(e.created_at)}
+        </span>
+      ),
+    },
+    {
+      key: "op",
+      label: "Operation",
+      width: 150,
+      render: (e) => (
+        <span className={`${ui.badge} ${OP_TONE[e.operation] ?? ui.bNeutral}`}>{e.operation}</span>
+      ),
+    },
+    {
+      key: "author",
+      label: "Author",
+      width: 170,
+      render: (e) => (
+        <span className={`${ui.srcChip} ${e.author_type === "agent" ? ui.srcChipAgent : ""}`}>
+          {e.author_type === "agent" ? <IconSparkles size={12} /> : <IconMapPin size={12} />}
+          {e.author}
+        </span>
+      ),
+    },
+    {
+      key: "doc",
+      label: "Document",
+      render: (e) =>
+        e.document_id ? (
+          <span className={`${ui.link}`} style={{ fontSize: 13 }}>
+            {e.doc_title || `${e.document_id.slice(0, 8)}…`}
+          </span>
+        ) : (
+          <span className={ui.faint} style={{ fontSize: 12 }}>
+            (deleted)
+          </span>
+        ),
+    },
+    {
+      key: "delta",
+      label: "Change",
+      width: 110,
+      align: "right",
+      render: (e) => {
+        if (e.size_before == null && e.size_after == null) {
+          return <span className={`${ui.faint} ${ui.mono}`} style={{ fontSize: 12 }}>—</span>;
+        }
+        const d = (e.size_after ?? 0) - (e.size_before ?? 0);
+        const color = d > 0 ? "var(--green)" : d < 0 ? "var(--red)" : "var(--text-faint)";
+        return (
+          <span className={ui.mono} style={{ fontSize: 12, color }}>
+            {d > 0 ? "+" : ""}
+            {d.toLocaleString()}
+          </span>
+        );
+      },
+    },
+  ];
 
   return (
-    <Container size="lg">
-      <p className={ui.eyebrow}>History</p>
-      <Title order={2} mb="md">
-        Audit Log
-      </Title>
-
-      <Group mb="md" gap="sm" align="flex-end">
-        <Select
-          label="Operation"
-          placeholder="All operations"
-          data={OPERATIONS}
-          value={operation}
-          onChange={(v) => setOperation(v || "")}
-          clearable
-          w={180}
-          size="sm"
-        />
-        <TextInput
-          label="Author"
-          placeholder="Filter by author"
-          value={author}
-          onChange={(e) => setAuthor(e.currentTarget.value)}
-          leftSection={<IconSearch size={14} />}
-          w={180}
-          size="sm"
-        />
-        <TextInput
-          label="From"
-          type="date"
-          value={fromDate}
-          onChange={(e) => setFromDate(e.currentTarget.value)}
-          w={150}
-          size="sm"
-        />
-        <TextInput
-          label="To"
-          type="date"
-          value={toDate}
-          onChange={(e) => setToDate(e.currentTarget.value)}
-          w={150}
-          size="sm"
-        />
-        <Select
-          label="Max entries"
-          data={["100", "250", "500", "1000"]}
-          value={limit}
-          onChange={(v) => setLimit(v || "100")}
-          w={120}
-          size="sm"
-        />
-        <Text size="sm" c="dimmed" pb={6}>
-          {entries?.length ?? 0} shown
-        </Text>
-      </Group>
-
-      {isLoading ? (
-        <Group justify="center" mt="xl">
-          <Loader />
-        </Group>
-      ) : !entries || entries.length === 0 ? (
-        <Text c="dimmed">No audit log entries found.</Text>
-      ) : (
-        <Table striped highlightOnHover>
-          <Table.Thead>
-            <Table.Tr>
-              <Table.Th>Time</Table.Th>
-              <Table.Th>Operation</Table.Th>
-              <Table.Th>Author</Table.Th>
-              <Table.Th>Document</Table.Th>
-              <Table.Th>Description</Table.Th>
-              <Table.Th>Size</Table.Th>
-            </Table.Tr>
-          </Table.Thead>
-          <Table.Tbody>
-            {entries.map((e) => (
-              <Table.Tr key={e.id}>
-                <Table.Td>
-                  <Text size="xs" c="dimmed" style={{ whiteSpace: "nowrap" }}>
-                    {formatDateTime(e.created_at)}
-                  </Text>
-                </Table.Td>
-                <Table.Td>
-                  <Badge
-                    variant="light"
-                    size="sm"
-                    color={operationColor(e.operation)}
-                  >
-                    {e.operation}
-                  </Badge>
-                </Table.Td>
-                <Table.Td>
-                  <Group gap={4}>
-                    <Text size="sm">{e.author}</Text>
-                    <Badge
-                      variant="dot"
-                      size="xs"
-                      color={e.author_type === "agent" ? "violet" : "green"}
-                    >
-                      {e.author_type}
-                    </Badge>
-                  </Group>
-                </Table.Td>
-                <Table.Td>
-                  {e.document_id ? (
-                    <Anchor
-                      size="xs"
-                      onClick={(ev) => {
-                        ev.preventDefault();
-                        navigate(`/document/${e.document_id}`);
-                      }}
-                      href={`/app/document/${e.document_id}`}
-                    >
-                      {e.doc_title || e.document_id.slice(0, 8) + "..."}
-                    </Anchor>
-                  ) : (
-                    <Text size="xs" c="dimmed">
-                      (deleted)
-                    </Text>
-                  )}
-                </Table.Td>
-                <Table.Td>
-                  <Text size="xs" lineClamp={2}>
-                    {e.description}
-                  </Text>
-                </Table.Td>
-                <Table.Td>
-                  {e.size_before != null && e.size_after != null ? (
-                    <Text size="xs" c="dimmed">
-                      {e.size_before.toLocaleString()} {"->"} {e.size_after.toLocaleString()}
-                    </Text>
-                  ) : e.size_after != null ? (
-                    <Text size="xs" c="dimmed">
-                      {e.size_after.toLocaleString()}
-                    </Text>
-                  ) : null}
-                </Table.Td>
-              </Table.Tr>
-            ))}
-          </Table.Tbody>
-        </Table>
-      )}
-    </Container>
+    <ListPage<AuditEntry>
+      eyebrow="Every read & write"
+      title="Audit Log"
+      subtitle="A complete trail of changes — by human and agent alike."
+      headerRight={<CliHint cmd="cerefox audit list" />}
+      searchValue={query}
+      onSearchChange={setQuery}
+      searchPlaceholder="Filter by document or description…"
+      searchText={(e) => `${e.doc_title ?? ""} ${e.description ?? ""} ${e.author ?? ""}`}
+      toolbarExtra={
+        <>
+          <Select
+            data={OPERATIONS}
+            value={operation}
+            onChange={(v) => setOperation(v || "")}
+            placeholder="All operations"
+            size="sm"
+            w={170}
+            clearable
+          />
+          <TextInput
+            type="date"
+            aria-label="From"
+            value={fromDate}
+            onChange={(e) => setFromDate(e.currentTarget.value)}
+            size="sm"
+            w={150}
+          />
+          <TextInput
+            type="date"
+            aria-label="To"
+            value={toDate}
+            onChange={(e) => setToDate(e.currentTarget.value)}
+            size="sm"
+            w={150}
+          />
+          <Select
+            data={["100", "250", "500", "1000"]}
+            value={limit}
+            onChange={(v) => setLimit(v || "100")}
+            size="sm"
+            w={100}
+          />
+        </>
+      }
+      columns={columns}
+      rows={entries ?? []}
+      rowKey={(e) => e.id}
+      rowClick={(e) => e.document_id && navigate(`/document/${e.document_id}`)}
+      loading={isLoading}
+      emptyText="No audit log entries found."
+      pageSize={12}
+    />
   );
 }

--- a/frontend/src/pages/AuditLogPage.tsx
+++ b/frontend/src/pages/AuditLogPage.tsx
@@ -10,6 +10,7 @@ import {
   TextInput,
   Title,
 } from "@mantine/core";
+import ui from "../styles/redesign.module.css";
 import { IconSearch } from "@tabler/icons-react";
 import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
@@ -68,6 +69,7 @@ export function AuditLogPage() {
 
   return (
     <Container size="lg">
+      <p className={ui.eyebrow}>History</p>
       <Title order={2} mb="md">
         Audit Log
       </Title>

--- a/frontend/src/pages/DashboardPage.module.css
+++ b/frontend/src/pages/DashboardPage.module.css
@@ -1,0 +1,289 @@
+/* Dashboard (redesign) — page-specific layout.
+   Shared primitives (btn, badge, card, eyebrow, secHead, srcChip, …)
+   live in src/styles/redesign.module.css. Tokens in tokens.css. */
+
+.wrap {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 34px 24px 80px;
+}
+
+/* ---- hero ---- */
+.dashHero {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 26px;
+  flex-wrap: wrap;
+}
+.dashHeroActions {
+  display: flex;
+  gap: 10px;
+}
+.quickSearch {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  height: 40px;
+  padding: 0 6px 0 13px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 11px;
+  color: var(--text-faint);
+  transition: border-color 0.15s, box-shadow 0.15s;
+  min-width: 280px;
+}
+.quickSearch:focus-within {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px var(--primary-soft);
+}
+.quickSearch input {
+  flex: 1;
+  min-width: 0;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  font-family: var(--font-ui);
+  font-size: 14px;
+  color: var(--text);
+}
+.quickSearch input::placeholder { color: var(--text-faint); }
+.qsGo {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border: 0;
+  border-radius: 8px;
+  cursor: pointer;
+  background: var(--primary);
+  color: var(--on-primary);
+}
+.qsGo:hover { background: var(--primary-strong); }
+
+/* ---- stat strip ---- */
+.statGrid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 14px;
+  margin-bottom: 30px;
+}
+.statTile {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 18px;
+}
+.statTop {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 30px;
+}
+.statIco {
+  display: grid;
+  place-items: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 11px;
+}
+.statValue {
+  font-family: var(--font-display);
+  font-size: 32px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1;
+  color: var(--text);
+}
+.statLabel {
+  font-size: 13px;
+  color: var(--text-dim);
+}
+.emptyVal {
+  font-family: var(--font-display);
+  font-size: 32px;
+  font-weight: 600;
+  line-height: 1;
+  color: var(--text-faint);
+}
+
+/* ---- main split ---- */
+.dashSplit {
+  display: grid;
+  grid-template-columns: 1fr 360px;
+  gap: 26px;
+  align-items: start;
+}
+.dashRail {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+/* ---- recent table ---- */
+.tbl {
+  width: 100%;
+  border-collapse: collapse;
+}
+.tbl th {
+  text-align: left;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+  padding: 0 14px 10px;
+  border-bottom: 1px solid var(--border-soft);
+}
+.tbl td {
+  padding: 13px 14px;
+  border-bottom: 1px solid var(--border-soft);
+  font-size: 13.5px;
+  vertical-align: middle;
+}
+.tbl tbody tr {
+  transition: background 0.12s;
+  cursor: pointer;
+}
+.tbl tbody tr:hover { background: var(--surface-2); }
+.tbl tbody tr:last-child td { border-bottom: 0; }
+.alignRight { text-align: right; }
+
+.docCell {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+}
+.docDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.docTitle {
+  display: block;
+  max-width: 340px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 13.5px;
+}
+
+/* ---- projects rail ---- */
+.projList {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.projScroll {
+  max-height: 416px;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.projRow {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  padding: 10px 11px;
+  border-radius: 9px;
+  transition: background 0.12s;
+}
+.projRow:hover { background: var(--surface-2); }
+.projDot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.projName {
+  flex: 1;
+  min-width: 0;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.projCounts {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+  color: var(--text-faint);
+}
+.trashCount {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  color: var(--text-faint);
+}
+.projBar {
+  margin-top: 11px;
+  height: 5px;
+  border-radius: 3px;
+  background: var(--surface-2);
+  overflow: hidden;
+}
+.projBar span {
+  display: block;
+  height: 100%;
+  border-radius: 3px;
+  transition: width 0.6s cubic-bezier(0.2, 0.7, 0.3, 1);
+}
+.projChev {
+  color: var(--text-faint);
+  opacity: 0;
+  transition: opacity 0.12s;
+  flex-shrink: 0;
+}
+.projRow:hover .projChev { opacity: 1; }
+.projFoot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 11px 14px;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--text-dim);
+  background: var(--surface-2);
+  border-top: 1px solid var(--border-soft);
+}
+
+/* ---- CLI mirror ---- */
+.cliCard {
+  background: linear-gradient(160deg, var(--surface), var(--surface-2));
+  padding: 18px;
+}
+.cliBlock {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.7;
+  background: var(--bg);
+  border: 1px solid var(--border-soft);
+  border-radius: 10px;
+  padding: 12px 13px;
+}
+.cliP { color: var(--primary); margin-right: 7px; }
+.cliS { color: var(--green); }
+.cliOut { color: var(--text-faint); padding-left: 17px; }
+
+/* ---- responsive ---- */
+@media (max-width: 920px) {
+  .statGrid { grid-template-columns: repeat(2, 1fr); }
+  .dashSplit { grid-template-columns: 1fr; }
+}

--- a/frontend/src/pages/DashboardPage.module.css
+++ b/frontend/src/pages/DashboardPage.module.css
@@ -264,24 +264,6 @@
   border-top: 1px solid var(--border-soft);
 }
 
-/* ---- CLI mirror ---- */
-.cliCard {
-  background: linear-gradient(160deg, var(--surface), var(--surface-2));
-  padding: 18px;
-}
-.cliBlock {
-  font-family: var(--font-mono);
-  font-size: 12px;
-  line-height: 1.7;
-  background: var(--bg);
-  border: 1px solid var(--border-soft);
-  border-radius: 10px;
-  padding: 12px 13px;
-}
-.cliP { color: var(--primary); margin-right: 7px; }
-.cliS { color: var(--green); }
-.cliOut { color: var(--text-faint); padding-left: 17px; }
-
 /* ---- responsive ---- */
 @media (max-width: 920px) {
   .statGrid { grid-template-columns: repeat(2, 1fr); }

--- a/frontend/src/pages/DashboardPage.module.css
+++ b/frontend/src/pages/DashboardPage.module.css
@@ -5,7 +5,7 @@
 .wrap {
   max-width: 1120px;
   margin: 0 auto;
-  padding: 34px 24px 80px;
+  padding: 8px 24px 80px;
 }
 
 /* ---- hero ---- */

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -102,8 +102,7 @@ export function DashboardPage() {
           <p className={ui.eyebrow}>Memory layer · online</p>
           <h1 className={ui.pageTitle}>{greeting()}, operator.</h1>
           <p className={ui.pageSub}>
-            Indexing <b>{(data?.total_chunks ?? 0).toLocaleString()}</b> chunks across{" "}
-            <b>{data?.project_count ?? 0}</b> projects.
+            Asynchronous shared memory for your agents — one store across CLI, MCP, and web.
           </p>
         </div>
         <div className={styles.dashHeroActions}>
@@ -142,6 +141,9 @@ export function DashboardPage() {
             <span className={`${styles.statIco} ${ui.bPrimary}`}>
               <IconDatabase size={18} />
             </span>
+            {trashTotal > 0 && (
+              <span className={`${ui.badge} ${ui.bNeutral}`}>{trashTotal} docs in trash</span>
+            )}
           </div>
           <div className={styles.statValue}>{(data?.doc_count ?? 0).toLocaleString()}</div>
           <div className={styles.statLabel}>Documents</div>
@@ -165,9 +167,6 @@ export function DashboardPage() {
             <span className={`${styles.statIco} ${ui.bBlue}`}>
               <IconFolder size={18} />
             </span>
-            {trashTotal > 0 && (
-              <span className={`${ui.badge} ${ui.bBlue}`}>{trashTotal} docs in trash</span>
-            )}
           </div>
           <div className={styles.statValue}>{data?.project_count ?? 0}</div>
           <div className={styles.statLabel}>Projects</div>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,228 +1,386 @@
+import { Popover, Text } from "@mantine/core";
 import {
-  Anchor,
-  Badge,
-  Button,
-  Card,
-  Container,
-  Group,
-  SimpleGrid,
-  Skeleton,
-  Stack,
-  Table,
-  Text,
-  TextInput,
-  Title,
-} from "@mantine/core";
-import { IconDatabase, IconFolder, IconList, IconSearch } from "@tabler/icons-react";
+  IconArrowRight,
+  IconChevronRight,
+  IconClock,
+  IconDatabase,
+  IconFileText,
+  IconFolder,
+  IconLink,
+  IconMapPin,
+  IconPlus,
+  IconSearch,
+  IconSparkles,
+  IconStack2,
+  IconTerminal2,
+  IconTrash,
+} from "@tabler/icons-react";
 import { useQuery } from "@tanstack/react-query";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
+import { fetchUsageSummary } from "../api/analytics";
 import { fetchDashboard } from "../api/dashboard";
-import { useProjects } from "../hooks/useProjects";
+import type { DashboardDoc } from "../api/types";
+import ui from "../styles/redesign.module.css";
 import { formatDateTime } from "../utils/dates";
+import styles from "./DashboardPage.module.css";
+
+const PROJECT_COLORS = ["--primary", "--violet", "--blue", "--green", "--yellow", "--red"];
+
+function fmtChars(n: number): string {
+  if (n >= 1e6) return `${(n / 1e6).toFixed(2)}M`;
+  if (n >= 1e3) return `${(n / 1e3).toFixed(1)}k`;
+  return String(n);
+}
+
+function greeting(): string {
+  const h = new Date().getHours();
+  if (h < 12) return "Good morning";
+  if (h < 18) return "Good afternoon";
+  return "Good evening";
+}
+
+function sourceChip(source: string | null): { icon: typeof IconMapPin; label: string; agent: boolean } {
+  const s = (source ?? "manual").toLowerCase();
+  switch (s) {
+    case "agent":
+      return { icon: IconSparkles, label: "agent", agent: true };
+    case "cli":
+      return { icon: IconTerminal2, label: "cli", agent: false };
+    case "file":
+      return { icon: IconFileText, label: "file", agent: false };
+    case "paste":
+      return { icon: IconFileText, label: "paste", agent: false };
+    case "url":
+      return { icon: IconLink, label: "url", agent: false };
+    default:
+      return { icon: IconMapPin, label: s, agent: false };
+  }
+}
 
 export function DashboardPage() {
   const navigate = useNavigate();
-  const [quickSearch, setQuickSearch] = useState("");
-  const { data, isLoading } = useQuery({
-    queryKey: ["dashboard"],
-    queryFn: fetchDashboard,
+  const [quick, setQuick] = useState("");
+  const { data } = useQuery({ queryKey: ["dashboard"], queryFn: fetchDashboard });
+
+  // Agent activity over the last 30 days (from the usage log, if tracking is on).
+  const since = useMemo(() => new Date(Date.now() - 30 * 864e5).toISOString(), []);
+  const { data: usage } = useQuery({
+    queryKey: ["usage-summary-30d", since],
+    queryFn: () => fetchUsageSummary({ start: since }),
+    staleTime: 60_000,
   });
-  const { data: projects } = useProjects();
+  const pathOps = (p: string) =>
+    usage?.ops_by_access_path.find((x) => x.access_path === p)?.count ?? 0;
+  const mcpOps = pathOps("remote-mcp") + pathOps("local-mcp");
+  const efOps = pathOps("edge-function");
+  const agentOps = mcpOps + efOps;
 
-  const projectMap = new Map(
-    projects?.map((p) => [p.id, p.name]) ?? [],
+  const projectMap = new Map((data?.projects ?? []).map((p) => [p.id, p.name]));
+  const colorMap = new Map(
+    (data?.projects ?? []).map((p, i) => [p.id, PROJECT_COLORS[i % PROJECT_COLORS.length]]),
   );
+  const docCounts = data?.project_doc_counts ?? {};
+  const trashCounts = data?.project_deleted_doc_counts ?? {};
+  const trashTotal = Object.values(trashCounts).reduce((a, b) => a + b, 0);
+  const maxDocs = Math.max(1, ...Object.values(docCounts));
 
-  const handleQuickSearch = () => {
-    if (quickSearch.trim()) {
-      navigate(`/search?q=${encodeURIComponent(quickSearch.trim())}&mode=docs`);
-    } else {
-      navigate("/search");
-    }
+  const goSearch = () => {
+    const q = quick.trim();
+    navigate(q ? `/search?q=${encodeURIComponent(q)}&mode=docs` : "/search");
   };
 
-  return (
-    <Container size="lg">
-      <Title order={2} mb="md">
-        Dashboard
-      </Title>
+  const projColor = (doc: DashboardDoc) =>
+    `var(${colorMap.get(doc.project_ids[0]) ?? "--border"})`;
 
-      <SimpleGrid cols={{ base: 1, sm: 3 }} mb="xl">
-        <Card shadow="xs" padding="md" radius="md" withBorder>
-          <Group align="center">
-            <IconDatabase size={24} color="var(--mantine-color-blue-6)" />
-            <Text size="xl" fw={700}>
-              {isLoading ? <Skeleton width={30} height={24} /> : data?.doc_count ?? 0}
-            </Text>
-            <Text size="sm" c="dimmed">
-              Documents
-            </Text>
-          </Group>
-        </Card>
-        <Card shadow="xs" padding="md" radius="md" withBorder>
-          <Group align="center">
-            <IconFolder size={24} color="var(--mantine-color-green-6)" />
-            <Text size="xl" fw={700}>
-              {isLoading ? <Skeleton width={30} height={24} /> : data?.project_count ?? 0}
-            </Text>
-            <Text size="sm" c="dimmed">
-              Projects
-            </Text>
-          </Group>
-        </Card>
-        <Card shadow="xs" padding="md" radius="md" withBorder>
+  return (
+    <div className={styles.wrap}>
+      {/* hero */}
+      <div className={`${styles.dashHero} ${ui.rise}`}>
+        <div style={{ minWidth: 0 }}>
+          <p className={ui.eyebrow}>Memory layer · online</p>
+          <h1 className={ui.pageTitle}>{greeting()}, operator.</h1>
+          <p className={ui.pageSub}>
+            Indexing <b>{(data?.total_chunks ?? 0).toLocaleString()}</b> chunks across{" "}
+            <b>{data?.project_count ?? 0}</b> projects.
+          </p>
+        </div>
+        <div className={styles.dashHeroActions}>
           <form
+            className={styles.quickSearch}
             onSubmit={(e) => {
               e.preventDefault();
-              handleQuickSearch();
+              goSearch();
             }}
-            style={{ display: "flex", alignItems: "center", height: "100%" }}
           >
-            <Group gap="xs" w="100%" align="center">
-              <TextInput
-                placeholder="Quick search..."
-                value={quickSearch}
-                onChange={(e) => setQuickSearch(e.currentTarget.value)}
-                leftSection={<IconSearch size={16} />}
-                style={{ flex: 1 }}
-                size="sm"
-              />
-              <Button type="submit" size="sm" variant="light">
-                Go
-              </Button>
-            </Group>
+            <IconSearch size={16} />
+            <input
+              value={quick}
+              onChange={(e) => setQuick(e.currentTarget.value)}
+              placeholder="Quick search…"
+            />
+            <button type="submit" className={styles.qsGo} aria-label="Search">
+              <IconArrowRight size={15} />
+            </button>
           </form>
-        </Card>
-      </SimpleGrid>
+          <button
+            type="button"
+            className={`${ui.btn} ${ui.btnPrimary}`}
+            onClick={() => navigate("/ingest")}
+          >
+            <IconPlus size={16} />
+            Ingest content
+          </button>
+        </div>
+      </div>
 
-      <Title order={4} mb="sm">
-        Recent Documents
-      </Title>
-      {isLoading ? (
-        <Stack gap="xs">
-          {[1, 2, 3].map((i) => (
-            <Skeleton key={i} height={40} />
-          ))}
-        </Stack>
-      ) : (
-        <Table striped highlightOnHover>
-          <Table.Thead>
-            <Table.Tr>
-              <Table.Th>Title</Table.Th>
-              <Table.Th>Chunks</Table.Th>
-              <Table.Th>Size</Table.Th>
-              <Table.Th>Updated</Table.Th>
-            </Table.Tr>
-          </Table.Thead>
-          <Table.Tbody>
-            {data?.recent_docs.map((doc) => (
-              <Table.Tr key={doc.id}>
-                <Table.Td>
-                  <Group gap="xs">
-                    <Anchor
-                      href={`/app/document/${doc.id}`}
-                      onClick={(e) => {
-                        e.preventDefault();
-                        navigate(`/document/${doc.id}`);
-                      }}
-                      fw={500}
-                      size="sm"
-                    >
-                      {doc.title || "Untitled"}
-                    </Anchor>
-                    {doc.project_ids
-                      .filter((pid) => projectMap.has(pid))
-                      .map((pid) => (
-                        <Badge key={pid} variant="light" size="xs">
-                          {projectMap.get(pid)}
-                        </Badge>
-                      ))}
-                    <Badge
-                      variant="light"
-                      size="xs"
-                      color={doc.review_status === "approved" ? "green" : "yellow"}
-                    >
-                      {doc.review_status === "approved" ? "Approved" : "Pending"}
-                    </Badge>
-                  </Group>
-                </Table.Td>
-                <Table.Td>
-                  <Text size="sm">{doc.chunk_count}</Text>
-                </Table.Td>
-                <Table.Td>
-                  <Text size="sm">{doc.total_chars.toLocaleString()}</Text>
-                </Table.Td>
-                <Table.Td>
-                  <Text size="sm" c="dimmed">
-                    {formatDateTime(doc.updated_at)}
+      {/* stat strip */}
+      <div className={styles.statGrid}>
+        <div className={`${ui.card} ${styles.statTile} ${ui.rise}`}>
+          <div className={styles.statTop}>
+            <span className={`${styles.statIco} ${ui.bPrimary}`}>
+              <IconDatabase size={18} />
+            </span>
+          </div>
+          <div className={styles.statValue}>{(data?.doc_count ?? 0).toLocaleString()}</div>
+          <div className={styles.statLabel}>Documents</div>
+        </div>
+
+        <div className={`${ui.card} ${styles.statTile} ${ui.rise}`}>
+          <div className={styles.statTop}>
+            <span className={`${styles.statIco} ${ui.bViolet}`}>
+              <IconStack2 size={18} />
+            </span>
+            <span className={`${ui.badge} ${ui.bViolet}`}>
+              {fmtChars(data?.total_chars ?? 0)} chars
+            </span>
+          </div>
+          <div className={styles.statValue}>{(data?.total_chunks ?? 0).toLocaleString()}</div>
+          <div className={styles.statLabel}>Indexed chunks</div>
+        </div>
+
+        <div className={`${ui.card} ${styles.statTile} ${ui.rise}`}>
+          <div className={styles.statTop}>
+            <span className={`${styles.statIco} ${ui.bBlue}`}>
+              <IconFolder size={18} />
+            </span>
+            {trashTotal > 0 && (
+              <span className={`${ui.badge} ${ui.bBlue}`}>{trashTotal} docs in trash</span>
+            )}
+          </div>
+          <div className={styles.statValue}>{data?.project_count ?? 0}</div>
+          <div className={styles.statLabel}>Projects</div>
+        </div>
+
+        {/* Agent activity — ops via MCP/edge-function paths over the last 30 days */}
+        <div className={`${ui.card} ${styles.statTile} ${ui.rise}`}>
+          <div className={styles.statTop}>
+            <span className={`${styles.statIco} ${ui.bGreen}`}>
+              <IconSparkles size={18} />
+            </span>
+            {agentOps > 0 ? (
+              <span className={`${ui.badge} ${ui.bGreen}`}>
+                {mcpOps.toLocaleString()} mcp · {efOps.toLocaleString()} edge
+              </span>
+            ) : (
+              <Popover width={260} position="bottom-end" withArrow shadow="md">
+                <Popover.Target>
+                  <button type="button" className={ui.whatis}>
+                    Why no data?
+                  </button>
+                </Popover.Target>
+                <Popover.Dropdown>
+                  <Text size="xs" c="dimmed">
+                    No agent activity (MCP or Edge Function) in the last 30 days. Agent ops are
+                    recorded in the usage log, which is <b>opt-in</b> — enable it with{" "}
+                    <code>cerefox config set usage_tracking_enabled true</code> if it's off.
                   </Text>
-                </Table.Td>
-              </Table.Tr>
-            ))}
-          </Table.Tbody>
-        </Table>
-      )}
+                </Popover.Dropdown>
+              </Popover>
+            )}
+          </div>
+          <div className={agentOps > 0 ? styles.statValue : styles.emptyVal}>
+            {agentOps > 0 ? agentOps.toLocaleString() : "—"}
+          </div>
+          <div className={styles.statLabel}>Agent activity · 30d</div>
+        </div>
+      </div>
 
-      {data && data.projects.length > 0 && (
-        <>
-          <Title order={4} mt="xl" mb="sm">
-            Projects
-          </Title>
-          <Table striped highlightOnHover>
-            <Table.Thead>
-              <Table.Tr>
-                <Table.Th>Name</Table.Th>
-                <Table.Th>Description</Table.Th>
-                <Table.Th>Documents</Table.Th>
-              </Table.Tr>
-            </Table.Thead>
-            <Table.Tbody>
-              {data.projects.map((p) => {
-                const docCount = data.project_doc_counts[p.id] ?? 0;
-                const deletedCount = data.project_deleted_doc_counts?.[p.id] ?? 0;
-                return (
-                  <Table.Tr key={p.id}>
-                    <Table.Td>
-                      <Text fw={600} size="sm">
-                        {p.name}
-                      </Text>
-                    </Table.Td>
-                    <Table.Td>
-                      <Text size="sm" c="dimmed" lineClamp={1}>
-                        {p.description || ""}
-                      </Text>
-                    </Table.Td>
-                    <Table.Td>
-                      <Group gap="xs">
-                        <Text size="sm">{docCount}</Text>
-                        {deletedCount > 0 && (
-                          <Text size="xs" c="dimmed">
-                            ({deletedCount} in trash)
-                          </Text>
-                        )}
-                        {docCount > 0 && (
-                          <Button
-                            variant="subtle"
-                            size="compact-xs"
-                            leftSection={<IconList size={12} />}
-                            onClick={() =>
-                              navigate(`/projects/${p.id}/documents`)
-                            }
-                          >
-                            List
-                          </Button>
-                        )}
-                      </Group>
-                    </Table.Td>
-                  </Table.Tr>
-                );
-              })}
-            </Table.Tbody>
-          </Table>
-        </>
-      )}
-    </Container>
+      {/* main split */}
+      <div className={styles.dashSplit}>
+        <section className={ui.rise}>
+          <div className={ui.secHead}>
+            <h2 className={ui.secTitle}>
+              <IconClock size={16} />
+              Recently changed documents
+            </h2>
+            <button
+              type="button"
+              className={`${ui.btn} ${ui.btnSubtle}`}
+              onClick={() => navigate("/search")}
+            >
+              View all
+              <IconArrowRight size={14} />
+            </button>
+          </div>
+          <div className={ui.card} style={{ overflow: "hidden" }}>
+            <table className={styles.tbl}>
+              <thead>
+                <tr>
+                  <th>Document</th>
+                  <th>Origin</th>
+                  <th className={styles.alignRight}>Chunks</th>
+                  <th className={styles.alignRight}>Size</th>
+                  <th className={styles.alignRight}>Updated</th>
+                </tr>
+              </thead>
+              <tbody>
+                {(data?.recent_docs ?? []).map((doc) => {
+                  const chip = sourceChip(doc.source);
+                  const ChipIcon = chip.icon;
+                  const pending = doc.review_status !== "approved";
+                  return (
+                    <tr key={doc.id} onClick={() => navigate(`/document/${doc.id}`)}>
+                      <td>
+                        <div className={styles.docCell}>
+                          <span className={styles.docDot} style={{ background: projColor(doc) }} />
+                          <div className={ui.col} style={{ gap: 3, minWidth: 0 }}>
+                            <span className={`${ui.link} ${styles.docTitle}`}>
+                              {doc.title || "Untitled"}
+                            </span>
+                            <div className={ui.row} style={{ gap: 6 }}>
+                              {doc.project_ids
+                                .filter((pid) => projectMap.has(pid))
+                                .slice(0, 1)
+                                .map((pid) => (
+                                  <span key={pid} className={`${ui.badge} ${ui.bNeutral}`}>
+                                    {projectMap.get(pid)}
+                                  </span>
+                                ))}
+                              {pending && (
+                                <span className={`${ui.badge} ${ui.bYellow}`}>
+                                  <span
+                                    style={{
+                                      width: 6,
+                                      height: 6,
+                                      borderRadius: "50%",
+                                      background: "currentColor",
+                                    }}
+                                  />
+                                  pending review
+                                </span>
+                              )}
+                            </div>
+                          </div>
+                        </div>
+                      </td>
+                      <td>
+                        <span className={`${ui.srcChip} ${chip.agent ? ui.srcChipAgent : ""}`}>
+                          <ChipIcon size={12} />
+                          {chip.label}
+                        </span>
+                      </td>
+                      <td className={`${styles.alignRight} ${ui.mono} ${ui.dim}`}>
+                        {doc.chunk_count}
+                      </td>
+                      <td className={`${styles.alignRight} ${ui.mono} ${ui.dim}`}>
+                        {doc.total_chars.toLocaleString()}
+                      </td>
+                      <td className={`${styles.alignRight} ${ui.faint}`}>
+                        {formatDateTime(doc.updated_at)}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <aside className={styles.dashRail}>
+          <section className={ui.rise} style={{ minHeight: 0 }}>
+            <div className={ui.secHead}>
+              <h2 className={ui.secTitle}>
+                <IconStack2 size={16} />
+                Projects <span className={ui.countPill}>{data?.project_count ?? 0}</span>
+              </h2>
+              <button
+                type="button"
+                className={`${ui.btn} ${ui.btnSubtle}`}
+                onClick={() => navigate("/projects")}
+              >
+                Manage
+              </button>
+            </div>
+            <div className={`${ui.card} ${styles.projList}`}>
+              <div className={styles.projScroll}>
+                {(data?.projects ?? []).map((p) => {
+                  const docs = docCounts[p.id] ?? 0;
+                  const trash = trashCounts[p.id] ?? 0;
+                  const color = `var(${colorMap.get(p.id) ?? "--border"})`;
+                  return (
+                    <button
+                      key={p.id}
+                      type="button"
+                      className={styles.projRow}
+                      onClick={() => navigate(`/projects/${p.id}/documents`)}
+                    >
+                      <span className={styles.projDot} style={{ background: color }} />
+                      <div className={ui.col} style={{ gap: 5, minWidth: 0, flex: 1 }}>
+                        <div className={ui.row} style={{ justifyContent: "space-between", gap: 8 }}>
+                          <span className={styles.projName}>{p.name}</span>
+                          <span className={styles.projCounts}>
+                            <span>{docs}</span>
+                            {trash > 0 && (
+                              <span className={styles.trashCount} title={`${trash} in trash`}>
+                                <IconTrash size={11} />
+                                {trash}
+                              </span>
+                            )}
+                          </span>
+                        </div>
+                        <div className={styles.projBar}>
+                          <span style={{ width: `${(docs / maxDocs) * 100}%`, background: color }} />
+                        </div>
+                      </div>
+                      <span className={styles.projChev}>
+                        <IconChevronRight size={15} />
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+              <div className={styles.projFoot}>
+                <span>{data?.project_count ?? 0} projects</span>
+                <span className={ui.faint}>{trashTotal} docs in trash</span>
+              </div>
+            </div>
+          </section>
+
+          <section className={`${ui.card} ${styles.cliCard} ${ui.rise}`}>
+            <div className={ui.row} style={{ gap: 8, marginBottom: 10 }}>
+              <IconTerminal2 size={15} />
+              <span style={{ fontWeight: 600, fontSize: 13.5 }}>Same memory, your terminal</span>
+            </div>
+            <div className={styles.cliBlock}>
+              <div>
+                <span className={styles.cliP}>$</span> cerefox search{" "}
+                <span className={styles.cliS}>"retry backoff"</span>
+              </div>
+              <div className={styles.cliOut}>→ 5 results · top 92% match</div>
+              <div style={{ marginTop: 6 }}>
+                <span className={styles.cliP}>$</span> cerefox document ingest ./rfc-018.md
+              </div>
+              <div className={styles.cliOut}>→ staged in research-notes</div>
+            </div>
+            <p className={ui.faint} style={{ fontSize: 12, margin: "10px 0 0", lineHeight: 1.5 }}>
+              The same memory from your terminal or any MCP agent — most actions
+              have CLI, MCP, and web parity.
+            </p>
+          </section>
+        </aside>
+      </div>
+    </div>
   );
 }

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -101,9 +101,6 @@ export function DashboardPage() {
         <div style={{ minWidth: 0 }}>
           <p className={ui.eyebrow}>Memory layer · online</p>
           <h1 className={ui.pageTitle}>{greeting()}, operator.</h1>
-          <p className={ui.pageSub}>
-            Asynchronous shared memory for your agents — one store across CLI, MCP, and web.
-          </p>
         </div>
         <div className={styles.dashHeroActions}>
           <form
@@ -361,6 +358,14 @@ export function DashboardPage() {
             <div className={ui.row} style={{ gap: 8, marginBottom: 10 }}>
               <IconTerminal2 size={15} />
               <span style={{ fontWeight: 600, fontSize: 13.5 }}>Same memory, your terminal</span>
+              <button
+                type="button"
+                className={ui.whatis}
+                style={{ marginLeft: "auto" }}
+                onClick={() => navigate("/help/guides/cli.md")}
+              >
+                cli docs
+              </button>
             </div>
             <div className={ui.cliBlock}>
               <div>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -358,21 +358,21 @@ export function DashboardPage() {
             </div>
           </section>
 
-          <section className={`${ui.card} ${styles.cliCard} ${ui.rise}`}>
+          <section className={`${ui.card} ${ui.cliCard} ${ui.rise}`}>
             <div className={ui.row} style={{ gap: 8, marginBottom: 10 }}>
               <IconTerminal2 size={15} />
               <span style={{ fontWeight: 600, fontSize: 13.5 }}>Same memory, your terminal</span>
             </div>
-            <div className={styles.cliBlock}>
+            <div className={ui.cliBlock}>
               <div>
-                <span className={styles.cliP}>$</span> cerefox search{" "}
-                <span className={styles.cliS}>"retry backoff"</span>
+                <span className={ui.cliP}>$</span> cerefox search{" "}
+                <span className={ui.cliS}>"retry backoff"</span>
               </div>
-              <div className={styles.cliOut}>→ 5 results · top 92% match</div>
+              <div className={ui.cliOut}>→ 5 results · top 92% match</div>
               <div style={{ marginTop: 6 }}>
-                <span className={styles.cliP}>$</span> cerefox document ingest ./rfc-018.md
+                <span className={ui.cliP}>$</span> cerefox document ingest ./rfc-018.md
               </div>
-              <div className={styles.cliOut}>→ staged in research-notes</div>
+              <div className={ui.cliOut}>→ staged in research-notes</div>
             </div>
             <p className={ui.faint} style={{ fontSize: 12, margin: "10px 0 0", lineHeight: 1.5 }}>
               The same memory from your terminal or any MCP agent — most actions

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -225,7 +225,7 @@ export function DashboardPage() {
               <thead>
                 <tr>
                   <th>Document</th>
-                  <th>Origin</th>
+                  <th>Author</th>
                   <th className={styles.alignRight}>Chunks</th>
                   <th className={styles.alignRight}>Size</th>
                   <th className={styles.alignRight}>Updated</th>
@@ -233,7 +233,13 @@ export function DashboardPage() {
               </thead>
               <tbody>
                 {(data?.recent_docs ?? []).map((doc) => {
-                  const chip = sourceChip(doc.source);
+                  const chip = doc.author
+                    ? {
+                        icon: doc.author_type === "agent" ? IconSparkles : IconMapPin,
+                        label: doc.author,
+                        agent: doc.author_type === "agent",
+                      }
+                    : sourceChip(doc.source);
                   const ChipIcon = chip.icon;
                   const pending = doc.review_status !== "approved";
                   return (

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -203,7 +203,7 @@ export function DashboardPage() {
           <div className={agentOps > 0 ? styles.statValue : styles.emptyVal}>
             {agentOps > 0 ? agentOps.toLocaleString() : "—"}
           </div>
-          <div className={styles.statLabel}>Agent activity · 30d</div>
+          <div className={styles.statLabel}>Agent operations · 30d</div>
         </div>
       </div>
 

--- a/frontend/src/pages/DocumentPage.module.css
+++ b/frontend/src/pages/DocumentPage.module.css
@@ -1,0 +1,278 @@
+/* Document (redesign) — page-specific layout.
+   Shared primitives in src/styles/redesign.module.css; tokens in tokens.css. */
+
+.wrap {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 24px 24px 80px;
+}
+
+.backBtn {
+  margin-bottom: 16px;
+  padding-left: 6px;
+}
+
+/* ---- header ---- */
+.docHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 22px;
+}
+.docTitle {
+  font-family: var(--font-display);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  font-size: 27px;
+  line-height: 1.15;
+  margin: 0;
+  color: var(--text);
+}
+.docMeta {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-top: 12px;
+  flex-wrap: wrap;
+  font-size: 12px;
+}
+.reviewPill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-dim);
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--border-soft);
+  background: var(--surface-2);
+  cursor: pointer;
+  font-family: inherit;
+}
+.reviewPill .dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+}
+
+/* ---- trash banner ---- */
+.trashBanner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 16px;
+  margin-bottom: 18px;
+  border-radius: var(--radius-card);
+  border: 1px solid var(--red);
+  background: var(--red-soft);
+  flex-wrap: wrap;
+}
+
+/* ---- split ---- */
+.docSplit {
+  display: grid;
+  grid-template-columns: 1fr 290px;
+  gap: 26px;
+  align-items: start;
+}
+.docRail {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  position: sticky;
+  top: 72px;
+}
+
+/* ---- content card ---- */
+.contentHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.docSource {
+  margin: 0;
+  padding: 18px;
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  line-height: 1.7;
+  color: var(--text-dim);
+  white-space: pre-wrap;
+  overflow: auto;
+}
+.mdBody {
+  padding: 8px 22px 24px;
+}
+
+/* ---- chunks ---- */
+.chunkList {
+  display: flex;
+  flex-direction: column;
+}
+.chunkItem {
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border-soft);
+}
+.chunkItem:last-child {
+  border-bottom: 0;
+}
+.chunkHead {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  font-size: 12px;
+  margin-bottom: 7px;
+}
+.chunkBody {
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  line-height: 1.65;
+  color: var(--text-dim);
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+/* ---- rail bits ---- */
+.railTitle {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+  margin-bottom: 10px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  white-space: nowrap;
+}
+.toc {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: 320px;
+  overflow-y: auto;
+}
+.tocLink {
+  font-size: 13px;
+  color: var(--text-dim);
+  text-decoration: none;
+  padding: 5px 10px;
+  border-radius: 7px;
+  border-left: 2px solid transparent;
+  cursor: pointer;
+  transition: all 0.12s;
+  text-align: left;
+  background: transparent;
+  border-top: 0;
+  border-right: 0;
+  border-bottom: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.tocLink:hover {
+  color: var(--text);
+  background: var(--surface-2);
+}
+.tocLvl2 {
+  padding-left: 22px;
+  font-size: 12.5px;
+  color: var(--text-faint);
+}
+.tocLvl3 {
+  padding-left: 34px;
+  font-size: 12px;
+  color: var(--text-faint);
+}
+
+.metaDl {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 7px 14px;
+  margin: 0;
+}
+.metaDl dt {
+  font-size: 12.5px;
+  color: var(--text-faint);
+}
+.metaDl dd {
+  font-size: 12.5px;
+  color: var(--text);
+  margin: 0;
+  text-align: right;
+}
+.metaTags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.metaTag {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  padding: 4px 8px;
+  border-radius: 7px;
+  background: var(--surface-2);
+  color: var(--text-dim);
+  display: inline-flex;
+  gap: 5px;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.metaTag b {
+  color: var(--text-faint);
+  font-weight: 500;
+}
+
+.verList {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.verRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.verLock {
+  color: var(--blue);
+  display: inline-flex;
+}
+
+.actList {
+  display: flex;
+  flex-direction: column;
+  gap: 13px;
+  max-height: 360px;
+  overflow-y: auto;
+}
+.actRow {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+}
+.actDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-top: 5px;
+  flex-shrink: 0;
+}
+.actAgent {
+  color: var(--violet);
+}
+
+@media (max-width: 860px) {
+  .docSplit {
+    grid-template-columns: 1fr;
+  }
+  .docRail {
+    position: static;
+  }
+}

--- a/frontend/src/pages/DocumentPage.module.css
+++ b/frontend/src/pages/DocumentPage.module.css
@@ -4,7 +4,7 @@
 .wrap {
   max-width: 1120px;
   margin: 0 auto;
-  padding: 14px 24px 80px;
+  padding: 6px 24px 80px;
 }
 
 .backBtn {
@@ -164,23 +164,22 @@
   overflow-y: auto;
 }
 .tocLink {
+  display: block;
+  width: 100%;
+  font-family: var(--font-ui);
   font-size: 13px;
-  line-height: 1.35;
+  line-height: 1.4;
   color: var(--text-dim);
   text-decoration: none;
   padding: 5px 10px;
   border-radius: 7px;
   cursor: pointer;
-  transition: all 0.12s;
+  transition: background 0.12s, color 0.12s;
   text-align: left;
   background: transparent;
   border: 0;
   white-space: normal;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
+  word-break: break-word;
 }
 .tocLink:hover {
   color: var(--text);

--- a/frontend/src/pages/DocumentPage.module.css
+++ b/frontend/src/pages/DocumentPage.module.css
@@ -4,11 +4,11 @@
 .wrap {
   max-width: 1120px;
   margin: 0 auto;
-  padding: 24px 24px 80px;
+  padding: 14px 24px 80px;
 }
 
 .backBtn {
-  margin-bottom: 16px;
+  margin-bottom: 12px;
   padding-left: 6px;
 }
 
@@ -95,6 +95,11 @@
   gap: 12px;
   flex-wrap: wrap;
 }
+/* scrollable content region (own scrollbar, independent of the rail) */
+.contentScroll {
+  max-height: calc(100vh - 210px);
+  overflow-y: auto;
+}
 .docSource {
   margin: 0;
   padding: 18px;
@@ -103,7 +108,6 @@
   line-height: 1.7;
   color: var(--text-dim);
   white-space: pre-wrap;
-  overflow: auto;
 }
 .mdBody {
   padding: 8px 22px 24px;
@@ -113,13 +117,14 @@
 .chunkList {
   display: flex;
   flex-direction: column;
+  gap: 10px;
+  padding: 14px;
 }
 .chunkItem {
-  padding: 14px 18px;
-  border-bottom: 1px solid var(--border-soft);
-}
-.chunkItem:last-child {
-  border-bottom: 0;
+  padding: 12px 14px;
+  border: 1px solid var(--border-soft);
+  border-radius: 10px;
+  background: var(--surface-2);
 }
 .chunkHead {
   display: flex;
@@ -160,34 +165,34 @@
 }
 .tocLink {
   font-size: 13px;
+  line-height: 1.35;
   color: var(--text-dim);
   text-decoration: none;
   padding: 5px 10px;
   border-radius: 7px;
-  border-left: 2px solid transparent;
   cursor: pointer;
   transition: all 0.12s;
   text-align: left;
   background: transparent;
-  border-top: 0;
-  border-right: 0;
-  border-bottom: 0;
-  white-space: nowrap;
+  border: 0;
+  white-space: normal;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
   overflow: hidden;
-  text-overflow: ellipsis;
 }
 .tocLink:hover {
   color: var(--text);
   background: var(--surface-2);
 }
 .tocLvl2 {
-  padding-left: 22px;
+  padding-left: 18px;
   font-size: 12.5px;
-  color: var(--text-faint);
 }
 .tocLvl3 {
-  padding-left: 34px;
-  font-size: 12px;
+  padding-left: 28px;
+  font-size: 12.5px;
   color: var(--text-faint);
 }
 

--- a/frontend/src/pages/DocumentPage.tsx
+++ b/frontend/src/pages/DocumentPage.tsx
@@ -1,107 +1,167 @@
+import { Loader, Menu, Modal } from "@mantine/core";
 import {
-  Accordion,
-  Badge,
-  Button,
-  Card,
-  Code,
-  Container,
-  Divider,
-  Group,
-  Loader,
-  Modal,
-  SegmentedControl,
-  Stack,
-  Table,
-  Text,
-  Title,
-} from "@mantine/core";
-import {
+  IconArrowLeft,
   IconArrowsDiff,
+  IconDots,
   IconDownload,
   IconEdit,
+  IconFileText,
   IconLock,
-  IconLockOpen,
+  IconMapPin,
+  IconSparkles,
+  IconStack2,
+  IconTerminal2,
   IconTrash,
 } from "@tabler/icons-react";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
+import ReactMarkdown from "react-markdown";
 import { useNavigate, useParams } from "react-router-dom";
-import { useState } from "react";
+import remarkGfm from "remark-gfm";
 
 import { fetchAuditLog, setReviewStatus, setVersionArchived } from "../api/audit";
-import { fetchDocument, fetchChunks, deleteDocument, fetchDocumentVersion, getDownloadUrl } from "../api/documents";
-import { restoreDocument, purgeDocument } from "../api/trash";
+import {
+  deleteDocument,
+  fetchChunks,
+  fetchDocument,
+  fetchDocumentVersion,
+  getDownloadUrl,
+} from "../api/documents";
+import { purgeDocument, restoreDocument } from "../api/trash";
 import { DiffViewer } from "../components/DiffViewer";
-import { MarkdownViewer } from "../components/MarkdownViewer";
+import { MarkdownLink } from "../components/MarkdownLink";
 import { useProjects } from "../hooks/useProjects";
 import { formatDateTime } from "../utils/dates";
-import { showSuccess, showError } from "../utils/notifications";
+import { showError, showSuccess } from "../utils/notifications";
+import md from "../components/MarkdownViewer.module.css";
+import ui from "../styles/redesign.module.css";
+import styles from "./DocumentPage.module.css";
+
+type View = "rendered" | "source" | "chunks";
+
+function slug(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+}
+
+function textOf(node: React.ReactNode): string {
+  if (typeof node === "string" || typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(textOf).join("");
+  if (node && typeof node === "object" && "props" in node) {
+    return textOf((node as { props: { children?: React.ReactNode } }).props.children);
+  }
+  return "";
+}
+
+interface TocEntry {
+  level: number;
+  text: string;
+  id: string;
+}
+function extractToc(markdown: string): TocEntry[] {
+  const out: TocEntry[] = [];
+  let inFence = false;
+  for (const line of markdown.split("\n")) {
+    if (line.startsWith("```")) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+    const m = line.match(/^(#{1,3})\s+(.+?)\s*#*$/);
+    if (m) out.push({ level: m[1].length, text: m[2], id: slug(m[2]) });
+  }
+  return out;
+}
+
+function opColor(op: string): string {
+  switch (op) {
+    case "create":
+      return "var(--green)";
+    case "update-content":
+      return "var(--blue)";
+    case "update-metadata":
+      return "var(--blue)";
+    case "delete":
+      return "var(--red)";
+    case "status-change":
+      return "var(--yellow)";
+    case "archive":
+      return "var(--violet)";
+    case "unarchive":
+      return "var(--primary)";
+    default:
+      return "var(--text-faint)";
+  }
+}
+
+function originChip(source: string | null): { icon: typeof IconMapPin; label: string; agent: boolean } {
+  const s = (source ?? "manual").toLowerCase();
+  if (s === "agent") return { icon: IconSparkles, label: "agent", agent: true };
+  if (s === "cli") return { icon: IconTerminal2, label: "cli", agent: false };
+  if (s === "url") return { icon: IconFileText, label: "url", agent: false };
+  return { icon: IconMapPin, label: s, agent: false };
+}
 
 export function DocumentPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [confirmDelete, setConfirmDelete] = useState(false);
+  const [view, setView] = useState<View>("rendered");
 
   const { data: doc, isLoading, error } = useQuery({
     queryKey: ["document", id],
     queryFn: () => fetchDocument(id!),
     enabled: !!id,
   });
-
   const { data: chunks, isLoading: chunksLoading } = useQuery({
     queryKey: ["document-chunks", id],
     queryFn: () => fetchChunks(id!),
     enabled: !!id,
   });
-
-  const [auditOpened, setAuditOpened] = useState(false);
-  const auditEnabled = !!id && auditOpened;
-  const { data: auditEntries, isLoading: auditLoading } = useQuery({
+  const { data: auditEntries } = useQuery({
     queryKey: ["document-audit", id],
     queryFn: () => fetchAuditLog({ document_id: id!, limit: 50 }),
-    enabled: auditEnabled,
+    enabled: !!id,
   });
-
   const { data: projects } = useProjects();
   const projectMap = new Map(projects?.map((p) => [p.id, p.name]) ?? []);
+
+  const invalidateDoc = () => {
+    queryClient.invalidateQueries({ queryKey: ["document", id] });
+    queryClient.invalidateQueries({ queryKey: ["dashboard"] });
+    queryClient.invalidateQueries({ queryKey: ["search"] });
+    queryClient.invalidateQueries({ queryKey: ["trash"] });
+  };
 
   const deleteMutation = useMutation({
     mutationFn: () => deleteDocument(id!),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["dashboard"] });
-      queryClient.invalidateQueries({ queryKey: ["document", id] });
-      queryClient.invalidateQueries({ queryKey: ["search"] });
-      queryClient.invalidateQueries({ queryKey: ["trash"] });
+      invalidateDoc();
       showSuccess("Document moved to trash");
       navigate("/");
     },
     onError: (err) => showError("Delete failed", String(err)),
   });
-
   const restoreMutation = useMutation({
     mutationFn: () => restoreDocument(id!),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["document", id] });
-      queryClient.invalidateQueries({ queryKey: ["trash"] });
-      queryClient.invalidateQueries({ queryKey: ["dashboard"] });
-      queryClient.invalidateQueries({ queryKey: ["search"] });
+      invalidateDoc();
       showSuccess("Document restored");
     },
     onError: (err) => showError("Restore failed", String(err)),
   });
-
   const purgeMutation = useMutation({
     mutationFn: () => purgeDocument(id!),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["trash"] });
-      queryClient.invalidateQueries({ queryKey: ["dashboard"] });
-      queryClient.invalidateQueries({ queryKey: ["search"] });
+      invalidateDoc();
       showSuccess("Document permanently deleted");
       navigate("/trash");
     },
     onError: (err) => showError("Purge failed", String(err)),
   });
-
   const reviewMutation = useMutation({
     mutationFn: (status: string) => setReviewStatus(id!, status),
     onSuccess: (_, status) => {
@@ -110,26 +170,21 @@ export function DocumentPage() {
     },
     onError: (err) => showError("Status update failed", String(err)),
   });
-
   const archiveMutation = useMutation({
     mutationFn: ({ versionId, archived }: { versionId: string; archived: boolean }) =>
       setVersionArchived(id!, versionId, archived),
     onSuccess: (_, { archived }) => {
       queryClient.invalidateQueries({ queryKey: ["document", id] });
-      showSuccess(archived ? "Version archived" : "Version unarchived",
-        archived ? "Protected from cleanup" : "Eligible for cleanup");
+      showSuccess(archived ? "Version archived" : "Protection removed");
     },
     onError: (err) => showError("Archive update failed", String(err)),
   });
 
-  const [confirmUnarchive, setConfirmUnarchive] = useState<string | null>(null);
   const [diffVersionId, setDiffVersionId] = useState<string | null>(null);
   const [diffVersionContent, setDiffVersionContent] = useState<string | null>(null);
   const [diffVersionLabel, setDiffVersionLabel] = useState("");
-  const [diffLoading, setDiffLoading] = useState(false);
 
   const openDiff = async (versionId: string, versionNumber: number) => {
-    setDiffLoading(true);
     setDiffVersionId(versionId);
     setDiffVersionLabel(`v${versionNumber}`);
     try {
@@ -138,445 +193,409 @@ export function DocumentPage() {
     } catch {
       showError("Failed to load version content");
       setDiffVersionId(null);
-    } finally {
-      setDiffLoading(false);
     }
+  };
+
+  const toc = useMemo(() => (doc ? extractToc(doc.full_content) : []), [doc]);
+
+  const mdComponents = useMemo(
+    () => ({
+      a: (props: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+        <MarkdownLink {...props} fromDocId={doc?.document_id} />
+      ),
+      h1: ({ children }: { children?: React.ReactNode }) => (
+        <h1 id={slug(textOf(children))}>{children}</h1>
+      ),
+      h2: ({ children }: { children?: React.ReactNode }) => (
+        <h2 id={slug(textOf(children))}>{children}</h2>
+      ),
+      h3: ({ children }: { children?: React.ReactNode }) => (
+        <h3 id={slug(textOf(children))}>{children}</h3>
+      ),
+    }),
+    [doc?.document_id],
+  );
+
+  const goToHeading = (headingId: string) => {
+    setView("rendered");
+    setTimeout(() => {
+      document.getElementById(headingId)?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }, 50);
   };
 
   if (isLoading) {
     return (
-      <Container size="lg">
-        <Group justify="center" mt="xl">
+      <div className={styles.wrap}>
+        <div style={{ display: "flex", justifyContent: "center", marginTop: 60 }}>
           <Loader />
-        </Group>
-      </Container>
+        </div>
+      </div>
     );
   }
-
   if (error || !doc) {
     return (
-      <Container size="lg">
-        <Text c="red" mt="xl">
+      <div className={styles.wrap}>
+        <p style={{ color: "var(--red)", marginTop: 40 }}>
           {error ? String(error) : "Document not found."}
-        </Text>
-      </Container>
+        </p>
+      </div>
     );
   }
 
   const metaEntries = Object.entries(doc.doc_metadata || {});
+  const approved = doc.review_status === "approved";
+  const chip = originChip(doc.doc_source);
+  const ChipIcon = chip.icon;
 
   return (
-    <Container size="lg">
-      <Group justify="space-between" align="flex-start" mb="md">
-        <div>
-          <Title order={2}>{doc.doc_title || "Untitled"}</Title>
-          <Group gap="xs" mt="xs">
+    <div className={styles.wrap}>
+      <button
+        type="button"
+        className={`${ui.btn} ${ui.btnSubtle} ${styles.backBtn}`}
+        onClick={() => navigate(-1)}
+      >
+        <IconArrowLeft size={15} />
+        Back
+      </button>
+
+      {/* header */}
+      <div className={`${styles.docHeader} ${ui.rise}`}>
+        <div style={{ minWidth: 0, flex: 1 }}>
+          <div className={ui.row} style={{ gap: 8, marginBottom: 8, flexWrap: "wrap" }}>
             {doc.project_ids
               .filter((pid) => projectMap.has(pid))
               .map((pid) => (
-                <Badge key={pid} variant="light" size="sm">
+                <span key={pid} className={`${ui.badge} ${ui.bNeutral}`}>
                   {projectMap.get(pid)}
-                </Badge>
+                </span>
               ))}
-            <Text size="sm" c="dimmed">
-              {doc.chunk_count} chunks | {doc.total_chars.toLocaleString()} chars
-            </Text>
-          </Group>
-          <Group gap="md" mt={4}>
-            {doc.created_at && (
-              <Text size="xs" c="dimmed">
-                Created: {formatDateTime(doc.created_at)}
-              </Text>
-            )}
+          </div>
+          <h1 className={styles.docTitle}>{doc.doc_title || "Untitled"}</h1>
+          <div className={styles.docMeta}>
+            <span className={`${ui.srcChip} ${chip.agent ? ui.srcChipAgent : ""}`}>
+              <ChipIcon size={12} />
+              {chip.label}
+            </span>
+            <span className={`${ui.mono} ${ui.faint}`}>{doc.chunk_count} chunks</span>
+            <span className={`${ui.mono} ${ui.faint}`}>{doc.total_chars.toLocaleString()} chars</span>
             {doc.updated_at && (
-              <Text size="xs" c="dimmed">
-                Updated: {formatDateTime(doc.updated_at)}
-              </Text>
+              <span className={`${ui.mono} ${ui.faint}`}>updated {formatDateTime(doc.updated_at)}</span>
             )}
-            <SegmentedControl
-              size="xs"
-              value={doc.review_status}
-              onChange={(v) => reviewMutation.mutate(v)}
-              color={doc.review_status === "approved" ? "green" : "yellow"}
-              data={[
-                { label: "Approved", value: "approved" },
-                { label: "Pending Review", value: "pending_review" },
-              ]}
+            <button
+              type="button"
+              className={styles.reviewPill}
+              title="Click to toggle review status"
+              onClick={() => reviewMutation.mutate(approved ? "pending_review" : "approved")}
               disabled={reviewMutation.isPending}
-            />
-          </Group>
+            >
+              <span
+                className="dot"
+                style={{
+                  width: 7,
+                  height: 7,
+                  borderRadius: "50%",
+                  background: approved ? "var(--green)" : "var(--yellow)",
+                }}
+              />
+              {approved ? "Approved" : "Pending"}
+            </button>
+          </div>
         </div>
-        <Group gap="xs">
-          <Button
-            variant="light"
-            size="xs"
-            leftSection={<IconEdit size={14} />}
+        <div className={ui.row} style={{ gap: 8, flexShrink: 0 }}>
+          <button
+            type="button"
+            className={`${ui.btn} ${ui.btnGhost}`}
             onClick={() => navigate(`/document/${id}/edit`)}
           >
+            <IconEdit size={14} />
             Edit
-          </Button>
-          <Button
-            variant="light"
-            size="xs"
-            leftSection={<IconDownload size={14} />}
-            component="a"
-            href={getDownloadUrl(id!)}
-          >
+          </button>
+          <a className={`${ui.btn} ${ui.btnGhost}`} href={getDownloadUrl(id!)}>
+            <IconDownload size={14} />
             Download
-          </Button>
+          </a>
           {!confirmDelete ? (
-            <Button
-              variant="light"
-              color="red"
-              size="xs"
-              leftSection={<IconTrash size={14} />}
+            <button
+              type="button"
+              className={`${ui.btn} ${ui.btnSubtle}`}
+              style={{ color: "var(--text-faint)" }}
+              title="Delete"
               onClick={() => setConfirmDelete(true)}
             >
-              Delete
-            </Button>
+              <IconTrash size={14} />
+            </button>
           ) : (
-            <Group gap={4}>
-              <Button
-                color="red"
-                size="xs"
+            <div className={ui.row} style={{ gap: 6 }}>
+              <button
+                type="button"
+                className={ui.btn}
+                style={{ background: "var(--red)", color: "#fff" }}
                 onClick={() => deleteMutation.mutate()}
-                loading={deleteMutation.isPending}
               >
-                Confirm delete
-              </Button>
-              <Button
-                variant="subtle"
-                size="xs"
+                Confirm
+              </button>
+              <button
+                type="button"
+                className={`${ui.btn} ${ui.btnSubtle}`}
                 onClick={() => setConfirmDelete(false)}
               >
                 Cancel
-              </Button>
-            </Group>
+              </button>
+            </div>
           )}
-        </Group>
-      </Group>
+        </div>
+      </div>
 
       {doc.deleted_at && (
-        <Card withBorder p="sm" mt="sm" bg="var(--mantine-color-red-light)">
-          <Group justify="space-between">
-            <Group gap="xs">
-              <Badge color="red" variant="filled">Deleted</Badge>
-              <Text size="sm">This document is in the trash (deleted {doc.deleted_at?.slice(0, 10)}). It is excluded from search.</Text>
-            </Group>
-            <Group gap="xs">
-              <Button
-                size="compact-sm"
-                color="green"
-                onClick={() => restoreMutation.mutate()}
-                loading={restoreMutation.isPending}
-              >
-                Restore
-              </Button>
-              <Button
-                size="compact-sm"
-                color="red"
-                onClick={() => purgeMutation.mutate()}
-                loading={purgeMutation.isPending}
-              >
-                Permanently Delete
-              </Button>
-            </Group>
-          </Group>
-        </Card>
+        <div className={styles.trashBanner}>
+          <div className={ui.row} style={{ gap: 8 }}>
+            <span className={`${ui.badge} ${ui.bNeutral}`} style={{ background: "var(--red)", color: "#fff" }}>
+              Deleted
+            </span>
+            <span style={{ fontSize: 13 }}>
+              In trash (deleted {doc.deleted_at.slice(0, 10)}) — excluded from search.
+            </span>
+          </div>
+          <div className={ui.row} style={{ gap: 8 }}>
+            <button type="button" className={`${ui.btn} ${ui.btnGhost}`} onClick={() => restoreMutation.mutate()}>
+              Restore
+            </button>
+            <button
+              type="button"
+              className={ui.btn}
+              style={{ background: "var(--red)", color: "#fff" }}
+              onClick={() => purgeMutation.mutate()}
+            >
+              Delete permanently
+            </button>
+          </div>
+        </div>
       )}
 
-      {metaEntries.length > 0 && (
-        <>
-          <Divider my="sm" />
-          <Accordion variant="contained" mb="md">
-            <Accordion.Item value="metadata">
-              <Accordion.Control>
-                <Text size="sm" fw={500}>
-                  Metadata ({metaEntries.length} fields)
-                </Text>
-              </Accordion.Control>
-              <Accordion.Panel>
-                <Table>
-                  <Table.Tbody>
-                    {metaEntries.map(([k, v]) => (
-                      <Table.Tr key={k}>
-                        <Table.Td fw={500} w={200}>
-                          {k}
-                        </Table.Td>
-                        <Table.Td>{String(v)}</Table.Td>
-                      </Table.Tr>
-                    ))}
-                  </Table.Tbody>
-                </Table>
-              </Accordion.Panel>
-            </Accordion.Item>
-          </Accordion>
-        </>
-      )}
+      <div className={styles.docSplit}>
+        {/* content */}
+        <div className={ui.rise} style={{ minWidth: 0 }}>
+          <div className={ui.card}>
+            <div className={styles.contentHead}>
+              <div className={ui.seg}>
+                <button
+                  type="button"
+                  className={`${ui.segBtn} ${view === "rendered" ? ui.segBtnOn : ""}`}
+                  onClick={() => setView("rendered")}
+                >
+                  <IconFileText size={14} />
+                  Rendered
+                </button>
+                <button
+                  type="button"
+                  className={`${ui.segBtn} ${view === "source" ? ui.segBtnOn : ""}`}
+                  onClick={() => setView("source")}
+                >
+                  <IconTerminal2 size={14} />
+                  Source
+                </button>
+                <button
+                  type="button"
+                  className={`${ui.segBtn} ${view === "chunks" ? ui.segBtnOn : ""}`}
+                  onClick={() => setView("chunks")}
+                >
+                  <IconStack2 size={14} />
+                  Chunks
+                </button>
+              </div>
+              <span className={`${ui.mono} ${ui.faint}`} style={{ fontSize: 12 }}>
+                {doc.total_chars.toLocaleString()} chars
+              </span>
+            </div>
+            <div className={ui.divider} />
 
-      <Accordion variant="contained" mb="md" onChange={(v) => {
-        if (v === "audit" || (Array.isArray(v) && v.includes("audit"))) {
-          setAuditOpened(true);
-        }
-      }}>
-        <Accordion.Item value="audit">
-          <Accordion.Control>
-            <Text size="sm" fw={500}>
-              Audit Trail{auditEntries ? ` (${auditEntries.length} entries)` : ""}
-            </Text>
-          </Accordion.Control>
-          <Accordion.Panel>
-            {auditLoading ? (
-              <Loader size="sm" />
-            ) : !auditEntries?.length ? (
-              <Text size="sm" c="dimmed">No audit entries for this document.</Text>
-            ) : (
-              <Table striped>
-                <Table.Thead>
-                  <Table.Tr>
-                    <Table.Th>Date</Table.Th>
-                    <Table.Th>Operation</Table.Th>
-                    <Table.Th>Author</Table.Th>
-                    <Table.Th>Size</Table.Th>
-                    <Table.Th>Description</Table.Th>
-                  </Table.Tr>
-                </Table.Thead>
-                <Table.Tbody>
-                  {auditEntries.map((e) => {
-                    const opColor = (() => {
-                      switch (e.operation) {
-                        case "create": return "green";
-                        case "update-content": return "blue";
-                        case "update-metadata": return "cyan";
-                        case "delete": return "red";
-                        case "status-change": return "yellow";
-                        case "archive": return "violet";
-                        case "unarchive": return "orange";
-                        default: return "gray";
-                      }
-                    })();
-                    const sizeText = e.size_before != null && e.size_after != null
-                      ? `${e.size_before.toLocaleString()} -> ${e.size_after.toLocaleString()}`
-                      : e.size_after != null
-                        ? e.size_after.toLocaleString()
-                        : "";
-                    return (
-                      <Table.Tr key={e.id}>
-                        <Table.Td>
-                          <Text size="xs">{formatDateTime(e.created_at)}</Text>
-                        </Table.Td>
-                        <Table.Td>
-                          <Badge variant="light" size="sm" color={opColor}>
-                            {e.operation}
-                          </Badge>
-                        </Table.Td>
-                        <Table.Td>
-                          <Group gap={4}>
-                            <Text size="sm">{e.author}</Text>
-                            <Badge variant="dot" size="xs"
-                              color={e.author_type === "agent" ? "violet" : "blue"}>
-                              {e.author_type}
-                            </Badge>
-                          </Group>
-                        </Table.Td>
-                        <Table.Td>
-                          <Text size="xs" c="dimmed">{sizeText}</Text>
-                        </Table.Td>
-                        <Table.Td>
-                          <Text size="xs" lineClamp={2}>{e.description}</Text>
-                        </Table.Td>
-                      </Table.Tr>
-                    );
-                  })}
-                </Table.Tbody>
-              </Table>
+            {view === "rendered" && (
+              <div className={styles.mdBody}>
+                <div className={md.markdown}>
+                  <ReactMarkdown remarkPlugins={[remarkGfm]} components={mdComponents}>
+                    {doc.full_content || "*(empty)*"}
+                  </ReactMarkdown>
+                </div>
+              </div>
             )}
-          </Accordion.Panel>
-        </Accordion.Item>
-      </Accordion>
+            {view === "source" && <pre className={styles.docSource}>{doc.full_content}</pre>}
+            {view === "chunks" && (
+              <div className={styles.chunkList}>
+                {chunksLoading ? (
+                  <div style={{ padding: 18 }}>
+                    <Loader size="sm" />
+                  </div>
+                ) : (
+                  chunks?.map((c, i) => (
+                    <div key={c.chunk_id} className={styles.chunkItem}>
+                      <div className={`${styles.chunkHead} ${ui.mono}`}>
+                        <span className={`${ui.badge} ${ui.bNeutral}`}>chunk {i + 1}</span>
+                        <span className={ui.faint}>
+                          {c.heading_path.length > 0 ? c.heading_path.join(" › ") : "(preamble)"}
+                        </span>
+                      </div>
+                      <p className={styles.chunkBody}>{c.content}</p>
+                    </div>
+                  ))
+                )}
+              </div>
+            )}
+          </div>
+        </div>
 
-      {doc.versions.length > 0 && (
-        <Accordion variant="contained" mb="md">
-          <Accordion.Item value="versions">
-            <Accordion.Control>
-              <Text size="sm" fw={500}>
-                Version History ({doc.versions.length} retained)
-              </Text>
-            </Accordion.Control>
-            <Accordion.Panel>
-              <Table striped>
-                <Table.Thead>
-                  <Table.Tr>
-                    <Table.Th>Version</Table.Th>
-                    <Table.Th>Date</Table.Th>
-                    <Table.Th>Size</Table.Th>
-                    <Table.Th>Chunks</Table.Th>
-                    <Table.Th>Protected</Table.Th>
-                    <Table.Th></Table.Th>
-                  </Table.Tr>
-                </Table.Thead>
-                <Table.Tbody>
-                  {doc.versions.map((v) => (
-                    <Table.Tr key={v.version_id}>
-                      <Table.Td>
-                        <Group gap={4}>
-                          <Badge variant="outline" size="sm">
-                            v{v.version_number}
-                          </Badge>
-                          {v.archived && <IconLock size={14} color="var(--mantine-color-blue-6)" />}
-                        </Group>
-                      </Table.Td>
-                      <Table.Td>
-                        <Text size="sm">{formatDateTime(v.created_at)}</Text>
-                      </Table.Td>
-                      <Table.Td>
-                        <Text size="sm">
-                          {v.total_chars.toLocaleString()} chars
-                        </Text>
-                      </Table.Td>
-                      <Table.Td>
-                        <Text size="sm">{v.chunk_count}</Text>
-                      </Table.Td>
-                      <Table.Td>
-                        {v.archived ? (
-                          confirmUnarchive === v.version_id ? (
-                            <Group gap={4}>
-                              <Button
-                                size="compact-xs"
-                                color="yellow"
-                                onClick={() => {
-                                  archiveMutation.mutate({ versionId: v.version_id, archived: false });
-                                  setConfirmUnarchive(null);
-                                }}
-                                loading={archiveMutation.isPending}
-                              >
-                                Confirm removal
-                              </Button>
-                              <Button
-                                size="compact-xs"
-                                variant="subtle"
-                                onClick={() => setConfirmUnarchive(null)}
-                              >
-                                Cancel
-                              </Button>
-                            </Group>
-                          ) : (
-                            <Badge
-                              variant="light"
-                              size="sm"
-                              color="green"
-                              leftSection={<IconLock size={12} />}
-                              style={{ cursor: "pointer" }}
-                              title="Click to remove protection. This version will become eligible for automatic cleanup."
-                              onClick={() => setConfirmUnarchive(v.version_id)}
-                            >
-                              Yes (archived)
-                            </Badge>
-                          )
-                        ) : (
-                          <Badge
-                            variant="light"
-                            size="sm"
-                            color="yellow"
-                            leftSection={<IconLockOpen size={12} />}
-                            style={{ cursor: "pointer" }}
-                            title="Click to archive. Archived versions are protected from automatic cleanup and retained indefinitely."
-                            onClick={() =>
-                              archiveMutation.mutate({ versionId: v.version_id, archived: true })
-                            }
-                          >
-                            No (will be deleted)
-                          </Badge>
-                        )}
-                      </Table.Td>
-                      <Table.Td>
-                        <Group gap={4}>
-                          <Button
-                            variant="subtle"
-                            size="compact-xs"
-                            leftSection={<IconArrowsDiff size={12} />}
-                            onClick={() => openDiff(v.version_id, v.version_number)}
-                            loading={diffLoading && diffVersionId === v.version_id}
-                          >
-                            Diff
-                          </Button>
-                          <Button
-                            variant="subtle"
-                            size="compact-xs"
-                            leftSection={<IconDownload size={12} />}
-                            component="a"
-                            href={getDownloadUrl(id!, v.version_id)}
-                          >
-                            Download
-                          </Button>
-                        </Group>
-                      </Table.Td>
-                    </Table.Tr>
-                  ))}
-                </Table.Tbody>
-              </Table>
-            </Accordion.Panel>
-          </Accordion.Item>
-        </Accordion>
-      )}
-
-      <Divider my="sm" />
-
-      <Accordion variant="separated" multiple defaultValue={["content"]}>
-        <Accordion.Item value="content">
-          <Accordion.Control>
-            <Text size="sm" fw={500}>
-              Full Content ({doc.total_chars.toLocaleString()} chars)
-            </Text>
-          </Accordion.Control>
-          <Accordion.Panel>
-            <MarkdownViewer
-              content={doc.full_content}
-              defaultView="rendered"
-              documentId={doc.document_id}
-            />
-          </Accordion.Panel>
-        </Accordion.Item>
-
-        <Accordion.Item value="chunks">
-          <Accordion.Control>
-            <Text size="sm" fw={500}>
-              Chunks ({doc.chunk_count})
-            </Text>
-          </Accordion.Control>
-          <Accordion.Panel>
-            {chunksLoading ? (
-              <Loader size="sm" />
-            ) : (
-              <Stack gap="sm">
-                {chunks?.map((c) => (
-                  <div
-                    key={c.chunk_id}
-                    style={{
-                      border: "1px solid var(--mantine-color-gray-3)",
-                      borderRadius: 8,
-                      padding: 8,
-                    }}
+        {/* rail */}
+        <aside className={styles.docRail}>
+          {toc.length > 0 && (
+            <div className={`${ui.card} ${ui.cardPad} ${ui.rise}`}>
+              <div className={styles.railTitle}>Contents</div>
+              <div className={styles.toc}>
+                {toc.map((t, idx) => (
+                  <button
+                    key={idx}
+                    type="button"
+                    className={`${styles.tocLink} ${t.level === 2 ? styles.tocLvl2 : ""} ${t.level === 3 ? styles.tocLvl3 : ""}`}
+                    onClick={() => goToHeading(t.id)}
                   >
-                    <Text size="xs" c="dimmed" mb={4} style={{ fontFamily: "monospace" }}>
-                      {c.heading_path.length > 0
-                        ? c.heading_path.join(" > ")
-                        : "(preamble)"}
-                    </Text>
-                    <Code
-                      block
-                      style={{ whiteSpace: "pre-wrap", fontSize: 12 }}
-                    >
-                      {c.content}
-                    </Code>
+                    {t.text}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <div className={`${ui.card} ${ui.cardPad} ${ui.rise}`}>
+            <div className={styles.railTitle}>Details</div>
+            <dl className={styles.metaDl}>
+              {doc.created_at && (
+                <>
+                  <dt>Created</dt>
+                  <dd>{new Date(doc.created_at).toLocaleDateString()}</dd>
+                </>
+              )}
+              {doc.updated_at && (
+                <>
+                  <dt>Updated</dt>
+                  <dd>{new Date(doc.updated_at).toLocaleDateString()}</dd>
+                </>
+              )}
+              <dt>Origin</dt>
+              <dd className={ui.mono}>{doc.doc_source ?? "manual"}</dd>
+            </dl>
+            {metaEntries.length > 0 && (
+              <>
+                <div className={ui.divider} style={{ margin: "12px 0" }} />
+                <div className={styles.railTitle} style={{ marginBottom: 8 }}>
+                  Metadata
+                </div>
+                <div className={styles.metaTags}>
+                  {metaEntries.map(([k, v]) => (
+                    <span key={k} className={styles.metaTag}>
+                      <b>{k}</b>
+                      {String(v)}
+                    </span>
+                  ))}
+                </div>
+              </>
+            )}
+          </div>
+
+          {doc.versions.length > 0 && (
+            <div className={`${ui.card} ${ui.cardPad} ${ui.rise}`}>
+              <div className={styles.railTitle}>
+                Versions <span className={ui.countPill}>{doc.versions.length}</span>
+              </div>
+              <div className={styles.verList}>
+                {doc.versions.map((v) => (
+                  <div key={v.version_id} className={styles.verRow}>
+                    <span className={`${ui.badge} ${ui.bNeutral} ${ui.mono}`}>v{v.version_number}</span>
+                    <span className={`${ui.faint} ${ui.mono}`} style={{ fontSize: 11 }}>
+                      {new Date(v.created_at).toLocaleDateString()}
+                    </span>
+                    {v.archived && (
+                      <span className={styles.verLock} title="Archived — protected from cleanup">
+                        <IconLock size={12} />
+                      </span>
+                    )}
+                    <Menu position="bottom-end" withinPortal shadow="md" width={180}>
+                      <Menu.Target>
+                        <button
+                          type="button"
+                          className={ui.iconBtn}
+                          style={{ width: 26, height: 26, marginLeft: "auto" }}
+                          aria-label="Version actions"
+                        >
+                          <IconDots size={14} />
+                        </button>
+                      </Menu.Target>
+                      <Menu.Dropdown>
+                        <Menu.Item
+                          leftSection={<IconArrowsDiff size={14} />}
+                          onClick={() => openDiff(v.version_id, v.version_number)}
+                        >
+                          Diff vs current
+                        </Menu.Item>
+                        <Menu.Item
+                          leftSection={<IconDownload size={14} />}
+                          component="a"
+                          href={getDownloadUrl(id!, v.version_id)}
+                        >
+                          Download
+                        </Menu.Item>
+                        <Menu.Item
+                          leftSection={<IconLock size={14} />}
+                          color={v.archived ? "yellow" : undefined}
+                          onClick={() =>
+                            archiveMutation.mutate({ versionId: v.version_id, archived: !v.archived })
+                          }
+                        >
+                          {v.archived ? "Remove protection" : "Archive (protect)"}
+                        </Menu.Item>
+                      </Menu.Dropdown>
+                    </Menu>
                   </div>
                 ))}
-              </Stack>
-            )}
-          </Accordion.Panel>
-        </Accordion.Item>
+              </div>
+            </div>
+          )}
 
-      </Accordion>
+          <div className={`${ui.card} ${ui.cardPad} ${ui.rise}`}>
+            <div className={styles.railTitle}>Activity</div>
+            {!auditEntries?.length ? (
+              <span className={ui.faint} style={{ fontSize: 12 }}>
+                No recorded activity.
+              </span>
+            ) : (
+              <div className={styles.actList}>
+                {auditEntries.map((e) => {
+                  const delta =
+                    e.size_before != null && e.size_after != null ? e.size_after - e.size_before : 0;
+                  return (
+                    <div key={e.id} className={styles.actRow}>
+                      <span className={styles.actDot} style={{ background: opColor(e.operation) }} />
+                      <div className={ui.col} style={{ gap: 2, minWidth: 0 }}>
+                        <span style={{ fontSize: 12.5 }}>{e.description || e.operation}</span>
+                        <span className={ui.faint} style={{ fontSize: 11 }}>
+                          <span className={e.author_type === "agent" ? styles.actAgent : ""}>
+                            {e.author}
+                          </span>{" "}
+                          · {new Date(e.created_at).toLocaleDateString()}
+                          {delta > 0 && (
+                            <span className={ui.mono} style={{ color: "var(--green)" }}>
+                              {" "}
+                              +{delta.toLocaleString()}
+                            </span>
+                          )}
+                        </span>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        </aside>
+      </div>
+
       <Modal
         opened={diffVersionId !== null && diffVersionContent !== null}
         onClose={() => {
@@ -595,6 +614,6 @@ export function DocumentPage() {
           />
         )}
       </Modal>
-    </Container>
+    </div>
   );
 }

--- a/frontend/src/pages/DocumentPage.tsx
+++ b/frontend/src/pages/DocumentPage.tsx
@@ -1,4 +1,4 @@
-import { Loader, Menu, Modal } from "@mantine/core";
+import { Loader, Menu, Modal, Popover, Text } from "@mantine/core";
 import {
   IconArrowLeft,
   IconArrowsDiff,
@@ -261,6 +261,7 @@ export function DocumentPage() {
       {/* header */}
       <div className={`${styles.docHeader} ${ui.rise}`}>
         <div style={{ minWidth: 0, flex: 1 }}>
+          <p className={ui.eyebrow}>Document</p>
           <div className={ui.row} style={{ gap: 8, marginBottom: 8, flexWrap: "wrap" }}>
             {doc.project_ids
               .filter((pid) => projectMap.has(pid))
@@ -409,6 +410,7 @@ export function DocumentPage() {
             </div>
             <div className={ui.divider} />
 
+            <div className={styles.contentScroll}>
             {view === "rendered" && (
               <div className={styles.mdBody}>
                 <div className={md.markdown}>
@@ -440,6 +442,7 @@ export function DocumentPage() {
                 )}
               </div>
             )}
+            </div>
           </div>
         </div>
 
@@ -490,7 +493,7 @@ export function DocumentPage() {
                 <div className={styles.metaTags}>
                   {metaEntries.map(([k, v]) => (
                     <span key={k} className={styles.metaTag}>
-                      <b>{k}</b>
+                      <b>{k}:</b>
                       {String(v)}
                     </span>
                   ))}
@@ -503,6 +506,20 @@ export function DocumentPage() {
             <div className={`${ui.card} ${ui.cardPad} ${ui.rise}`}>
               <div className={styles.railTitle}>
                 Versions <span className={ui.countPill}>{doc.versions.length}</span>
+                <Popover width={240} position="bottom-end" withArrow shadow="md">
+                  <Popover.Target>
+                    <button type="button" className={ui.whatis} style={{ marginLeft: "auto" }}>
+                      what's protection?
+                    </button>
+                  </Popover.Target>
+                  <Popover.Dropdown>
+                    <Text size="xs" c="dimmed">
+                      Archived (protected) versions are kept indefinitely and excluded from
+                      automatic cleanup. Unprotected older versions may be pruned by retention.
+                      Toggle protection from a version's ⋯ menu.
+                    </Text>
+                  </Popover.Dropdown>
+                </Popover>
               </div>
               <div className={styles.verList}>
                 {doc.versions.map((v) => (

--- a/frontend/src/pages/HelpPage.tsx
+++ b/frontend/src/pages/HelpPage.tsx
@@ -8,11 +8,12 @@ import {
   NavLink,
   Stack,
   Text,
+  TextInput,
   Title,
 } from "@mantine/core";
-import { IconBook, IconRobot, IconFileText } from "@tabler/icons-react";
+import { IconBook, IconRobot, IconFileText, IconSearch } from "@tabler/icons-react";
 import { useQuery } from "@tanstack/react-query";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 import { fetchDocContent, fetchDocsIndex, type DocEntry } from "../api/docs";
@@ -44,6 +45,14 @@ export function HelpPage() {
   });
 
   const docs = indexQuery.data ?? [];
+  const [filter, setFilter] = useState("");
+  const filtered = useMemo(() => {
+    const q = filter.trim().toLowerCase();
+    if (!q) return docs;
+    return docs.filter(
+      (d) => d.title.toLowerCase().includes(q) || d.path.toLowerCase().includes(q),
+    );
+  }, [docs, filter]);
 
   // Default to README on first visit
   const selectedPath = docPath && docPath.length > 0 ? docPath : docs[0]?.path;
@@ -57,11 +66,11 @@ export function HelpPage() {
 
   const grouped = useMemo(() => {
     const out: Record<string, DocEntry[]> = {};
-    for (const entry of docs) {
+    for (const entry of filtered) {
       (out[entry.category] ??= []).push(entry);
     }
     return out;
-  }, [docs]);
+  }, [filtered]);
 
   if (indexQuery.isLoading) {
     return (
@@ -103,6 +112,19 @@ export function HelpPage() {
             <Title order={5} mb="xs">
               Help
             </Title>
+            <TextInput
+              placeholder="Filter guides…"
+              value={filter}
+              onChange={(e) => setFilter(e.currentTarget.value)}
+              leftSection={<IconSearch size={14} />}
+              size="xs"
+              mb="sm"
+            />
+            {filtered.length === 0 && (
+              <Text size="xs" c="dimmed">
+                No guides match "{filter}".
+              </Text>
+            )}
             {CATEGORY_ORDER.filter((cat) => grouped[cat]?.length).map((cat) => (
               <Stack key={cat} gap={0} mb="sm">
                 <Group gap={6} mb={4} mt={6}>

--- a/frontend/src/pages/HelpPage.tsx
+++ b/frontend/src/pages/HelpPage.tsx
@@ -17,6 +17,7 @@ import { useNavigate, useParams } from "react-router-dom";
 
 import { fetchDocContent, fetchDocsIndex, type DocEntry } from "../api/docs";
 import { MarkdownViewer } from "../components/MarkdownViewer";
+import ui from "../styles/redesign.module.css";
 
 const CATEGORY_LABELS: Record<string, string> = {
   readme: "Project overview",
@@ -94,7 +95,8 @@ export function HelpPage() {
   }
 
   return (
-    <Container fluid py="md">
+    <Container fluid py="xs">
+      <p className={ui.eyebrow}>Reference</p>
       <Grid gutter="md">
         <Grid.Col span={{ base: 12, md: 3 }}>
           <Stack gap={2}>
@@ -146,7 +148,11 @@ export function HelpPage() {
                   raw
                 </Anchor>
               </Group>
-              <MarkdownViewer content={contentQuery.data} showToggle={false} />
+              <MarkdownViewer
+                content={contentQuery.data}
+                showToggle={false}
+                maxHeight="calc(100vh - 170px)"
+              />
             </Stack>
           )}
         </Grid.Col>

--- a/frontend/src/pages/HelpPage.tsx
+++ b/frontend/src/pages/HelpPage.tsx
@@ -17,6 +17,7 @@ import { useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 import { fetchDocContent, fetchDocsIndex, type DocEntry } from "../api/docs";
+import { CliHint } from "../components/CliHint";
 import { MarkdownViewer } from "../components/MarkdownViewer";
 import ui from "../styles/redesign.module.css";
 
@@ -156,19 +157,22 @@ export function HelpPage() {
           )}
           {contentQuery.data && (
             <Stack gap="sm">
-              <Group justify="space-between" align="flex-end">
+              <Group justify="space-between" align="flex-end" wrap="nowrap">
                 <Title order={3}>
                   {docs.find((d) => d.path === selectedPath)?.title ?? selectedPath}
                 </Title>
-                <Anchor
-                  size="xs"
-                  c="dimmed"
-                  href={`/api/v1/docs/${selectedPath}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  raw
-                </Anchor>
+                <Group gap="sm" wrap="nowrap">
+                  <CliHint cmd="cerefox guides show" args={selectedPath} />
+                  <Anchor
+                    size="xs"
+                    c="dimmed"
+                    href={`/api/v1/docs/${selectedPath}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    raw
+                  </Anchor>
+                </Group>
               </Group>
               <MarkdownViewer
                 content={contentQuery.data}

--- a/frontend/src/pages/IngestPage.module.css
+++ b/frontend/src/pages/IngestPage.module.css
@@ -2,9 +2,9 @@
    Shared primitives in src/styles/redesign.module.css; tokens in tokens.css. */
 
 .wrap {
-  max-width: 860px;
+  max-width: 1120px;
   margin: 0 auto;
-  padding: 20px 24px 80px;
+  padding: 8px 24px 80px;
 }
 
 .split {

--- a/frontend/src/pages/IngestPage.module.css
+++ b/frontend/src/pages/IngestPage.module.css
@@ -1,0 +1,180 @@
+/* Ingest (redesign) — page-specific layout.
+   Shared primitives in src/styles/redesign.module.css; tokens in tokens.css. */
+
+.wrap {
+  max-width: 860px;
+  margin: 0 auto;
+  padding: 34px 24px 80px;
+}
+
+.split {
+  display: grid;
+  grid-template-columns: 1fr 280px;
+  gap: 28px;
+  align-items: start;
+}
+.col {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+/* ---- fields ---- */
+.field label {
+  display: block;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 8px;
+}
+.input {
+  width: 100%;
+  font-family: var(--font-ui);
+  font-size: 14px;
+  color: var(--text);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 10px 13px;
+  transition: border-color 0.15s, box-shadow 0.15s;
+  outline: none;
+}
+.input::placeholder {
+  color: var(--text-faint);
+}
+.input:focus {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px var(--primary-soft);
+}
+.textarea {
+  min-height: 280px;
+  resize: vertical;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  line-height: 1.6;
+}
+.preview {
+  min-height: 280px;
+}
+
+/* ---- drop zone ---- */
+.dropZone {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 36px 20px;
+  border: 1.5px dashed var(--border);
+  border-radius: var(--radius-card);
+  background: var(--surface-2);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.dropZone:hover,
+.dropZoneOver {
+  border-color: var(--primary);
+  background: var(--primary-soft);
+}
+.dropZoneHas {
+  border-style: solid;
+  border-color: var(--primary-line);
+}
+.dropIco {
+  display: grid;
+  place-items: center;
+  width: 46px;
+  height: 46px;
+  border-radius: 13px;
+  background: var(--primary-soft);
+  color: var(--primary);
+}
+
+/* ---- toggle switch ---- */
+.toggleRow {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  cursor: pointer;
+}
+.toggle {
+  width: 38px;
+  height: 22px;
+  border-radius: 999px;
+  border: 0;
+  background: var(--surface-hover);
+  padding: 2px;
+  cursor: pointer;
+  transition: background 0.16s;
+  flex-shrink: 0;
+}
+.toggle span {
+  display: block;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--text-faint);
+  transition: transform 0.16s, background 0.16s;
+}
+.toggleOn {
+  background: var(--primary);
+}
+.toggleOn span {
+  transform: translateX(16px);
+  background: #fff;
+}
+
+/* ---- pipeline steps ---- */
+.steps {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.steps li {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+}
+.steps li div {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.steps li b {
+  font-size: 13px;
+}
+.steps li span.faint {
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--text-faint);
+}
+.stepN {
+  display: grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 8px;
+  flex-shrink: 0;
+  background: var(--primary-soft);
+  color: var(--primary);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding-top: 4px;
+  flex-wrap: wrap;
+}
+
+@media (max-width: 760px) {
+  .split {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/pages/IngestPage.module.css
+++ b/frontend/src/pages/IngestPage.module.css
@@ -4,7 +4,7 @@
 .wrap {
   max-width: 860px;
   margin: 0 auto;
-  padding: 34px 24px 80px;
+  padding: 20px 24px 80px;
 }
 
 .split {

--- a/frontend/src/pages/IngestPage.tsx
+++ b/frontend/src/pages/IngestPage.tsx
@@ -473,6 +473,14 @@ export function IngestPage() {
             <div className={ui.row} style={{ gap: 8, marginBottom: 10 }}>
               <IconTerminal2 size={15} />
               <span style={{ fontWeight: 600, fontSize: 13.5 }}>CLI equivalent</span>
+              <button
+                type="button"
+                className={ui.whatis}
+                style={{ marginLeft: "auto" }}
+                onClick={() => navigate("/help/guides/cli.md")}
+              >
+                cli docs
+              </button>
             </div>
             <div className={ui.cliBlock}>
               <div>

--- a/frontend/src/pages/IngestPage.tsx
+++ b/frontend/src/pages/IngestPage.tsx
@@ -1,5 +1,5 @@
 import { Alert } from "@mantine/core";
-import { IconCheck, IconFileText, IconPlus, IconTerminal2, IconUpload, IconX } from "@tabler/icons-react";
+import { IconCheck, IconFileText, IconPlus, IconSearch, IconTerminal2, IconUpload, IconX } from "@tabler/icons-react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
@@ -27,6 +27,7 @@ export function IngestPage() {
   const [tab, setTab] = useState<Tab>("paste");
   const [title, setTitle] = useState("");
   const [projectIds, setProjectIds] = useState<string[]>([]);
+  const [projFilter, setProjFilter] = useState("");
   const [metaPairs, setMetaPairs] = useState<{ key: string; value: string }[]>([]);
   const [updateExisting, setUpdateExisting] = useState(false);
   const [content, setContent] = useState("");
@@ -121,6 +122,11 @@ export function IngestPage() {
   const firstProjectName =
     projects?.find((p) => p.id === projectIds[0])?.name ?? "core-platform";
 
+  const allProjects = projects ?? [];
+  const visibleProjects = projFilter
+    ? allProjects.filter((p) => p.name.toLowerCase().includes(projFilter.toLowerCase()))
+    : allProjects;
+
   return (
     <div className={styles.wrap}>
       <div className={ui.pageHead}>
@@ -192,65 +198,7 @@ export function IngestPage() {
         }}
       >
         <div className={styles.col}>
-          {tab === "file" && (
-            <>
-              <input
-                ref={fileInputRef}
-                type="file"
-                accept=".md,.txt,.docx"
-                style={{ display: "none" }}
-                onChange={(e) => handleFile(e.currentTarget.files?.[0] ?? null)}
-              />
-              <div
-                className={`${styles.dropZone} ${dragOver ? styles.dropZoneOver : ""} ${file ? styles.dropZoneHas : ""}`}
-                onClick={() => fileInputRef.current?.click()}
-                onDragOver={(e) => {
-                  e.preventDefault();
-                  setDragOver(true);
-                }}
-                onDragLeave={() => setDragOver(false)}
-                onDrop={(e) => {
-                  e.preventDefault();
-                  setDragOver(false);
-                  const f = e.dataTransfer.files?.[0];
-                  if (f) handleFile(f);
-                }}
-              >
-                <span className={styles.dropIco}>
-                  <IconUpload size={20} />
-                </span>
-                {file ? (
-                  <>
-                    <div className={ui.mono} style={{ fontWeight: 600, fontSize: 14, marginTop: 10 }}>
-                      {file.name}
-                    </div>
-                    <span className={ui.faint} style={{ fontSize: 12.5 }}>
-                      Ready to ingest · click to replace
-                    </span>
-                  </>
-                ) : (
-                  <>
-                    <div style={{ fontWeight: 600, fontSize: 14, marginTop: 10 }}>
-                      Drop a file or click to browse
-                    </div>
-                    <span className={ui.faint} style={{ fontSize: 12.5 }}>
-                      .md · .txt · .docx
-                    </span>
-                  </>
-                )}
-              </div>
-              {filenameCheck?.exists && (
-                <Alert color="blue" variant="light">
-                  A document named "{filenameCheck.title}" already exists (updated{" "}
-                  {filenameCheck.updated_at
-                    ? new Date(filenameCheck.updated_at).toLocaleDateString()
-                    : "unknown"}
-                  ). Enable "Update existing" to overwrite it.
-                </Alert>
-              )}
-            </>
-          )}
-
+          {/* common fields stay put across tabs */}
           <div className={styles.field}>
             <label>
               Title
@@ -264,28 +212,48 @@ export function IngestPage() {
             />
           </div>
 
-          {projects && projects.length > 0 && (
+          {allProjects.length > 0 && (
             <div className={styles.field}>
               <label>Projects</label>
+              {allProjects.length > 8 && (
+                <div className={ui.selectWrap} style={{ width: "100%", marginBottom: 8, height: 34 }}>
+                  <IconSearch size={14} />
+                  <input
+                    className={ui.selectEl}
+                    style={{ maxWidth: "none", flex: 1 }}
+                    placeholder={`Filter ${allProjects.length} projects…`}
+                    value={projFilter}
+                    onChange={(e) => setProjFilter(e.currentTarget.value)}
+                  />
+                </div>
+              )}
               <div className={ui.row} style={{ gap: 7, flexWrap: "wrap" }}>
-                {projects.map((p, i) => (
-                  <button
-                    key={p.id}
-                    type="button"
-                    className={`${ui.chip} ${projectIds.includes(p.id) ? ui.chipOn : ""}`}
-                    onClick={() => toggleProject(p.id)}
-                  >
-                    <span
-                      style={{
-                        width: 7,
-                        height: 7,
-                        borderRadius: "50%",
-                        background: `var(${PROJECT_COLORS[i % PROJECT_COLORS.length]})`,
-                      }}
-                    />
-                    {p.name}
-                  </button>
-                ))}
+                {visibleProjects.map((p) => {
+                  const idx = allProjects.indexOf(p);
+                  return (
+                    <button
+                      key={p.id}
+                      type="button"
+                      className={`${ui.chip} ${projectIds.includes(p.id) ? ui.chipOn : ""}`}
+                      onClick={() => toggleProject(p.id)}
+                    >
+                      <span
+                        style={{
+                          width: 7,
+                          height: 7,
+                          borderRadius: "50%",
+                          background: `var(${PROJECT_COLORS[idx % PROJECT_COLORS.length]})`,
+                        }}
+                      />
+                      {p.name}
+                    </button>
+                  );
+                })}
+                {visibleProjects.length === 0 && (
+                  <span className={ui.faint} style={{ fontSize: 12.5 }}>
+                    No projects match "{projFilter}".
+                  </span>
+                )}
               </div>
             </div>
           )}
@@ -347,7 +315,66 @@ export function IngestPage() {
             </div>
           </div>
 
-          {tab === "paste" && (
+          {/* tab-specific primary input (same slot for both tabs) */}
+          {tab === "file" ? (
+            <div className={styles.field}>
+              <label>File</label>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".md,.txt,.docx"
+                style={{ display: "none" }}
+                onChange={(e) => handleFile(e.currentTarget.files?.[0] ?? null)}
+              />
+              <div
+                className={`${styles.dropZone} ${dragOver ? styles.dropZoneOver : ""} ${file ? styles.dropZoneHas : ""}`}
+                onClick={() => fileInputRef.current?.click()}
+                onDragOver={(e) => {
+                  e.preventDefault();
+                  setDragOver(true);
+                }}
+                onDragLeave={() => setDragOver(false)}
+                onDrop={(e) => {
+                  e.preventDefault();
+                  setDragOver(false);
+                  const f = e.dataTransfer.files?.[0];
+                  if (f) handleFile(f);
+                }}
+              >
+                <span className={styles.dropIco}>
+                  <IconUpload size={20} />
+                </span>
+                {file ? (
+                  <>
+                    <div className={ui.mono} style={{ fontWeight: 600, fontSize: 14, marginTop: 10 }}>
+                      {file.name}
+                    </div>
+                    <span className={ui.faint} style={{ fontSize: 12.5 }}>
+                      Ready to ingest · click to replace
+                    </span>
+                  </>
+                ) : (
+                  <>
+                    <div style={{ fontWeight: 600, fontSize: 14, marginTop: 10 }}>
+                      Drop a file or click to browse
+                    </div>
+                    <span className={ui.faint} style={{ fontSize: 12.5 }}>
+                      .md · .txt · .docx
+                    </span>
+                  </>
+                )}
+              </div>
+              {filenameCheck?.exists && (
+                <Alert color="blue" variant="light" mt="sm">
+                  A document named "{filenameCheck.title}" already exists (updated{" "}
+                  {filenameCheck.updated_at
+                    ? new Date(filenameCheck.updated_at).toLocaleDateString()
+                    : "unknown"}
+                  ). Enable "Update existing" to overwrite it.
+                </Alert>
+              )}
+            </div>
+          ) : (
             <div className={styles.field}>
               <div className={ui.row} style={{ justifyContent: "space-between", marginBottom: 8 }}>
                 <label style={{ margin: 0 }}>Content</label>
@@ -453,7 +480,7 @@ export function IngestPage() {
                 <span className={ui.cliS}>./{file?.name ?? "doc.md"}</span> \
               </div>
               <div style={{ paddingLeft: 16 }}>
-                --project <span className={ui.cliS}>{firstProjectName}</span>
+                --project-name <span className={ui.cliS}>{firstProjectName}</span>
               </div>
               <div className={ui.cliOut}>→ ~{chunkEstimate || "?"} chunks · staged</div>
             </div>

--- a/frontend/src/pages/IngestPage.tsx
+++ b/frontend/src/pages/IngestPage.tsx
@@ -1,85 +1,70 @@
-import {
-  Alert,
-  Button,
-  Container,
-  FileInput,
-  Group,
-  MultiSelect,
-  Stack,
-  Tabs,
-  TextInput,
-  Textarea,
-  Title,
-  Text,
-  ActionIcon,
-  Select,
-  SegmentedControl,
-} from "@mantine/core";
-import { IconCheck, IconFileUpload, IconPlus, IconTextSize, IconX } from "@tabler/icons-react";
+import { Alert } from "@mantine/core";
+import { IconCheck, IconFileText, IconPlus, IconTerminal2, IconUpload, IconX } from "@tabler/icons-react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
-import { MarkdownViewer } from "../components/MarkdownViewer";
-
-import { ingestPaste, checkFilename } from "../api/documents";
 import { detectV07FromResponse } from "../api/client";
-import { useMetadataKeys, useProjects } from "../hooks/useProjects";
+import { checkFilename, ingestPaste } from "../api/documents";
 import type { FilenameCheckResponse, IngestResponse } from "../api/types";
+import { MarkdownViewer } from "../components/MarkdownViewer";
+import { useMetadataKeys, useProjects } from "../hooks/useProjects";
 import { showError, showV07DeferredToast } from "../utils/notifications";
+import ui from "../styles/redesign.module.css";
+import styles from "./IngestPage.module.css";
+
+const PROJECT_COLORS = ["--primary", "--violet", "--blue", "--green", "--yellow", "--red"];
+
+type Tab = "paste" | "file";
 
 export function IngestPage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { data: projects } = useProjects();
   const { data: metadataKeys } = useMetadataKeys();
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
-  // Paste mode state
+  const [tab, setTab] = useState<Tab>("paste");
   const [title, setTitle] = useState("");
-  const [content, setContent] = useState("");
   const [projectIds, setProjectIds] = useState<string[]>([]);
-  const [updateExisting, setUpdateExisting] = useState(false);
   const [metaPairs, setMetaPairs] = useState<{ key: string; value: string }[]>([]);
-  const [contentView, setContentView] = useState<string>("edit");
-
-  // File mode state
+  const [updateExisting, setUpdateExisting] = useState(false);
+  const [content, setContent] = useState("");
+  const [contentView, setContentView] = useState<"edit" | "preview">("edit");
   const [file, setFile] = useState<File | null>(null);
-  const [fileTitle, setFileTitle] = useState("");
-  const [fileProjectIds, setFileProjectIds] = useState<string[]>([]);
-  const [fileUpdateExisting, setFileUpdateExisting] = useState(false);
-  const [fileMetaPairs, setFileMetaPairs] = useState<{ key: string; value: string }[]>([]);
+  const [dragOver, setDragOver] = useState(false);
   const [filenameCheck, setFilenameCheck] = useState<FilenameCheckResponse | null>(null);
-
-  // Shared result
   const [result, setResult] = useState<IngestResponse | null>(null);
 
+  const collectMeta = () => {
+    const metadata: Record<string, string> = {};
+    for (const p of metaPairs) {
+      if (p.key.trim() && p.value.trim()) metadata[p.key.trim()] = p.value.trim();
+    }
+    return metadata;
+  };
+
+  const onIngestSuccess = (res: IngestResponse) => {
+    setResult(res);
+    if (res.success) queryClient.invalidateQueries({ queryKey: ["dashboard"] });
+  };
+  const onIngestError = (err: unknown) => {
+    if (!showV07DeferredToast(err)) {
+      showError("Ingest failed", err instanceof Error ? err.message : String(err));
+    }
+  };
+
   const pasteMutation = useMutation({
-    mutationFn: () => {
-      const metadata: Record<string, string> = {};
-      for (const pair of metaPairs) {
-        if (pair.key.trim() && pair.value.trim()) {
-          metadata[pair.key.trim()] = pair.value.trim();
-        }
-      }
-      return ingestPaste({
+    mutationFn: () =>
+      ingestPaste({
         title,
         content,
         update_existing: updateExisting,
         project_ids: projectIds,
-        metadata,
-      });
-    },
-    onSuccess: (res) => {
-      setResult(res);
-      if (res.success) {
-        queryClient.invalidateQueries({ queryKey: ["dashboard"] });
-      }
-    },
-    onError: (err) => {
-      if (!showV07DeferredToast(err)) {
-        showError("Ingest failed", err instanceof Error ? err.message : String(err));
-      }
-    },
+        metadata: collectMeta(),
+      }),
+    onSuccess: onIngestSuccess,
+    onError: onIngestError,
   });
 
   const fileMutation = useMutation({
@@ -87,25 +72,12 @@ export function IngestPage() {
       if (!file) throw new Error("No file selected");
       const formData = new FormData();
       formData.append("file", file);
-      if (fileTitle.trim()) formData.append("title", fileTitle.trim());
-      formData.append("update_existing", String(fileUpdateExisting));
-      if (fileProjectIds.length > 0) {
-        formData.append("project_ids", fileProjectIds.join(","));
-      }
-      const fileMeta: Record<string, string> = {};
-      for (const pair of fileMetaPairs) {
-        if (pair.key.trim() && pair.value.trim()) {
-          fileMeta[pair.key.trim()] = pair.value.trim();
-        }
-      }
-      if (Object.keys(fileMeta).length > 0) {
-        formData.append("metadata", JSON.stringify(fileMeta));
-      }
-
-      const resp = await fetch("/api/v1/ingest/file", {
-        method: "POST",
-        body: formData,
-      });
+      if (title.trim()) formData.append("title", title.trim());
+      formData.append("update_existing", String(updateExisting));
+      if (projectIds.length > 0) formData.append("project_ids", projectIds.join(","));
+      const meta = collectMeta();
+      if (Object.keys(meta).length > 0) formData.append("metadata", JSON.stringify(meta));
+      const resp = await fetch("/api/v1/ingest/file", { method: "POST", body: formData });
       if (!resp.ok) {
         const v07 = await detectV07FromResponse(resp);
         if (v07) throw v07;
@@ -113,104 +85,50 @@ export function IngestPage() {
       }
       return resp.json() as Promise<IngestResponse>;
     },
-    onSuccess: (res) => {
-      setResult(res);
-      if (res.success) {
-        queryClient.invalidateQueries({ queryKey: ["dashboard"] });
-      }
-    },
-    onError: (err) => {
-      if (!showV07DeferredToast(err)) {
-        showError("File ingest failed", err instanceof Error ? err.message : String(err));
-      }
-    },
+    onSuccess: onIngestSuccess,
+    onError: onIngestError,
   });
 
-  const handleFileChange = async (f: File | null) => {
+  const handleFile = async (f: File | null) => {
     setFile(f);
     setFilenameCheck(null);
     if (f?.name) {
       try {
         const check = await checkFilename(f.name);
         setFilenameCheck(check);
-        if (check.exists) setFileUpdateExisting(true);
+        if (check.exists) setUpdateExisting(true);
       } catch {
-        // ignore check errors
+        /* ignore check errors */
       }
     }
   };
 
-  const projectOptions =
-    projects?.map((p) => ({ value: p.id, label: p.name })) || [];
+  const toggleProject = (id: string) =>
+    setProjectIds((s) => (s.includes(id) ? s.filter((x) => x !== id) : [...s, id]));
 
-  const keyOptions =
-    metadataKeys?.map((mk) => ({
-      value: mk.key,
-      label: `${mk.key} (${mk.doc_count})`,
-    })) || [];
+  const submit = () => (tab === "file" ? fileMutation.mutate() : pasteMutation.mutate());
+  const pending = pasteMutation.isPending || fileMutation.isPending;
+  const canSubmit =
+    tab === "file" ? !!file : title.trim().length > 0 && content.trim().length > 0;
 
-  const renderMetaFields = (
-    pairs: { key: string; value: string }[],
-    setPairs: (p: { key: string; value: string }[]) => void,
-  ) => (
-    <div>
-      <Text size="sm" fw={500} mb="xs">
-        Metadata (optional)
-      </Text>
-      <Stack gap="xs">
-        {pairs.map((pair, idx) => (
-          <Group key={idx} gap="xs">
-            <Select
-              placeholder="Key"
-              data={keyOptions}
-              value={pair.key}
-              onChange={(v) => {
-                const updated = [...pairs];
-                updated[idx] = { ...pair, key: v || "" };
-                setPairs(updated);
-              }}
-              searchable
-              w={200}
-              size="sm"
-            />
-            <TextInput
-              placeholder="Value"
-              value={pair.value}
-              onChange={(e) => {
-                const updated = [...pairs];
-                updated[idx] = { ...pair, value: e.currentTarget.value };
-                setPairs(updated);
-              }}
-              w={250}
-              size="sm"
-            />
-            <ActionIcon
-              variant="subtle"
-              color="red"
-              onClick={() => setPairs(pairs.filter((_, i) => i !== idx))}
-            >
-              <IconX size={14} />
-            </ActionIcon>
-          </Group>
-        ))}
-        <Button
-          variant="light"
-          size="xs"
-          w={140}
-          leftSection={<IconPlus size={14} />}
-          onClick={() => setPairs([...pairs, { key: "", value: "" }])}
-        >
-          Add field
-        </Button>
-      </Stack>
-    </div>
-  );
+  const chunkEstimate =
+    tab === "paste"
+      ? Math.round(content.length / 700)
+      : file
+        ? Math.round(file.size / 700)
+        : 0;
+
+  const firstProjectName =
+    projects?.find((p) => p.id === projectIds[0])?.name ?? "core-platform";
 
   return (
-    <Container size="md">
-      <Title order={2} mb="md">
-        Ingest Content
-      </Title>
+    <div className={styles.wrap}>
+      <div className={ui.pageHead}>
+        <div>
+          <p className={ui.eyebrow}>Add to memory</p>
+          <h1 className={ui.pageTitle}>Ingest content</h1>
+        </div>
+      </div>
 
       {result?.success && (
         <Alert
@@ -223,24 +141,17 @@ export function IngestPage() {
         >
           {result.updated
             ? `"${result.title}" updated and re-indexed.`
-            : `"${result.title}" ingested successfully.`}
+            : `"${result.title}" ingested successfully.`}{" "}
           {result.document_id && (
-            <>
-              {" "}
-              <Text
-                component="span"
-                size="sm"
-                c="blue"
-                style={{ cursor: "pointer", textDecoration: "underline" }}
-                onClick={() => navigate(`/document/${result.document_id}`)}
-              >
-                View document
-              </Text>
-            </>
+            <span
+              style={{ cursor: "pointer", textDecoration: "underline", color: "var(--primary)" }}
+              onClick={() => navigate(`/document/${result.document_id}`)}
+            >
+              View document
+            </span>
           )}
         </Alert>
       )}
-
       {result && !result.success && result.error && (
         <Alert
           icon={<IconX size={16} />}
@@ -254,178 +165,301 @@ export function IngestPage() {
         </Alert>
       )}
 
-      <Tabs defaultValue="paste">
-        <Tabs.List mb="md">
-          <Tabs.Tab value="paste" leftSection={<IconTextSize size={16} />}>
-            Paste Content
-          </Tabs.Tab>
-          <Tabs.Tab value="file" leftSection={<IconFileUpload size={16} />}>
-            Upload File
-          </Tabs.Tab>
-        </Tabs.List>
+      <div className={ui.seg} style={{ marginBottom: 20 }}>
+        <button
+          type="button"
+          className={`${ui.segBtn} ${tab === "paste" ? ui.segBtnOn : ""}`}
+          onClick={() => setTab("paste")}
+        >
+          <IconFileText size={14} />
+          Paste content
+        </button>
+        <button
+          type="button"
+          className={`${ui.segBtn} ${tab === "file" ? ui.segBtnOn : ""}`}
+          onClick={() => setTab("file")}
+        >
+          <IconUpload size={14} />
+          Upload file
+        </button>
+      </div>
 
-        <Tabs.Panel value="paste">
-          <form
-            onSubmit={(e) => {
-              e.preventDefault();
-              pasteMutation.mutate();
-            }}
-          >
-            <Stack gap="md">
-              <TextInput
-                label="Title"
-                value={title}
-                onChange={(e) => setTitle(e.currentTarget.value)}
-                required
-                placeholder="Document title"
+      <form
+        className={styles.split}
+        onSubmit={(e) => {
+          e.preventDefault();
+          if (canSubmit) submit();
+        }}
+      >
+        <div className={styles.col}>
+          {tab === "file" && (
+            <>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".md,.txt,.docx"
+                style={{ display: "none" }}
+                onChange={(e) => handleFile(e.currentTarget.files?.[0] ?? null)}
               />
-
-              {projectOptions.length > 0 && (
-                <MultiSelect
-                  label="Projects"
-                  data={projectOptions}
-                  value={projectIds}
-                  onChange={setProjectIds}
-                  clearable
-                  searchable
-                  placeholder="Assign to projects (optional)"
-                />
-              )}
-
-              {renderMetaFields(metaPairs, setMetaPairs)}
-
-              <div>
-                <Group justify="space-between" mb="xs">
-                  <Text size="sm" fw={500}>
-                    Content
-                  </Text>
-                  <SegmentedControl
-                    size="xs"
-                    value={contentView}
-                    onChange={setContentView}
-                    data={[
-                      { label: "Edit", value: "edit" },
-                      { label: "Preview", value: "preview" },
-                    ]}
-                    w={160}
-                  />
-                </Group>
-                {contentView === "edit" ? (
-                  <Textarea
-                    value={content}
-                    onChange={(e) => setContent(e.currentTarget.value)}
-                    minRows={10}
-                    autosize
-                    required
-                    placeholder="Paste your Markdown content here..."
-                    styles={{ input: { fontFamily: "monospace", fontSize: 13 } }}
-                  />
+              <div
+                className={`${styles.dropZone} ${dragOver ? styles.dropZoneOver : ""} ${file ? styles.dropZoneHas : ""}`}
+                onClick={() => fileInputRef.current?.click()}
+                onDragOver={(e) => {
+                  e.preventDefault();
+                  setDragOver(true);
+                }}
+                onDragLeave={() => setDragOver(false)}
+                onDrop={(e) => {
+                  e.preventDefault();
+                  setDragOver(false);
+                  const f = e.dataTransfer.files?.[0];
+                  if (f) handleFile(f);
+                }}
+              >
+                <span className={styles.dropIco}>
+                  <IconUpload size={20} />
+                </span>
+                {file ? (
+                  <>
+                    <div className={ui.mono} style={{ fontWeight: 600, fontSize: 14, marginTop: 10 }}>
+                      {file.name}
+                    </div>
+                    <span className={ui.faint} style={{ fontSize: 12.5 }}>
+                      Ready to ingest · click to replace
+                    </span>
+                  </>
                 ) : (
-                  <div
-                    style={{
-                      border: "1px solid var(--mantine-color-gray-3)",
-                      borderRadius: 8,
-                      padding: 12,
-                      minHeight: 200,
-                    }}
-                  >
-                    <MarkdownViewer
-                      content={content}
-                      defaultView="rendered"
-                      maxHeight={400}
-                      showToggle={false}
-                    />
-                  </div>
+                  <>
+                    <div style={{ fontWeight: 600, fontSize: 14, marginTop: 10 }}>
+                      Drop a file or click to browse
+                    </div>
+                    <span className={ui.faint} style={{ fontSize: 12.5 }}>
+                      .md · .txt · .docx
+                    </span>
+                  </>
                 )}
               </div>
-
-              <Group>
-                <Button type="submit" loading={pasteMutation.isPending}>
-                  Ingest
-                </Button>
-                <Button
-                  variant={updateExisting ? "filled" : "light"}
-                  color={updateExisting ? "yellow" : "gray"}
-                  size="sm"
-                  onClick={() => setUpdateExisting(!updateExisting)}
-                >
-                  {updateExisting ? "Update existing: ON" : "Update existing: OFF"}
-                </Button>
-              </Group>
-            </Stack>
-          </form>
-        </Tabs.Panel>
-
-        <Tabs.Panel value="file">
-          <form
-            onSubmit={(e) => {
-              e.preventDefault();
-              fileMutation.mutate();
-            }}
-          >
-            <Stack gap="md">
-              <FileInput
-                label="File"
-                placeholder="Select a .md, .txt, or .docx file"
-                accept=".md,.txt,.docx"
-                value={file}
-                onChange={handleFileChange}
-                required
-              />
-
               {filenameCheck?.exists && (
                 <Alert color="blue" variant="light">
-                  <Text size="sm">
-                    A document with filename "{filenameCheck.title}" already
-                    exists (last updated{" "}
-                    {filenameCheck.updated_at
-                      ? new Date(filenameCheck.updated_at).toLocaleDateString()
-                      : "unknown"}
-                    ).
-                  </Text>
+                  A document named "{filenameCheck.title}" already exists (updated{" "}
+                  {filenameCheck.updated_at
+                    ? new Date(filenameCheck.updated_at).toLocaleDateString()
+                    : "unknown"}
+                  ). Enable "Update existing" to overwrite it.
                 </Alert>
               )}
+            </>
+          )}
 
-              <TextInput
-                label="Title (optional)"
-                value={fileTitle}
-                onChange={(e) => setFileTitle(e.currentTarget.value)}
-                placeholder="Defaults to filename if empty"
-              />
+          <div className={styles.field}>
+            <label>
+              Title
+              {tab === "file" && <span className={ui.faint}> (optional — defaults to filename)</span>}
+            </label>
+            <input
+              className={styles.input}
+              value={title}
+              onChange={(e) => setTitle(e.currentTarget.value)}
+              placeholder="Document title"
+            />
+          </div>
 
-              {projectOptions.length > 0 && (
-                <MultiSelect
-                  label="Projects"
-                  data={projectOptions}
-                  value={fileProjectIds}
-                  onChange={setFileProjectIds}
-                  clearable
-                  searchable
-                  placeholder="Assign to projects (optional)"
+          {projects && projects.length > 0 && (
+            <div className={styles.field}>
+              <label>Projects</label>
+              <div className={ui.row} style={{ gap: 7, flexWrap: "wrap" }}>
+                {projects.map((p, i) => (
+                  <button
+                    key={p.id}
+                    type="button"
+                    className={`${ui.chip} ${projectIds.includes(p.id) ? ui.chipOn : ""}`}
+                    onClick={() => toggleProject(p.id)}
+                  >
+                    <span
+                      style={{
+                        width: 7,
+                        height: 7,
+                        borderRadius: "50%",
+                        background: `var(${PROJECT_COLORS[i % PROJECT_COLORS.length]})`,
+                      }}
+                    />
+                    {p.name}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <div className={styles.field}>
+            <label>
+              Metadata <span className={ui.faint}>(optional)</span>
+            </label>
+            <datalist id="cerefox-meta-keys">
+              {metadataKeys?.map((mk) => (
+                <option key={mk.key} value={mk.key} />
+              ))}
+            </datalist>
+            <div className={ui.col} style={{ gap: 8 }}>
+              {metaPairs.map((p, i) => (
+                <div key={i} className={ui.row} style={{ gap: 8 }}>
+                  <input
+                    className={styles.input}
+                    style={{ flex: 1 }}
+                    list="cerefox-meta-keys"
+                    placeholder="key"
+                    value={p.key}
+                    onChange={(e) =>
+                      setMetaPairs((m) =>
+                        m.map((x, idx) => (idx === i ? { ...x, key: e.currentTarget.value } : x)),
+                      )
+                    }
+                  />
+                  <input
+                    className={styles.input}
+                    style={{ flex: 1 }}
+                    placeholder="value"
+                    value={p.value}
+                    onChange={(e) =>
+                      setMetaPairs((m) =>
+                        m.map((x, idx) => (idx === i ? { ...x, value: e.currentTarget.value } : x)),
+                      )
+                    }
+                  />
+                  <button
+                    type="button"
+                    className={ui.iconBtn}
+                    aria-label="Remove"
+                    onClick={() => setMetaPairs((m) => m.filter((_, idx) => idx !== i))}
+                  >
+                    <IconX size={15} />
+                  </button>
+                </div>
+              ))}
+              <button
+                type="button"
+                className={`${ui.btn} ${ui.btnSubtle}`}
+                style={{ alignSelf: "flex-start" }}
+                onClick={() => setMetaPairs((m) => [...m, { key: "", value: "" }])}
+              >
+                <IconPlus size={14} />
+                Add field
+              </button>
+            </div>
+          </div>
+
+          {tab === "paste" && (
+            <div className={styles.field}>
+              <div className={ui.row} style={{ justifyContent: "space-between", marginBottom: 8 }}>
+                <label style={{ margin: 0 }}>Content</label>
+                <div className={ui.seg} style={{ padding: 2 }}>
+                  <button
+                    type="button"
+                    className={`${ui.segBtn} ${contentView === "edit" ? ui.segBtnOn : ""}`}
+                    style={{ padding: "4px 10px" }}
+                    onClick={() => setContentView("edit")}
+                  >
+                    Edit
+                  </button>
+                  <button
+                    type="button"
+                    className={`${ui.segBtn} ${contentView === "preview" ? ui.segBtnOn : ""}`}
+                    style={{ padding: "4px 10px" }}
+                    onClick={() => setContentView("preview")}
+                  >
+                    Preview
+                  </button>
+                </div>
+              </div>
+              {contentView === "edit" ? (
+                <textarea
+                  className={`${styles.input} ${styles.textarea}`}
+                  value={content}
+                  onChange={(e) => setContent(e.currentTarget.value)}
+                  placeholder="# Paste your Markdown here…"
                 />
+              ) : (
+                <div className={`${ui.card} ${ui.cardPad} ${styles.preview}`}>
+                  {content.trim() ? (
+                    <MarkdownViewer content={content} defaultView="rendered" maxHeight={400} showToggle={false} />
+                  ) : (
+                    <span className={ui.faint}>Nothing to preview yet.</span>
+                  )}
+                </div>
               )}
+            </div>
+          )}
 
-              {renderMetaFields(fileMetaPairs, setFileMetaPairs)}
+          <div className={styles.actions}>
+            <button type="submit" className={`${ui.btn} ${ui.btnPrimary}`} disabled={!canSubmit || pending}>
+              <IconCheck size={16} />
+              {tab === "file" ? "Upload & ingest" : "Ingest"}
+            </button>
+            <label className={styles.toggleRow}>
+              <button
+                type="button"
+                className={`${styles.toggle} ${updateExisting ? styles.toggleOn : ""}`}
+                role="switch"
+                aria-checked={updateExisting}
+                onClick={() => setUpdateExisting((v) => !v)}
+              >
+                <span />
+              </button>
+              <span style={{ fontSize: 13 }}>Update existing if title matches</span>
+            </label>
+          </div>
+        </div>
 
-              <Group>
-                <Button type="submit" loading={fileMutation.isPending}>
-                  Upload &amp; Ingest
-                </Button>
-                <Button
-                  variant={fileUpdateExisting ? "filled" : "light"}
-                  color={fileUpdateExisting ? "yellow" : "gray"}
-                  size="sm"
-                  onClick={() => setFileUpdateExisting(!fileUpdateExisting)}
-                >
-                  {fileUpdateExisting
-                    ? "Update existing: ON"
-                    : "Update existing: OFF"}
-                </Button>
-              </Group>
-            </Stack>
-          </form>
-        </Tabs.Panel>
-      </Tabs>
-    </Container>
+        {/* rail */}
+        <aside className={styles.col}>
+          <div className={`${ui.card} ${ui.cardPad} ${ui.rise}`}>
+            <div className={ui.mono} style={{ fontSize: 10.5, letterSpacing: "0.1em", textTransform: "uppercase", color: "var(--text-faint)", marginBottom: 12 }}>
+              Pipeline
+            </div>
+            <ol className={styles.steps}>
+              <li>
+                <span className={styles.stepN}>1</span>
+                <div>
+                  <b>Chunked</b>
+                  <span className="faint">
+                    Split on headings into ~{chunkEstimate || "—"} semantic chunks.
+                  </span>
+                </div>
+              </li>
+              <li>
+                <span className={styles.stepN}>2</span>
+                <div>
+                  <b>Embedded</b>
+                  <span className="faint">Each chunk vectorized for semantic search.</span>
+                </div>
+              </li>
+              <li>
+                <span className={styles.stepN}>3</span>
+                <div>
+                  <b>Staged</b>
+                  <span className="faint">Indexed and discoverable by your agents.</span>
+                </div>
+              </li>
+            </ol>
+          </div>
+
+          <div className={`${ui.card} ${ui.cliCard} ${ui.rise}`}>
+            <div className={ui.row} style={{ gap: 8, marginBottom: 10 }}>
+              <IconTerminal2 size={15} />
+              <span style={{ fontWeight: 600, fontSize: 13.5 }}>CLI equivalent</span>
+            </div>
+            <div className={ui.cliBlock}>
+              <div>
+                <span className={ui.cliP}>$</span> cerefox document ingest{" "}
+                <span className={ui.cliS}>./{file?.name ?? "doc.md"}</span> \
+              </div>
+              <div style={{ paddingLeft: 16 }}>
+                --project <span className={ui.cliS}>{firstProjectName}</span>
+              </div>
+              <div className={ui.cliOut}>→ ~{chunkEstimate || "?"} chunks · staged</div>
+            </div>
+          </div>
+        </aside>
+      </form>
+    </div>
   );
 }

--- a/frontend/src/pages/MetadataSearchPage.tsx
+++ b/frontend/src/pages/MetadataSearchPage.tsx
@@ -15,6 +15,7 @@ import {
   Title,
 } from "@mantine/core";
 import ui from "../styles/redesign.module.css";
+import { CliHint } from "../components/CliHint";
 import { IconPlus, IconSearch, IconTrash } from "@tabler/icons-react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useCallback, useState } from "react";
@@ -108,10 +109,21 @@ export function MetadataSearchPage() {
 
   return (
     <Container size="lg">
-      <p className={ui.eyebrow}>Knowledge base</p>
-      <Title order={2} mb="md">
-        Metadata Search
-      </Title>
+      <Group justify="space-between" align="flex-start" mb="md" wrap="nowrap">
+        <div>
+          <p className={ui.eyebrow}>Knowledge base</p>
+          <Title order={2}>Metadata Search</Title>
+        </div>
+        <CliHint
+          command={`cerefox metadata search -f '${JSON.stringify(
+            (() => {
+              const mf: Record<string, string> = {};
+              for (const f of filters) if (f.key.trim() && f.value.trim()) mf[f.key.trim()] = f.value.trim();
+              return Object.keys(mf).length ? mf : { key: "value" };
+            })(),
+          )}'`}
+        />
+      </Group>
 
       {/* ── Controls ──────────────────────────────────────────────────── */}
       <Card withBorder mb="md" p="md">

--- a/frontend/src/pages/MetadataSearchPage.tsx
+++ b/frontend/src/pages/MetadataSearchPage.tsx
@@ -1,136 +1,86 @@
 import {
   ActionIcon,
-  Badge,
   Button,
   Card,
-  Checkbox,
-  Container,
   Group,
-  Loader,
   NumberInput,
   Select,
   Stack,
   Text,
   TextInput,
-  Title,
 } from "@mantine/core";
-import ui from "../styles/redesign.module.css";
-import { CliHint } from "../components/CliHint";
 import { IconPlus, IconSearch, IconTrash } from "@tabler/icons-react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useCallback, useState } from "react";
+import { useNavigate } from "react-router-dom";
 
-import {
-  fetchMetadataSearch,
-  type MetadataSearchParams,
-} from "../api/metadataSearch";
+import { fetchMetadataSearch, type MetadataSearchParams } from "../api/metadataSearch";
 import { fetchMetadataKeys, fetchProjects } from "../api/projects";
 import type { MetadataSearchResult } from "../api/types";
+import { CliHint } from "../components/CliHint";
+import ui from "../styles/redesign.module.css";
+import lp from "../components/ListPage.module.css";
 
 export function MetadataSearchPage() {
-  // ── Filter state ─────────────────────────────────────────────────────────
-  const [filters, setFilters] = useState<Array<{ key: string; value: string }>>([
-    { key: "", value: "" },
-  ]);
+  const navigate = useNavigate();
+  const [filters, setFilters] = useState<Array<{ key: string; value: string }>>([{ key: "", value: "" }]);
   const [projectId, setProjectId] = useState<string>("");
   const [updatedSince, setUpdatedSince] = useState("");
   const [createdSince, setCreatedSince] = useState("");
-  const [limit, setLimit] = useState<number>(10);
-  const [includeContent, setIncludeContent] = useState(false);
+  const [limit, setLimit] = useState<number>(25);
 
-  // ── Autocomplete data ────────────────────────────────────────────────────
-  const { data: metadataKeys } = useQuery({
-    queryKey: ["metadataKeys"],
-    queryFn: fetchMetadataKeys,
-    staleTime: 60_000,
-  });
+  const { data: metadataKeys } = useQuery({ queryKey: ["metadataKeys"], queryFn: fetchMetadataKeys, staleTime: 60_000 });
+  const { data: projects } = useQuery({ queryKey: ["projects"], queryFn: fetchProjects, staleTime: 60_000 });
 
-  const { data: projects } = useQuery({
-    queryKey: ["projects"],
-    queryFn: fetchProjects,
-    staleTime: 60_000,
-  });
+  const keySuggestions = (metadataKeys ?? []).map((k) => ({ value: k.key, label: `${k.key} (${k.doc_count} docs)` }));
+  const projectOptions = [{ value: "", label: "All projects" }, ...(projects ?? []).map((p) => ({ value: p.id, label: p.name }))];
 
-  const keySuggestions = (metadataKeys ?? []).map((k) => ({
-    value: k.key,
-    label: `${k.key} (${k.doc_count} docs)`,
-  }));
-
-  const projectOptions = [
-    { value: "", label: "All projects" },
-    ...(projects ?? []).map((p) => ({ value: p.id, label: p.name })),
-  ];
-
-  // ── Filter management ────────────────────────────────────────────────────
   const addFilter = () => setFilters((f) => [...f, { key: "", value: "" }]);
-
-  const removeFilter = (idx: number) =>
-    setFilters((f) => f.filter((_, i) => i !== idx));
-
+  const removeFilter = (idx: number) => setFilters((f) => f.filter((_, i) => i !== idx));
   const updateFilter = (idx: number, field: "key" | "value", val: string) =>
     setFilters((f) => f.map((row, i) => (i === idx ? { ...row, [field]: val } : row)));
 
-  // ── Search mutation ──────────────────────────────────────────────────────
-  const {
-    mutate: doSearch,
-    data: results,
-    isPending,
-    error,
-    reset,
-  } = useMutation({
+  const { mutate: doSearch, data: results, isPending, error, reset } = useMutation({
     mutationFn: (params: MetadataSearchParams) => fetchMetadataSearch(params),
   });
 
-  const handleSearch = useCallback(() => {
+  const buildFilter = useCallback(() => {
     const mf: Record<string, string> = {};
-    for (const f of filters) {
-      if (f.key.trim() && f.value.trim()) {
-        mf[f.key.trim()] = f.value.trim();
-      }
-    }
-    if (Object.keys(mf).length === 0) return;
+    for (const f of filters) if (f.key.trim() && f.value.trim()) mf[f.key.trim()] = f.value.trim();
+    return mf;
+  }, [filters]);
 
-    const params: MetadataSearchParams = {
-      metadata_filter: mf,
-      limit,
-      include_content: includeContent,
-    };
+  const handleSearch = useCallback(() => {
+    const mf = buildFilter();
+    if (Object.keys(mf).length === 0) return;
+    const params: MetadataSearchParams = { metadata_filter: mf, limit };
     if (projectId) params.project_id = projectId;
     if (updatedSince) params.updated_since = updatedSince;
     if (createdSince) params.created_since = createdSince;
-
     reset();
     doSearch(params);
-  }, [filters, projectId, updatedSince, createdSince, limit, includeContent, doSearch, reset]);
+  }, [buildFilter, projectId, updatedSince, createdSince, limit, doSearch, reset]);
 
-  const validFilterCount = filters.filter(
-    (f) => f.key.trim() && f.value.trim(),
-  ).length;
+  const validFilterCount = filters.filter((f) => f.key.trim() && f.value.trim()).length;
+  const mf = buildFilter();
+  const cliArgs = `-f '${JSON.stringify(Object.keys(mf).length ? mf : { key: "value" })}'`;
 
   return (
-    <Container size="lg">
-      <Group justify="space-between" align="flex-start" mb="md" wrap="nowrap">
+    <div className={lp.wrap}>
+      <div className={ui.pageHead}>
         <div>
           <p className={ui.eyebrow}>Knowledge base</p>
-          <Title order={2}>Metadata Search</Title>
+          <h1 className={ui.pageTitle}>Metadata Search</h1>
+          <p className={ui.pageSub}>Find documents by their metadata keys and values.</p>
         </div>
-        <CliHint
-          cmd="cerefox metadata search"
-          args={`-f '${JSON.stringify(
-            (() => {
-              const mf: Record<string, string> = {};
-              for (const f of filters) if (f.key.trim() && f.value.trim()) mf[f.key.trim()] = f.value.trim();
-              return Object.keys(mf).length ? mf : { key: "value" };
-            })(),
-          )}'`}
-        />
-      </Group>
+        <CliHint cmd="cerefox metadata search" args={cliArgs} />
+      </div>
 
-      {/* ── Controls ──────────────────────────────────────────────────── */}
-      <Card withBorder mb="md" p="md">
+      {/* filter builder */}
+      <Card withBorder mb="md" p="md" radius="lg">
         <Stack gap="sm">
-          <Text fw={500} size="sm">
-            Metadata Filters (all must match)
+          <Text fw={600} size="sm">
+            Metadata filters <span className={ui.faint}>(all must match)</span>
           </Text>
           {filters.map((f, idx) => (
             <Group key={idx} gap="xs" align="flex-end">
@@ -152,257 +102,108 @@ export function MetadataSearchPage() {
                 size="sm"
               />
               {filters.length > 1 && (
-                <ActionIcon
-                  variant="subtle"
-                  color="red"
-                  onClick={() => removeFilter(idx)}
-                  size="md"
-                >
+                <ActionIcon variant="subtle" color="red" onClick={() => removeFilter(idx)} size="md">
                   <IconTrash size={16} />
                 </ActionIcon>
               )}
             </Group>
           ))}
-          <Button
-            variant="subtle"
-            size="xs"
-            leftSection={<IconPlus size={14} />}
-            onClick={addFilter}
-            style={{ alignSelf: "flex-start" }}
-          >
+          <Button variant="subtle" size="xs" leftSection={<IconPlus size={14} />} onClick={addFilter} style={{ alignSelf: "flex-start" }}>
             Add filter
           </Button>
 
           <Group gap="sm" grow>
-            <Select
-              label="Project"
-              data={projectOptions}
-              value={projectId}
-              onChange={(v) => setProjectId(v ?? "")}
-              size="sm"
-              clearable
-            />
-            <NumberInput
-              label="Limit"
-              value={limit}
-              onChange={(v) => setLimit(Number(v) || 10)}
-              min={1}
-              max={100}
-              size="sm"
-            />
+            <Select label="Project" data={projectOptions} value={projectId} onChange={(v) => setProjectId(v ?? "")} size="sm" clearable />
+            <NumberInput label="Limit" value={limit} onChange={(v) => setLimit(Number(v) || 25)} min={1} max={100} size="sm" />
           </Group>
-
           <Group gap="sm" grow>
-            <TextInput
-              label="Updated since"
-              placeholder="YYYY-MM-DD"
-              value={updatedSince}
-              onChange={(e) => setUpdatedSince(e.currentTarget.value)}
-              size="sm"
-            />
-            <TextInput
-              label="Created since"
-              placeholder="YYYY-MM-DD"
-              value={createdSince}
-              onChange={(e) => setCreatedSince(e.currentTarget.value)}
-              size="sm"
-            />
+            <TextInput label="Updated since" type="date" value={updatedSince} onChange={(e) => setUpdatedSince(e.currentTarget.value)} size="sm" />
+            <TextInput label="Created since" type="date" value={createdSince} onChange={(e) => setCreatedSince(e.currentTarget.value)} size="sm" />
           </Group>
 
-          <Group>
-            <Checkbox
-              label="Include document content"
-              checked={includeContent}
-              onChange={(e) => setIncludeContent(e.currentTarget.checked)}
-              size="sm"
-            />
-          </Group>
-
-          <Button
-            leftSection={<IconSearch size={16} />}
-            onClick={handleSearch}
-            disabled={validFilterCount === 0}
-            loading={isPending}
-          >
+          <Button leftSection={<IconSearch size={16} />} onClick={handleSearch} disabled={validFilterCount === 0} loading={isPending} style={{ alignSelf: "flex-start" }}>
             Search
           </Button>
         </Stack>
       </Card>
 
-      {/* ── Results ───────────────────────────────────────────────────── */}
-      {isPending && (
-        <Group justify="center" mt="xl">
-          <Loader />
-        </Group>
-      )}
-
+      {/* results */}
       {error && (
         <Text c="red" mt="md">
           Error: {(error as Error).message}
         </Text>
       )}
-
-      {results && results.length === 0 && (
-        <Text c="dimmed" mt="md">
-          No documents match the metadata filter.
-        </Text>
-      )}
-
-      {results && results.length > 0 && (
-        <Stack gap="sm" mt="md">
-          <Text size="sm" c="dimmed">
-            {results.length} document{results.length !== 1 ? "s" : ""} found
-          </Text>
-          {results.map((doc: MetadataSearchResult) => (
-            <MetadataResultCard
-              key={doc.document_id}
-              doc={doc}
-              showContent={includeContent}
-            />
-          ))}
-        </Stack>
-      )}
-    </Container>
-  );
-}
-
-// ── Result card component ──────────────────────────────────────────────────
-
-function MetadataResultCard({
-  doc,
-  showContent,
-}: {
-  doc: MetadataSearchResult;
-  showContent: boolean;
-}) {
-  const [expanded, setExpanded] = useState(false);
-  const [renderMd, setRenderMd] = useState(true);
-  const metaEntries = Object.entries(doc.doc_metadata ?? {});
-  const topMeta = metaEntries.slice(0, 3);
-  const hasMoreMeta = metaEntries.length > 3;
-
-  return (
-    <Card withBorder p="sm">
-      {/* ── Collapsed: click anywhere to expand/collapse ───────────── */}
-      <div
-        style={{ cursor: "pointer" }}
-        onClick={() => setExpanded((e) => !e)}
-      >
-        <Group justify="space-between" mb={4}>
-          <Group gap="xs">
-            <Text fw={600} size="sm">{doc.title}</Text>
-            <Badge size="xs" variant="light" color={doc.review_status === "approved" ? "green" : "yellow"}>
-              {doc.review_status}
-            </Badge>
-          </Group>
-        </Group>
-
-        <Group gap={4} mb={4}>
-          {(expanded ? metaEntries : topMeta).map(([k, v]) => (
-            <Badge key={k} size="xs" variant="outline">
-              {k}={String(v).length > 30 ? String(v).slice(0, 28) + "..." : String(v)}
-            </Badge>
-          ))}
-          {!expanded && hasMoreMeta && (
-            <Badge size="xs" variant="light" c="dimmed">+{metaEntries.length - 3} more</Badge>
-          )}
-        </Group>
-
-        {doc.project_names.length > 0 && (
-          <Group gap={4} mb={4}>
-            {doc.project_names.map((name) => (
-              <Badge key={name} size="xs" variant="filled" color="blue">{name}</Badge>
-            ))}
-          </Group>
-        )}
-
-        <Text size="xs" c="dimmed">
-          {doc.total_chars.toLocaleString()} chars | {doc.chunk_count} chunks |
-          {doc.version_count > 0 ? ` ${doc.version_count} versions |` : ""} updated{" "}
-          {doc.updated_at?.slice(0, 10) ?? "?"}
-        </Text>
-      </div>
-
-      {/* ── Expanded: full metadata + content + link ───────────────── */}
-      {expanded && (
-        <Stack gap="xs" mt="sm">
-          {/* All metadata as key-value table */}
-          {metaEntries.length > 0 && (
-            <Card p="xs" bg="var(--mantine-color-gray-light)" radius="sm">
-              <Text size="xs" fw={500} mb={4}>All Metadata</Text>
-              {metaEntries.map(([k, v]) => (
-                <Group key={k} gap={4}>
-                  <Text size="xs" fw={500} c="dimmed" style={{ minWidth: 100 }}>{k}:</Text>
-                  <Text size="xs">{String(v)}</Text>
-                </Group>
-              ))}
-            </Card>
-          )}
-
-          {/* Document fields */}
-          <Group gap="xs">
-            <Text size="xs" c="dimmed">ID: {doc.document_id}</Text>
-            {doc.source && <Text size="xs" c="dimmed">| Source: {doc.source}</Text>}
-            <Text size="xs" c="dimmed">| Created: {doc.created_at?.slice(0, 10) ?? "?"}</Text>
-          </Group>
-
-          {/* Content viewer with raw/md toggle */}
-          {showContent && doc.content && (
-            <Card p="xs" withBorder radius="sm">
-              <Group justify="space-between" mb={4}>
-                <Text size="xs" fw={500}>Content</Text>
-                <Button
-                  size="compact-xs"
-                  variant="subtle"
-                  onClick={() => setRenderMd((r) => !r)}
-                >
-                  {renderMd ? "Raw" : "Rendered"}
-                </Button>
-              </Group>
-              {renderMd ? (
-                <div
-                  style={{ maxHeight: 300, overflow: "auto", fontSize: 12 }}
-                  dangerouslySetInnerHTML={{
-                    __html: doc.content
-                      .replace(/^### (.+)$/gm, "<h4>$1</h4>")
-                      .replace(/^## (.+)$/gm, "<h3>$1</h3>")
-                      .replace(/^# (.+)$/gm, "<h2>$1</h2>")
-                      .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
-                      .replace(/\n\n/g, "<br/><br/>")
-                      .replace(/\n/g, "<br/>"),
-                  }}
-                />
+      {results && (
+        <div className={`${ui.card} ${ui.rise}`} style={{ overflow: "hidden" }}>
+          <table className={lp.tbl}>
+            <thead>
+              <tr>
+                <th>Document</th>
+                <th>Metadata</th>
+                <th style={{ width: 160 }}>Project</th>
+                <th style={{ width: 110, textAlign: "right" }}>Updated</th>
+              </tr>
+            </thead>
+            <tbody>
+              {results.length === 0 ? (
+                <tr>
+                  <td colSpan={4} className={lp.emptyRow}>
+                    No documents match the metadata filter.
+                  </td>
+                </tr>
               ) : (
-                <Text
-                  size="xs"
-                  style={{
-                    whiteSpace: "pre-wrap",
-                    maxHeight: 300,
-                    overflow: "auto",
-                    fontFamily: "monospace",
-                  }}
-                >
-                  {doc.content}
-                </Text>
+                results.map((doc: MetadataSearchResult) => {
+                  const entries = Object.entries(doc.doc_metadata ?? {});
+                  return (
+                    <tr
+                      key={doc.document_id}
+                      style={{ cursor: "pointer" }}
+                      onClick={() => navigate(`/document/${doc.document_id}`)}
+                    >
+                      <td>
+                        <span className={ui.link} style={{ fontSize: 13.5 }}>
+                          {doc.title}
+                        </span>
+                      </td>
+                      <td>
+                        <span style={{ display: "inline-flex", gap: 6, flexWrap: "wrap" }}>
+                          {entries.slice(0, 3).map(([k, v]) => (
+                            <span key={k} className={`${ui.badge} ${ui.bNeutral}`}>
+                              {k}={String(v).length > 24 ? `${String(v).slice(0, 22)}…` : String(v)}
+                            </span>
+                          ))}
+                          {entries.length > 3 && (
+                            <span className={`${ui.badge} ${ui.bNeutral}`}>+{entries.length - 3}</span>
+                          )}
+                        </span>
+                      </td>
+                      <td>
+                        <span style={{ display: "inline-flex", gap: 4, flexWrap: "wrap" }}>
+                          {doc.project_names.map((n) => (
+                            <span key={n} className={`${ui.badge} ${ui.bNeutral}`}>
+                              {n}
+                            </span>
+                          ))}
+                        </span>
+                      </td>
+                      <td style={{ textAlign: "right" }}>
+                        <span className={`${ui.faint} ${ui.mono}`} style={{ fontSize: 12 }}>
+                          {doc.updated_at?.slice(0, 10) ?? "?"}
+                        </span>
+                      </td>
+                    </tr>
+                  );
+                })
               )}
-            </Card>
-          )}
-
-          {/* Link to document detail (opens in new tab) */}
-          <Group>
-            <Button
-              component="a"
-              href={`/app/document/${doc.document_id}`}
-              target="_blank"
-              rel="noopener"
-              size="compact-xs"
-              variant="light"
-            >
-              View Document Details
-            </Button>
-          </Group>
-        </Stack>
+            </tbody>
+          </table>
+          <div className={lp.foot}>
+            <span className={lp.faint}>
+              {results.length} document{results.length !== 1 ? "s" : ""}
+            </span>
+          </div>
+        </div>
       )}
-    </Card>
+    </div>
   );
 }

--- a/frontend/src/pages/MetadataSearchPage.tsx
+++ b/frontend/src/pages/MetadataSearchPage.tsx
@@ -14,6 +14,7 @@ import {
   TextInput,
   Title,
 } from "@mantine/core";
+import ui from "../styles/redesign.module.css";
 import { IconPlus, IconSearch, IconTrash } from "@tabler/icons-react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useCallback, useState } from "react";
@@ -107,6 +108,7 @@ export function MetadataSearchPage() {
 
   return (
     <Container size="lg">
+      <p className={ui.eyebrow}>Knowledge base</p>
       <Title order={2} mb="md">
         Metadata Search
       </Title>

--- a/frontend/src/pages/MetadataSearchPage.tsx
+++ b/frontend/src/pages/MetadataSearchPage.tsx
@@ -115,7 +115,8 @@ export function MetadataSearchPage() {
           <Title order={2}>Metadata Search</Title>
         </div>
         <CliHint
-          command={`cerefox metadata search -f '${JSON.stringify(
+          cmd="cerefox metadata search"
+          args={`-f '${JSON.stringify(
             (() => {
               const mf: Record<string, string> = {};
               for (const f of filters) if (f.key.trim() && f.value.trim()) mf[f.key.trim()] = f.value.trim();

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -1,44 +1,38 @@
-import {
-  ActionIcon,
-  Button,
-  Card,
-  Container,
-  Grid,
-  Group,
-  Loader,
-  Modal,
-  Stack,
-  Text,
-  TextInput,
-  Title,
-} from "@mantine/core";
-import ui from "../styles/redesign.module.css";
-import { IconEdit, IconTrash } from "@tabler/icons-react";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Button, Group, Modal, Stack, TextInput } from "@mantine/core";
+import { IconEdit, IconPlus, IconTrash } from "@tabler/icons-react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 
-import {
-  createProject,
-  deleteProject,
-  updateProject,
-} from "../api/projects";
+import { fetchDashboard } from "../api/dashboard";
+import { createProject, deleteProject, updateProject } from "../api/projects";
+import type { Project } from "../api/types";
+import { CliHint } from "../components/CliHint";
+import { ListPage, type ListColumn } from "../components/ListPage";
 import { useProjects } from "../hooks/useProjects";
-import { showSuccess, showError } from "../utils/notifications";
+import { showError, showSuccess } from "../utils/notifications";
+import ui from "../styles/redesign.module.css";
+
+const PROJECT_COLORS = ["--primary", "--violet", "--blue", "--green", "--yellow", "--red"];
 
 export function ProjectsPage() {
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { data: projects, isLoading } = useProjects();
+  const { data: dash } = useQuery({ queryKey: ["dashboard"], queryFn: fetchDashboard });
 
-  // Create form
+  const docCounts = dash?.project_doc_counts ?? {};
+  const trashCounts = dash?.project_deleted_doc_counts ?? {};
+  const maxDocs = Math.max(1, ...Object.values(docCounts));
+  const colorMap = new Map((projects ?? []).map((p, i) => [p.id, PROJECT_COLORS[i % PROJECT_COLORS.length]]));
+
+  const [query, setQuery] = useState("");
+  const [createOpen, setCreateOpen] = useState(false);
   const [newName, setNewName] = useState("");
   const [newDesc, setNewDesc] = useState("");
-
-  // Edit modal
   const [editId, setEditId] = useState<string | null>(null);
   const [editName, setEditName] = useState("");
   const [editDesc, setEditDesc] = useState("");
-
-  // Delete confirmation
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
 
   const createMutation = useMutation({
@@ -48,13 +42,12 @@ export function ProjectsPage() {
       showSuccess("Project created");
       setNewName("");
       setNewDesc("");
+      setCreateOpen(false);
     },
     onError: (err) => showError("Create failed", String(err)),
   });
-
   const updateMutation = useMutation({
-    mutationFn: () =>
-      updateProject(editId!, editName.trim(), editDesc.trim()),
+    mutationFn: () => updateProject(editId!, editName.trim(), editDesc.trim()),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["projects"] });
       showSuccess("Project updated");
@@ -62,7 +55,6 @@ export function ProjectsPage() {
     },
     onError: (err) => showError("Update failed", String(err)),
   });
-
   const deleteMutation = useMutation({
     mutationFn: (id: string) => deleteProject(id),
     onSuccess: () => {
@@ -74,130 +66,185 @@ export function ProjectsPage() {
     onError: (err) => showError("Delete failed", String(err)),
   });
 
-  const openEdit = (project: { id: string; name: string; description: string | null }) => {
-    setEditId(project.id);
-    setEditName(project.name);
-    setEditDesc(project.description || "");
-  };
-
-  return (
-    <Container size="lg">
-      <p className={ui.eyebrow}>Organize</p>
-      <Title order={2} mb="md">
-        Projects
-      </Title>
-
-      <Grid>
-        <Grid.Col span={{ base: 12, md: 8 }}>
-          <Title order={4} mb="sm">
-            All Projects
-          </Title>
-          {isLoading ? (
-            <Loader />
-          ) : !projects || projects.length === 0 ? (
-            <Text c="dimmed">No projects yet. Create one to get started.</Text>
-          ) : (
-            <Stack gap="sm">
-              {projects.map((p) => (
-                <Card key={p.id} shadow="xs" padding="sm" radius="md" withBorder>
-                  <Group justify="space-between">
-                    <div>
-                      <Text fw={600} size="sm">
-                        {p.name}
-                      </Text>
-                      {p.description && (
-                        <Text size="xs" c="dimmed">
-                          {p.description}
-                        </Text>
-                      )}
-                    </div>
-                    <Group gap={4}>
-                      <ActionIcon
-                        variant="subtle"
-                        size="sm"
-                        onClick={() => openEdit(p)}
-                      >
-                        <IconEdit size={14} />
-                      </ActionIcon>
-                      {confirmDeleteId === p.id ? (
-                        <Group gap={4}>
-                          <Button
-                            color="red"
-                            size="compact-xs"
-                            onClick={() => deleteMutation.mutate(p.id)}
-                            loading={deleteMutation.isPending}
-                          >
-                            Yes
-                          </Button>
-                          <Button
-                            variant="subtle"
-                            size="compact-xs"
-                            onClick={() => setConfirmDeleteId(null)}
-                          >
-                            No
-                          </Button>
-                        </Group>
-                      ) : (
-                        <ActionIcon
-                          variant="subtle"
-                          color="red"
-                          size="sm"
-                          onClick={() => setConfirmDeleteId(p.id)}
-                        >
-                          <IconTrash size={14} />
-                        </ActionIcon>
-                      )}
-                    </Group>
-                  </Group>
-                </Card>
-              ))}
-            </Stack>
-          )}
-        </Grid.Col>
-
-        <Grid.Col span={{ base: 12, md: 4 }}>
-          <Card shadow="xs" padding="md" radius="md" withBorder>
-            <Title order={5} mb="sm">
-              Create Project
-            </Title>
-            <form
-              onSubmit={(e) => {
-                e.preventDefault();
-                if (newName.trim()) createMutation.mutate();
+  const columns: ListColumn<Project>[] = [
+    {
+      key: "name",
+      label: "Project",
+      render: (p) => (
+        <div style={{ display: "flex", alignItems: "center", gap: 11 }}>
+          <span
+            style={{
+              width: 9,
+              height: 9,
+              borderRadius: "50%",
+              flexShrink: 0,
+              background: `var(${colorMap.get(p.id) ?? "--border"})`,
+            }}
+          />
+          <div style={{ display: "flex", flexDirection: "column", gap: 2, minWidth: 0 }}>
+            <span className={ui.mono} style={{ fontWeight: 600, fontSize: 13 }}>
+              {p.name}
+            </span>
+            {p.description && (
+              <span className={ui.faint} style={{ fontSize: 12 }}>
+                {p.description}
+              </span>
+            )}
+          </div>
+        </div>
+      ),
+    },
+    {
+      key: "docs",
+      label: "Documents",
+      width: 180,
+      render: (p) => {
+        const n = docCounts[p.id] ?? 0;
+        return (
+          <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+            <span className={ui.mono} style={{ fontSize: 13 }}>
+              {n}
+            </span>
+            <span
+              style={{
+                flex: 1,
+                maxWidth: 90,
+                height: 5,
+                borderRadius: 3,
+                background: "var(--surface-2)",
+                overflow: "hidden",
               }}
             >
-              <Stack gap="sm">
-                <TextInput
-                  label="Name"
-                  value={newName}
-                  onChange={(e) => setNewName(e.currentTarget.value)}
-                  required
-                  placeholder="Project name"
-                />
-                <TextInput
-                  label="Description"
-                  value={newDesc}
-                  onChange={(e) => setNewDesc(e.currentTarget.value)}
-                  placeholder="Optional description"
-                />
-                <Button
-                  type="submit"
-                  size="sm"
-                  loading={createMutation.isPending}
-                >
-                  Create
-                </Button>
-              </Stack>
-            </form>
-          </Card>
-        </Grid.Col>
-      </Grid>
+              <span
+                style={{
+                  display: "block",
+                  height: "100%",
+                  width: `${(n / maxDocs) * 100}%`,
+                  background: `var(${colorMap.get(p.id) ?? "--border"})`,
+                }}
+              />
+            </span>
+          </div>
+        );
+      },
+    },
+    {
+      key: "trash",
+      label: "In trash",
+      width: 90,
+      align: "right",
+      render: (p) => {
+        const t = trashCounts[p.id] ?? 0;
+        return t > 0 ? (
+          <span className={`${ui.mono} ${ui.faint}`} style={{ fontSize: 12 }}>
+            {t}
+          </span>
+        ) : (
+          <span className={`${ui.mono} ${ui.faint}`} style={{ fontSize: 12 }}>
+            —
+          </span>
+        );
+      },
+    },
+  ];
 
-      <Modal
-        opened={editId !== null}
-        onClose={() => setEditId(null)}
-        title="Edit Project"
-      >
+  return (
+    <>
+      <ListPage<Project>
+        eyebrow="Memory spaces"
+        title="Projects"
+        subtitle="Scoped collections your agents read from and write to."
+        headerRight={
+          <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 8 }}>
+            <CliHint cmd="cerefox project list" />
+            <button type="button" className={`${ui.btn} ${ui.btnPrimary}`} onClick={() => setCreateOpen(true)}>
+              <IconPlus size={16} />
+              New project
+            </button>
+          </div>
+        }
+        searchValue={query}
+        onSearchChange={setQuery}
+        searchPlaceholder="Filter projects…"
+        searchText={(p) => `${p.name} ${p.description ?? ""}`}
+        columns={columns}
+        rows={projects ?? []}
+        rowKey={(p) => p.id}
+        rowClick={(p) => navigate(`/projects/${p.id}/documents`)}
+        loading={isLoading}
+        emptyText="No projects yet. Create one to get started."
+        actions={(p) =>
+          confirmDeleteId === p.id ? (
+            <>
+              <button
+                type="button"
+                className={`${ui.btn} ${ui.btnSubtle}`}
+                style={{ color: "var(--red)" }}
+                onClick={() => deleteMutation.mutate(p.id)}
+              >
+                Delete
+              </button>
+              <button type="button" className={`${ui.btn} ${ui.btnSubtle}`} onClick={() => setConfirmDeleteId(null)}>
+                Cancel
+              </button>
+            </>
+          ) : (
+            <>
+              <button
+                type="button"
+                className={ui.iconBtnSm}
+                title="Edit"
+                onClick={() => {
+                  setEditId(p.id);
+                  setEditName(p.name);
+                  setEditDesc(p.description || "");
+                }}
+              >
+                <IconEdit size={14} />
+              </button>
+              <button
+                type="button"
+                className={`${ui.iconBtnSm} ${ui.iconBtnDanger}`}
+                title="Delete"
+                onClick={() => setConfirmDeleteId(p.id)}
+              >
+                <IconTrash size={14} />
+              </button>
+            </>
+          )
+        }
+      />
+
+      <Modal opened={createOpen} onClose={() => setCreateOpen(false)} title="New project">
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (newName.trim()) createMutation.mutate();
+          }}
+        >
+          <Stack gap="sm">
+            <TextInput
+              label="Name"
+              value={newName}
+              onChange={(e) => setNewName(e.currentTarget.value)}
+              required
+              placeholder="Project name"
+              data-autofocus
+            />
+            <TextInput
+              label="Description"
+              value={newDesc}
+              onChange={(e) => setNewDesc(e.currentTarget.value)}
+              placeholder="Optional description"
+            />
+            <Button type="submit" loading={createMutation.isPending}>
+              Create
+            </Button>
+          </Stack>
+        </form>
+      </Modal>
+
+      <Modal opened={editId !== null} onClose={() => setEditId(null)} title="Edit project">
         <form
           onSubmit={(e) => {
             e.preventDefault();
@@ -205,18 +252,9 @@ export function ProjectsPage() {
           }}
         >
           <Stack gap="sm">
-            <TextInput
-              label="Name"
-              value={editName}
-              onChange={(e) => setEditName(e.currentTarget.value)}
-              required
-            />
-            <TextInput
-              label="Description"
-              value={editDesc}
-              onChange={(e) => setEditDesc(e.currentTarget.value)}
-            />
-            <Group>
+            <TextInput label="Name" value={editName} onChange={(e) => setEditName(e.currentTarget.value)} required />
+            <TextInput label="Description" value={editDesc} onChange={(e) => setEditDesc(e.currentTarget.value)} />
+            <Group gap="sm">
               <Button type="submit" loading={updateMutation.isPending}>
                 Save
               </Button>
@@ -227,6 +265,6 @@ export function ProjectsPage() {
           </Stack>
         </form>
       </Modal>
-    </Container>
+    </>
   );
 }

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -12,6 +12,7 @@ import {
   TextInput,
   Title,
 } from "@mantine/core";
+import ui from "../styles/redesign.module.css";
 import { IconEdit, IconTrash } from "@tabler/icons-react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
@@ -81,6 +82,7 @@ export function ProjectsPage() {
 
   return (
     <Container size="lg">
+      <p className={ui.eyebrow}>Organize</p>
       <Title order={2} mb="md">
         Projects
       </Title>

--- a/frontend/src/pages/SearchPage.module.css
+++ b/frontend/src/pages/SearchPage.module.css
@@ -1,0 +1,195 @@
+/* Search (redesign) — page-specific layout.
+   Shared primitives in src/styles/redesign.module.css; tokens in tokens.css. */
+
+.wrap {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 34px 24px 80px;
+}
+
+/* ---- search bar ---- */
+.searchBar {
+  padding: 6px;
+}
+.searchInputRow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  color: var(--text-faint);
+}
+.searchInput {
+  flex: 1;
+  min-width: 0;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  font-family: var(--font-ui);
+  font-size: 17px;
+  color: var(--text);
+}
+.searchInput::placeholder {
+  color: var(--text-faint);
+}
+.searchControls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 12px 8px;
+  flex-wrap: wrap;
+}
+.controlsRight {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+  flex-wrap: wrap;
+}
+.filterRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 12px 12px;
+  flex-wrap: wrap;
+}
+
+/* ---- result meta ---- */
+.resultMeta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin: 22px 2px 14px;
+  font-size: 13.5px;
+  color: var(--text-dim);
+}
+
+/* ---- result cards ---- */
+.results {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.resultCard {
+  overflow: hidden;
+  transition: border-color 0.16s, box-shadow 0.16s;
+}
+.resultCard:hover {
+  border-color: var(--border);
+  box-shadow: var(--shadow-md);
+}
+.resultCardOpen {
+  border-color: var(--primary-line);
+}
+.resultHead {
+  display: flex;
+  align-items: flex-start;
+  gap: 15px;
+  padding: 16px 18px;
+  cursor: pointer;
+}
+.resultTitleWrap {
+  flex: 1;
+  min-width: 0;
+}
+.resultTitle {
+  flex: 1;
+  min-width: 0;
+  font-family: var(--font-display);
+  font-size: 16px;
+  font-weight: 600;
+  margin: 0;
+  color: var(--text);
+  letter-spacing: -0.01em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  flex-wrap: nowrap;
+  gap: 2px;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--text-faint);
+  overflow: hidden;
+}
+.breadcrumb > span {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  white-space: nowrap;
+}
+.breadcrumb svg {
+  opacity: 0.6;
+}
+.resultMetaR {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+.chev {
+  color: var(--text-faint);
+  transition: transform 0.2s;
+  display: inline-flex;
+}
+.chevOpen {
+  transform: rotate(180deg);
+}
+.resultSnippet {
+  padding: 0 18px 16px 71px;
+  font-size: 13.5px;
+  line-height: 1.6;
+  color: var(--text-dim);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  white-space: pre-wrap;
+}
+.resultSnippetOpen {
+  -webkit-line-clamp: unset;
+  line-clamp: unset;
+}
+.resultExpand {
+  padding: 0 18px 16px 71px;
+  animation: fade 0.2s ease;
+}
+.resultStats {
+  display: flex;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-faint);
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+.dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.emptyState {
+  text-align: center;
+  padding: 48px;
+  color: var(--text-faint);
+}
+
+@keyframes fade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .resultExpand { animation: none; }
+}
+
+@media (max-width: 720px) {
+  .resultSnippet,
+  .resultExpand {
+    padding-left: 18px;
+  }
+}

--- a/frontend/src/pages/SearchPage.module.css
+++ b/frontend/src/pages/SearchPage.module.css
@@ -4,7 +4,7 @@
 .wrap {
   max-width: 1120px;
   margin: 0 auto;
-  padding: 20px 24px 80px;
+  padding: 8px 24px 80px;
 }
 
 /* ---- search bar ---- */

--- a/frontend/src/pages/SearchPage.module.css
+++ b/frontend/src/pages/SearchPage.module.css
@@ -4,7 +4,7 @@
 .wrap {
   max-width: 1120px;
   margin: 0 auto;
-  padding: 34px 24px 80px;
+  padding: 20px 24px 80px;
 }
 
 /* ---- search bar ---- */

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -53,7 +53,8 @@ export function SearchPage() {
             </span>
           )}
           <CliHint
-            command={`cerefox search "${state.q || "query"}"${state.mode !== "docs" ? ` --mode ${state.mode}` : ""}`}
+            cmd="cerefox search"
+            args={`"${state.q || "query"}"${state.mode !== "docs" ? ` --mode ${state.mode}` : ""}`}
           />
         </div>
       </div>

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -1,16 +1,20 @@
-import { Container, Title } from "@mantine/core";
+import { useQuery } from "@tanstack/react-query";
 import { useCallback } from "react";
 import { useSearchParams } from "react-router-dom";
 
+import { fetchDashboard } from "../api/dashboard";
 import type { SearchMode } from "../api/types";
 import { SearchControls } from "../components/SearchControls";
 import { SearchResults } from "../components/SearchResults";
 import { serializeMfParam, useSearchQuery, useSearchState } from "../hooks/useSearch";
+import ui from "../styles/redesign.module.css";
+import styles from "./SearchPage.module.css";
 
 export function SearchPage() {
   const [, setSearchParams] = useSearchParams();
   const state = useSearchState();
   const { data, isLoading, error } = useSearchQuery(state);
+  const { data: dash } = useQuery({ queryKey: ["dashboard"], queryFn: fetchDashboard });
 
   const handleSearch = useCallback(
     (params: {
@@ -34,13 +38,19 @@ export function SearchPage() {
     [setSearchParams],
   );
 
-  const hasQuery = !!state.q;
-
   return (
-    <Container size="lg">
-      <Title order={2} mb="md">
-        Search Knowledge Base
-      </Title>
+    <div className={styles.wrap}>
+      <div className={ui.pageHead}>
+        <div>
+          <p className={ui.eyebrow}>Knowledge base</p>
+          <h1 className={ui.pageTitle}>Search memory</h1>
+        </div>
+        {dash && (
+          <span className={`${ui.mono} ${ui.faint}`} style={{ fontSize: 12 }}>
+            {dash.doc_count.toLocaleString()} docs · {dash.total_chunks.toLocaleString()} chunks
+          </span>
+        )}
+      </div>
 
       <SearchControls
         query={state.q}
@@ -56,8 +66,8 @@ export function SearchPage() {
         data={data}
         isLoading={isLoading}
         error={error as Error | null}
-        hasQuery={hasQuery}
+        hasQuery={!!state.q}
       />
-    </Container>
+    </div>
   );
 }

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -4,6 +4,7 @@ import { useSearchParams } from "react-router-dom";
 
 import { fetchDashboard } from "../api/dashboard";
 import type { SearchMode } from "../api/types";
+import { CliHint } from "../components/CliHint";
 import { SearchControls } from "../components/SearchControls";
 import { SearchResults } from "../components/SearchResults";
 import { serializeMfParam, useSearchQuery, useSearchState } from "../hooks/useSearch";
@@ -45,11 +46,16 @@ export function SearchPage() {
           <p className={ui.eyebrow}>Knowledge base</p>
           <h1 className={ui.pageTitle}>Search memory</h1>
         </div>
-        {dash && (
-          <span className={`${ui.mono} ${ui.faint}`} style={{ fontSize: 12 }}>
-            {dash.doc_count.toLocaleString()} docs · {dash.total_chunks.toLocaleString()} chunks
-          </span>
-        )}
+        <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 8 }}>
+          {dash && (
+            <span className={`${ui.mono} ${ui.faint}`} style={{ fontSize: 12 }}>
+              {dash.doc_count.toLocaleString()} docs · {dash.total_chunks.toLocaleString()} chunks
+            </span>
+          )}
+          <CliHint
+            command={`cerefox search "${state.q || "query"}"${state.mode !== "docs" ? ` --mode ${state.mode}` : ""}`}
+          />
+        </div>
       </div>
 
       <SearchControls

--- a/frontend/src/pages/TrashPage.tsx
+++ b/frontend/src/pages/TrashPage.tsx
@@ -1,196 +1,196 @@
-import {
-  Badge,
-  Button,
-  Card,
-  Container,
-  Group,
-  Loader,
-  Select,
-  Stack,
-  Text,
-  Title,
-} from "@mantine/core";
-import ui from "../styles/redesign.module.css";
-import { IconRestore, IconTrash } from "@tabler/icons-react";
+import { Select } from "@mantine/core";
+import { IconArrowBackUp, IconTrash } from "@tabler/icons-react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 
-import { fetchTrash, restoreDocument, purgeDocument, type DeletedDocument } from "../api/trash";
+import { fetchTrash, purgeDocument, restoreDocument, type DeletedDocument } from "../api/trash";
+import { CliHint } from "../components/CliHint";
+import { ListPage, type ListColumn } from "../components/ListPage";
 import { useProjects } from "../hooks/useProjects";
+import { showError, showSuccess } from "../utils/notifications";
+import ui from "../styles/redesign.module.css";
+
+const PROJECT_COLORS = ["--primary", "--violet", "--blue", "--green", "--yellow", "--red"];
+function colorFor(name: string): string {
+  let h = 0;
+  for (let i = 0; i < name.length; i++) h = (h * 31 + name.charCodeAt(i)) >>> 0;
+  return `var(${PROJECT_COLORS[h % PROJECT_COLORS.length]})`;
+}
 
 export function TrashPage() {
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { data: projects } = useProjects();
-  // Resolve project_id → name for the chips on each deleted row.
-  // Junction rows are preserved across soft-delete, so the trash UI can
-  // still show which projects a deleted document belonged to.
   const projectMap = new Map(projects?.map((p) => [p.id, p.name]) ?? []);
-  const [limit, setLimit] = useState("50");
 
-  const { data: docs, isLoading, error } = useQuery({
+  const [limit, setLimit] = useState("50");
+  const [query, setQuery] = useState("");
+  const [confirmId, setConfirmId] = useState<string | null>(null);
+
+  const { data: docs, isLoading } = useQuery({
     queryKey: ["trash", limit],
     queryFn: () => fetchTrash(Number(limit)),
     staleTime: 10_000,
   });
-  const atCap = !!docs && docs.length === Number(limit);
 
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: ["trash"] });
+    queryClient.invalidateQueries({ queryKey: ["dashboard"] });
+    queryClient.invalidateQueries({ queryKey: ["search"] });
+  };
   const restoreMut = useMutation({
     mutationFn: restoreDocument,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["trash"] });
-      queryClient.invalidateQueries({ queryKey: ["dashboard"] });
-      queryClient.invalidateQueries({ queryKey: ["search"] });
+      invalidate();
+      showSuccess("Document restored");
     },
+    onError: (e) => showError("Restore failed", String(e)),
   });
-
   const purgeMut = useMutation({
     mutationFn: purgeDocument,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["trash"] });
-      queryClient.invalidateQueries({ queryKey: ["dashboard"] });
-      queryClient.invalidateQueries({ queryKey: ["search"] });
+      invalidate();
+      showSuccess("Permanently deleted");
     },
+    onError: (e) => showError("Purge failed", String(e)),
   });
 
+  const columns: ListColumn<DeletedDocument>[] = [
+    {
+      key: "title",
+      label: "Document",
+      render: (d) => {
+        const firstProj = d.project_ids.find((pid) => projectMap.has(pid));
+        return (
+          <div style={{ display: "flex", alignItems: "center", gap: 11 }}>
+            <span
+              style={{
+                width: 8,
+                height: 8,
+                borderRadius: "50%",
+                flexShrink: 0,
+                background: firstProj ? colorFor(projectMap.get(firstProj)!) : "var(--text-faint)",
+              }}
+            />
+            <span className={ui.link} style={{ fontSize: 13.5 }}>
+              {d.title}
+            </span>
+          </div>
+        );
+      },
+    },
+    {
+      key: "project",
+      label: "Project",
+      width: 160,
+      render: (d) => {
+        const names = d.project_ids.filter((pid) => projectMap.has(pid)).map((pid) => projectMap.get(pid)!);
+        return names.length ? (
+          <span style={{ display: "inline-flex", gap: 4, flexWrap: "wrap" }}>
+            {names.map((n) => (
+              <span key={n} className={`${ui.badge} ${ui.bNeutral}`}>
+                {n}
+              </span>
+            ))}
+          </span>
+        ) : (
+          <span className={ui.faint} style={{ fontSize: 12 }}>
+            —
+          </span>
+        );
+      },
+    },
+    {
+      key: "size",
+      label: "Size",
+      width: 110,
+      align: "right",
+      render: (d) => (
+        <span className={`${ui.mono} ${ui.dim}`} style={{ fontSize: 12 }}>
+          {d.total_chars.toLocaleString()}
+        </span>
+      ),
+    },
+    {
+      key: "deleted",
+      label: "Deleted",
+      width: 120,
+      align: "right",
+      render: (d) => (
+        <span className={`${ui.faint} ${ui.mono}`} style={{ fontSize: 12 }}>
+          {d.deleted_at?.slice(0, 10) ?? "?"}
+        </span>
+      ),
+    },
+  ];
+
   return (
-    <Container size="lg">
-      <p className={ui.eyebrow}>Recoverable</p>
-      <Title order={2} mb="md">Trash</Title>
-      <Group justify="space-between" align="flex-end" mb="md">
-        <Text c="dimmed" size="sm">
-          Deleted documents are recoverable until permanently purged.
-        </Text>
+    <ListPage<DeletedDocument>
+      eyebrow="Recoverable"
+      title="Trash"
+      subtitle="Soft-deleted documents — excluded from search until restored or purged."
+      headerRight={<CliHint cmd="cerefox document restore" args="<id>" />}
+      searchValue={query}
+      onSearchChange={setQuery}
+      searchPlaceholder="Filter trashed documents…"
+      searchText={(d) => d.title}
+      toolbarExtra={
         <Select
-          label="Show up to"
           data={["50", "100", "200", "500"]}
           value={limit}
           onChange={(v) => setLimit(v || "50")}
-          w={120}
-          size="xs"
+          size="sm"
+          w={110}
+          aria-label="Max rows"
         />
-      </Group>
-      {atCap && (
-        <Text c="dimmed" size="xs" mb="sm">
-          Showing the first {limit} — raise the limit to see more.
-        </Text>
-      )}
-
-      {isLoading && (
-        <Group justify="center" mt="xl"><Loader /></Group>
-      )}
-
-      {error && (
-        <Text c="red" mt="md">Error: {(error as Error).message}</Text>
-      )}
-
-      {docs && docs.length === 0 && (
-        <Card withBorder p="xl">
-          <Text ta="center" c="dimmed" size="lg">Trash is empty.</Text>
-        </Card>
-      )}
-
-      {docs && docs.length > 0 && (
-        <Stack gap="sm">
-          <Text size="sm" c="dimmed">{docs.length} deleted document{docs.length !== 1 ? "s" : ""}</Text>
-          {docs.map((doc) => (
-            <TrashCard
-              key={doc.id}
-              doc={doc}
-              projectMap={projectMap}
-              onRestore={() => restoreMut.mutate(doc.id)}
-              onPurge={() => purgeMut.mutate(doc.id)}
-              restoring={restoreMut.isPending}
-              purging={purgeMut.isPending}
-            />
-          ))}
-        </Stack>
-      )}
-    </Container>
-  );
-}
-
-function TrashCard({
-  doc,
-  projectMap,
-  onRestore,
-  onPurge,
-  restoring,
-  purging,
-}: {
-  doc: DeletedDocument;
-  projectMap: Map<string, string>;
-  onRestore: () => void;
-  onPurge: () => void;
-  restoring: boolean;
-  purging: boolean;
-}) {
-  const [confirmPurge, setConfirmPurge] = useState(false);
-  // project_ids may include IDs we can't resolve (e.g. a project deleted
-  // after the doc went to trash). Filter to known projects so we don't
-  // render orphan UUID-looking badges.
-  const knownProjects = doc.project_ids.filter((pid) => projectMap.has(pid));
-
-  return (
-    <Card withBorder p="sm">
-      <Group justify="space-between">
-        <div>
-          <Group gap="xs" mb={4}>
-            <Text fw={600} size="sm">{doc.title}</Text>
-            <Badge size="xs" color="red" variant="light">Deleted</Badge>
-            {knownProjects.map((pid) => (
-              <Badge key={pid} size="xs" variant="light" color="blue">
-                {projectMap.get(pid)}
-              </Badge>
-            ))}
-          </Group>
-          <Text size="xs" c="dimmed">
-            {doc.total_chars.toLocaleString()} chars | {doc.chunk_count} chunks |
-            deleted {doc.deleted_at?.slice(0, 10) ?? "?"}
-            {knownProjects.length === 0 && doc.project_ids.length === 0 && " | no project"}
-          </Text>
-        </div>
-        <Group gap="xs">
-          <Button
-            size="compact-sm"
-            variant="light"
-            color="green"
-            leftSection={<IconRestore size={14} />}
-            onClick={onRestore}
-            loading={restoring}
-          >
-            Restore
-          </Button>
-          {!confirmPurge ? (
-            <Button
-              size="compact-sm"
-              variant="light"
-              color="red"
-              leftSection={<IconTrash size={14} />}
-              onClick={() => setConfirmPurge(true)}
+      }
+      columns={columns}
+      rows={docs ?? []}
+      rowKey={(d) => d.id}
+      rowClick={(d) => navigate(`/document/${d.id}`)}
+      loading={isLoading}
+      emptyText="Trash is empty."
+      actions={(d) =>
+        confirmId === d.id ? (
+          <>
+            <button
+              type="button"
+              className={`${ui.btn} ${ui.btnSubtle}`}
+              style={{ color: "var(--red)" }}
+              onClick={() => {
+                purgeMut.mutate(d.id);
+                setConfirmId(null);
+              }}
             >
-              Purge
-            </Button>
-          ) : (
-            <Group gap={4}>
-              <Button
-                size="compact-sm"
-                color="red"
-                onClick={() => { onPurge(); setConfirmPurge(false); }}
-                loading={purging}
-              >
-                Confirm Purge
-              </Button>
-              <Button
-                size="compact-sm"
-                variant="subtle"
-                onClick={() => setConfirmPurge(false)}
-              >
-                Cancel
-              </Button>
-            </Group>
-          )}
-        </Group>
-      </Group>
-    </Card>
+              Confirm purge
+            </button>
+            <button type="button" className={`${ui.btn} ${ui.btnSubtle}`} onClick={() => setConfirmId(null)}>
+              Cancel
+            </button>
+          </>
+        ) : (
+          <>
+            <button
+              type="button"
+              className={`${ui.btn} ${ui.btnGhost}`}
+              title="Restore"
+              onClick={() => restoreMut.mutate(d.id)}
+            >
+              <IconArrowBackUp size={14} />
+              Restore
+            </button>
+            <button
+              type="button"
+              className={`${ui.iconBtnSm} ${ui.iconBtnDanger}`}
+              title="Delete permanently"
+              onClick={() => setConfirmId(d.id)}
+            >
+              <IconTrash size={14} />
+            </button>
+          </>
+        )
+      }
+    />
   );
 }

--- a/frontend/src/pages/TrashPage.tsx
+++ b/frontend/src/pages/TrashPage.tsx
@@ -10,6 +10,7 @@ import {
   Text,
   Title,
 } from "@mantine/core";
+import ui from "../styles/redesign.module.css";
 import { IconRestore, IconTrash } from "@tabler/icons-react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
@@ -53,6 +54,7 @@ export function TrashPage() {
 
   return (
     <Container size="lg">
+      <p className={ui.eyebrow}>Recoverable</p>
       <Title order={2} mb="md">Trash</Title>
       <Group justify="space-between" align="flex-end" mb="md">
         <Text c="dimmed" size="sm">

--- a/frontend/src/pages/TrashPage.tsx
+++ b/frontend/src/pages/TrashPage.tsx
@@ -5,6 +5,7 @@ import {
   Container,
   Group,
   Loader,
+  Select,
   Stack,
   Text,
   Title,
@@ -23,12 +24,14 @@ export function TrashPage() {
   // Junction rows are preserved across soft-delete, so the trash UI can
   // still show which projects a deleted document belonged to.
   const projectMap = new Map(projects?.map((p) => [p.id, p.name]) ?? []);
+  const [limit, setLimit] = useState("50");
 
   const { data: docs, isLoading, error } = useQuery({
-    queryKey: ["trash"],
-    queryFn: () => fetchTrash(),
+    queryKey: ["trash", limit],
+    queryFn: () => fetchTrash(Number(limit)),
     staleTime: 10_000,
   });
+  const atCap = !!docs && docs.length === Number(limit);
 
   const restoreMut = useMutation({
     mutationFn: restoreDocument,
@@ -51,9 +54,24 @@ export function TrashPage() {
   return (
     <Container size="lg">
       <Title order={2} mb="md">Trash</Title>
-      <Text c="dimmed" size="sm" mb="md">
-        Deleted documents are recoverable until permanently purged.
-      </Text>
+      <Group justify="space-between" align="flex-end" mb="md">
+        <Text c="dimmed" size="sm">
+          Deleted documents are recoverable until permanently purged.
+        </Text>
+        <Select
+          label="Show up to"
+          data={["50", "100", "200", "500"]}
+          value={limit}
+          onChange={(v) => setLimit(v || "50")}
+          w={120}
+          size="xs"
+        />
+      </Group>
+      {atCap && (
+        <Text c="dimmed" size="xs" mb="sm">
+          Showing the first {limit} — raise the limit to see more.
+        </Text>
+      )}
 
       {isLoading && (
         <Group justify="center" mt="xl"><Loader /></Group>

--- a/frontend/src/styles/redesign.module.css
+++ b/frontend/src/styles/redesign.module.css
@@ -353,6 +353,32 @@
   padding-left: 17px;
 }
 
+/* compact inline terminal snippet (CliHint) — same theming as cliBlock */
+.cliHintBlock {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  background: var(--bg);
+  border: 1px solid var(--border-soft);
+  border-radius: 8px;
+  padding: 5px 10px;
+  color: var(--text);
+  cursor: pointer;
+  transition: border-color 0.14s;
+  max-width: 440px;
+}
+.cliHintBlock:hover {
+  border-color: var(--border);
+}
+.cliHintArgs {
+  color: var(--green);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* ---- entrance ---- */
 .rise {
   animation: rise 0.45s cubic-bezier(0.2, 0.7, 0.3, 1) both;

--- a/frontend/src/styles/redesign.module.css
+++ b/frontend/src/styles/redesign.module.css
@@ -327,6 +327,32 @@
   color: var(--text);
 }
 
+/* ---- CLI-mirror card ---- */
+.cliCard {
+  background: linear-gradient(160deg, var(--surface), var(--surface-2));
+  padding: 18px;
+}
+.cliBlock {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.7;
+  background: var(--bg);
+  border: 1px solid var(--border-soft);
+  border-radius: 10px;
+  padding: 12px 13px;
+}
+.cliP {
+  color: var(--primary);
+  margin-right: 7px;
+}
+.cliS {
+  color: var(--green);
+}
+.cliOut {
+  color: var(--text-faint);
+  padding-left: 17px;
+}
+
 /* ---- entrance ---- */
 .rise {
   animation: rise 0.45s cubic-bezier(0.2, 0.7, 0.3, 1) both;

--- a/frontend/src/styles/redesign.module.css
+++ b/frontend/src/styles/redesign.module.css
@@ -128,6 +128,7 @@
 .bBlue { background: var(--blue-soft); color: var(--blue); }
 .bGreen { background: var(--green-soft); color: var(--green); }
 .bYellow { background: var(--yellow-soft); color: var(--yellow); }
+.bRed { background: var(--red-soft); color: var(--red); }
 .bNeutral { background: var(--surface-2); color: var(--text-dim); }
 
 /* ---- section heads ---- */
@@ -232,6 +233,28 @@
   color: var(--text);
   border-color: var(--border);
   background: var(--surface-hover);
+}
+.iconBtnSm {
+  display: grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
+  border: 1px solid var(--border-soft);
+  background: var(--surface-2);
+  color: var(--text-dim);
+  cursor: pointer;
+  transition: all 0.14s;
+}
+.iconBtnSm:hover {
+  color: var(--text);
+  border-color: var(--border);
+  background: var(--surface-hover);
+}
+.iconBtnDanger:hover {
+  color: var(--red);
+  border-color: var(--red-soft);
+  background: var(--red-soft);
 }
 
 /* ---- segmented control ---- */

--- a/frontend/src/styles/redesign.module.css
+++ b/frontend/src/styles/redesign.module.css
@@ -1,0 +1,211 @@
+/* Shared redesign primitives — reused across redesigned pages.
+   Page-specific layout lives in each page's own *.module.css.
+   Consumes the semantic tokens in tokens.css. */
+
+/* ---- typography bits ---- */
+.eyebrow {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--primary);
+  margin: 0 0 9px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.eyebrow::before {
+  content: "";
+  width: 16px;
+  height: 1.5px;
+  background: var(--primary);
+  display: inline-block;
+}
+.pageTitle {
+  font-family: var(--font-display);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  font-size: 30px;
+  line-height: 1.1;
+  margin: 0;
+  color: var(--text);
+}
+.pageSub {
+  color: var(--text-dim);
+  font-size: 14px;
+  margin: 6px 0 0;
+}
+.pageSub b {
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-weight: 600;
+}
+.mono { font-family: var(--font-mono); }
+.dim { color: var(--text-dim); }
+.faint { color: var(--text-faint); }
+.col { display: flex; flex-direction: column; }
+.row { display: flex; align-items: center; }
+.link {
+  color: var(--text);
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+  transition: color 0.14s;
+}
+.link:hover { color: var(--primary); }
+
+/* ---- buttons ---- */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  font-family: var(--font-ui);
+  font-size: 13.5px;
+  font-weight: 600;
+  padding: 9px 15px;
+  border-radius: 10px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: all 0.15s;
+  white-space: nowrap;
+}
+.btnPrimary {
+  background: var(--primary);
+  color: var(--on-primary);
+  box-shadow: var(--shadow-sm);
+}
+.btnPrimary:hover {
+  background: var(--primary-strong);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-md);
+}
+.btnGhost {
+  background: var(--surface-2);
+  color: var(--text);
+  border-color: var(--border-soft);
+}
+.btnGhost:hover {
+  background: var(--surface-hover);
+  border-color: var(--border);
+}
+.btnSubtle {
+  background: transparent;
+  color: var(--text-dim);
+  padding: 7px 10px;
+  font-size: 12.5px;
+}
+.btnSubtle:hover {
+  background: var(--surface-2);
+  color: var(--text);
+}
+
+/* ---- cards ---- */
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-card);
+  box-shadow: var(--shadow-sm);
+}
+.cardPad { padding: 18px; }
+
+/* ---- badges + accent fills ---- */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1;
+  padding: 4px 8px;
+  border-radius: 999px;
+  white-space: nowrap;
+}
+.bPrimary { background: var(--primary-soft); color: var(--primary); }
+.bViolet { background: var(--violet-soft); color: var(--violet); }
+.bBlue { background: var(--blue-soft); color: var(--blue); }
+.bGreen { background: var(--green-soft); color: var(--green); }
+.bYellow { background: var(--yellow-soft); color: var(--yellow); }
+.bNeutral { background: var(--surface-2); color: var(--text-dim); }
+
+/* ---- section heads ---- */
+.secHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 14px;
+}
+.secTitle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-display);
+  font-size: 16px;
+  font-weight: 600;
+  margin: 0;
+  color: var(--text);
+}
+.secTitle svg { color: var(--text-dim); }
+.countPill {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 7px;
+  border-radius: 999px;
+  background: var(--surface-2);
+  color: var(--text-dim);
+  border: 1px solid var(--border-soft);
+}
+
+/* ---- source/author chip ---- */
+.srcChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  padding: 4px 9px;
+  border-radius: 7px;
+  border: 1px solid var(--border-soft);
+  color: var(--text-dim);
+  background: var(--surface-2);
+}
+.srcChipAgent {
+  color: var(--violet);
+  background: var(--violet-soft);
+  border-color: transparent;
+}
+
+/* ---- "why no data?" inline link ---- */
+.whatis {
+  font-size: 11px;
+  color: var(--text-faint);
+  text-decoration: none;
+  border-bottom: 1px dotted var(--text-faint);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  background: transparent;
+  border-left: 0;
+  border-right: 0;
+  border-top: 0;
+  padding: 0;
+}
+.whatis:hover {
+  color: var(--primary);
+  border-color: var(--primary);
+}
+
+/* ---- entrance ---- */
+.rise {
+  animation: rise 0.45s cubic-bezier(0.2, 0.7, 0.3, 1) both;
+}
+@keyframes rise {
+  from { transform: translateY(9px); }
+  to { transform: translateY(0); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .rise { animation: none; }
+}

--- a/frontend/src/styles/redesign.module.css
+++ b/frontend/src/styles/redesign.module.css
@@ -198,6 +198,135 @@
   border-color: var(--primary);
 }
 
+/* ---- page head (eyebrow + title + right meta) ---- */
+.pageHead {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 26px;
+}
+
+/* ---- divider ---- */
+.divider {
+  height: 1px;
+  background: var(--border-soft);
+  border: 0;
+  margin: 0;
+}
+
+/* ---- icon button ---- */
+.iconBtn {
+  display: inline-grid;
+  place-items: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 9px;
+  border: 1px solid var(--border-soft);
+  background: var(--surface-2);
+  color: var(--text-dim);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.iconBtn:hover {
+  color: var(--text);
+  border-color: var(--border);
+  background: var(--surface-hover);
+}
+
+/* ---- segmented control ---- */
+.seg {
+  display: inline-flex;
+  padding: 3px;
+  gap: 2px;
+  background: var(--surface-2);
+  border: 1px solid var(--border-soft);
+  border-radius: 11px;
+}
+.segBtn {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  font-family: var(--font-ui);
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--text-dim);
+  padding: 6px 13px;
+  border-radius: 8px;
+  transition: all 0.14s;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.segBtn:hover {
+  color: var(--text);
+}
+.segBtnOn {
+  background: var(--surface);
+  color: var(--text);
+  box-shadow: var(--shadow-sm);
+}
+
+/* ---- chip (toggle) ---- */
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-ui);
+  font-size: 12.5px;
+  font-weight: 500;
+  padding: 5px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--border-soft);
+  background: var(--surface-2);
+  color: var(--text-dim);
+  cursor: pointer;
+  transition: all 0.14s;
+}
+.chip:hover {
+  color: var(--text);
+  border-color: var(--border);
+}
+.chipOn {
+  background: var(--primary-soft);
+  border-color: var(--primary-line);
+  color: var(--primary);
+}
+
+/* ---- compact native select ---- */
+.selectWrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 0 9px;
+  height: 32px;
+  border: 1px solid var(--border-soft);
+  border-radius: 8px;
+  background: var(--surface-2);
+  color: var(--text-dim);
+}
+.selectWrap:hover {
+  border-color: var(--border);
+}
+.selectEl {
+  appearance: none;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  font-family: var(--font-ui);
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--text);
+  cursor: pointer;
+  padding-right: 2px;
+  max-width: 180px;
+}
+.selectEl option {
+  background: var(--surface);
+  color: var(--text);
+}
+
 /* ---- entrance ---- */
 .rise {
   animation: rise 0.45s cubic-bezier(0.2, 0.7, 0.3, 1) both;

--- a/frontend/src/theme.css
+++ b/frontend/src/theme.css
@@ -1,0 +1,27 @@
+/* Ambient brand ground: two soft radial glows behind everything.
+   No markup needed — painted on <body>, scoped to Mantine's color scheme.
+   Orange glow top-right, violet glow top-left, low opacity. */
+
+body {
+  background-attachment: fixed;
+}
+
+[data-mantine-color-scheme="dark"] body {
+  background-image:
+    radial-gradient(60% 50% at 100% 0%,
+      color-mix(in oklab, var(--mantine-color-fox-5) 10%, transparent),
+      transparent 70%),
+    radial-gradient(55% 45% at 0% 0%,
+      color-mix(in oklab, var(--mantine-color-violet-6) 9%, transparent),
+      transparent 70%);
+}
+
+[data-mantine-color-scheme="light"] body {
+  background-image:
+    radial-gradient(60% 50% at 100% 0%,
+      color-mix(in oklab, var(--mantine-color-fox-6) 7%, transparent),
+      transparent 70%),
+    radial-gradient(55% 45% at 0% 0%,
+      color-mix(in oklab, var(--mantine-color-violet-6) 6%, transparent),
+      transparent 70%);
+}

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -1,0 +1,121 @@
+// theme.ts — Cerefox Mantine v8 theme
+// Wire into MantineProvider:  <MantineProvider theme={theme}> … </MantineProvider>
+//
+// Fonts are loaded via Google Fonts <link> tags in index.html:
+//   Space Grotesk (display/headings), Geist (UI/body), JetBrains Mono (data)
+//
+// The hex ramps below are derived from the authoritative oklch tokens (see
+// design handoff tokens.css). Mantine wants 10-shade arrays (0 = lightest … 9 = darkest).
+
+import { createTheme, type MantineColorsTuple } from "@mantine/core";
+
+// Fox-orange — primary action color
+const fox: MantineColorsTuple = [
+  "#fff1e8", "#ffdcc6", "#fcbd97", "#f99d66", "#f78440",
+  "#f57626", "#e6641a", "#bf5115", "#983f10", "#722f0b",
+];
+
+// Indigo-tinted neutral ramp → drives dark mode surfaces.
+// Mantine dark convention: dark[0] = text … dark[7] = body bg … dark[9] = deepest.
+const ink: MantineColorsTuple = [
+  "#f3f1f7", // 0  text
+  "#c4c0d4", // 1
+  "#a6a2b8", // 2  dimmed text
+  "#756f88", // 3  faint text
+  "#332f49", // 4  border (dark)
+  "#2b2840", // 5
+  "#1f1c34", // 6  surface / card (dark)
+  "#161427", // 7  body bg (dark)
+  "#121023", // 8
+  "#0d0b1c", // 9
+];
+
+const violet: MantineColorsTuple = [
+  "#f3eefe", "#e0d3fb", "#c4aef4", "#aa8aed", "#9a76e8",
+  "#8a62e2", "#7a45d6", "#6636bb", "#522a96", "#3f2175",
+];
+
+const blue: MantineColorsTuple = [
+  "#e9f2fd", "#cbe0fa", "#9cc6f4", "#6cabef", "#5aa9f0",
+  "#3f8fe0", "#356fd0", "#2b5aad", "#22478a", "#193668",
+];
+
+const green: MantineColorsTuple = [
+  "#e6f8ef", "#c3edd9", "#8fdcb6", "#5acf95", "#4ec98a",
+  "#36b576", "#2f9e6a", "#257e54", "#1d6242", "#154731",
+];
+
+const yellow: MantineColorsTuple = [
+  "#fdf6e3", "#f8e9bd", "#f0d585", "#e8c24f", "#e6bb45",
+  "#d6a52f", "#b88824", "#8f6a1b", "#6d5115", "#4d390e",
+];
+
+const red: MantineColorsTuple = [
+  "#fdecea", "#f9cfc9", "#f1a79c", "#ea7f70", "#e8675a",
+  "#dd4a3b", "#c43a2c", "#9d2f24", "#79251c", "#591b15",
+];
+
+export const theme = createTheme({
+  primaryColor: "fox",
+  // brighter shade in dark mode, deeper in light for contrast
+  primaryShade: { light: 6, dark: 5 },
+
+  colors: { fox, dark: ink, violet, blue, green, yellow, red },
+
+  fontFamily: "Geist, system-ui, -apple-system, sans-serif",
+  fontFamilyMonospace: "'JetBrains Mono', ui-monospace, monospace",
+  headings: {
+    fontFamily: "'Space Grotesk', system-ui, sans-serif",
+    fontWeight: "600",
+    sizes: {
+      h1: { fontSize: "30px", lineHeight: "1.15", fontWeight: "600" },
+      h2: { fontSize: "22px", lineHeight: "1.2", fontWeight: "600" },
+      h3: { fontSize: "16px", lineHeight: "1.3", fontWeight: "600" },
+    },
+  },
+
+  defaultRadius: "md",
+  radius: { xs: "6px", sm: "8px", md: "10px", lg: "14px", xl: "16px" },
+
+  shadows: {
+    sm: "0 1px 2px rgba(0,0,0,.10)",
+    md: "0 10px 30px -12px rgba(40,40,70,.18)",
+    lg: "0 28px 64px -20px rgba(35,30,80,.28)",
+  },
+
+  components: {
+    Card: {
+      defaultProps: { radius: "lg", withBorder: true, shadow: "sm", padding: "lg" },
+    },
+    Button: {
+      defaultProps: { radius: "md" },
+      styles: { root: { fontWeight: 600 } },
+    },
+    Badge: {
+      defaultProps: { radius: "xl", variant: "light" },
+      styles: { root: { fontFamily: "'JetBrains Mono', monospace", fontWeight: 500, textTransform: "none" } },
+    },
+    TextInput: { defaultProps: { radius: "md" } },
+    Select:    { defaultProps: { radius: "md" } },
+    Table: {
+      styles: {
+        th: {
+          fontFamily: "'JetBrains Mono', monospace",
+          fontSize: "10.5px",
+          fontWeight: 500,
+          letterSpacing: "0.1em",
+          textTransform: "uppercase",
+        },
+      },
+    },
+    SegmentedControl: { defaultProps: { radius: "md" } },
+    Modal:   { defaultProps: { radius: "lg" } },
+    Tabs:    {},
+  },
+
+  other: {
+    // accent tokens for ad-hoc use in CSS-in-JS / modules
+    fontDisplay: "'Space Grotesk', sans-serif",
+    fontMono: "'JetBrains Mono', monospace",
+  },
+});

--- a/frontend/src/tokens.css
+++ b/frontend/src/tokens.css
@@ -1,0 +1,76 @@
+/* ============================================================
+   Cerefox — semantic design tokens (redesign).
+   Accents derive from Mantine's generated vars so theme.ts is
+   the single source of truth for brand hues. Only the neutral
+   surfaces/text (which Mantine doesn't express semantically)
+   are bespoke, scoped to the resolved color-scheme so "auto"
+   works. Targeted CSS modules consume these.
+   ============================================================ */
+
+:root {
+  --font-ui: "Geist", system-ui, -apple-system, sans-serif;
+  --font-display: "Space Grotesk", system-ui, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, monospace;
+
+  --radius-pill: 999px;
+  --radius-card: 14px;
+  --radius-ctrl: 10px;
+  --radius-sm: 8px;
+}
+
+/* ---- neutrals + elevation (bespoke; no clean Mantine equivalent) ---- */
+[data-mantine-color-scheme="dark"] {
+  --bg: oklch(0.165 0.026 285);
+  --surface: oklch(0.215 0.028 285);
+  --surface-2: oklch(0.255 0.03 285);
+  --surface-hover: oklch(0.275 0.032 285);
+  --border: oklch(0.32 0.03 285);
+  --border-soft: oklch(0.27 0.026 285);
+
+  --text: oklch(0.965 0.008 285);
+  --text-dim: oklch(0.73 0.02 285);
+  --text-faint: oklch(0.56 0.022 285);
+
+  --shadow-sm: 0 1px 2px oklch(0 0 0 / 0.4);
+  --shadow-md: 0 8px 24px -8px oklch(0 0 0 / 0.55);
+  --shadow-lg: 0 24px 60px -16px oklch(0 0 0 / 0.65);
+  --scrim: oklch(0.1 0.02 285 / 0.66);
+}
+
+[data-mantine-color-scheme="light"] {
+  --bg: oklch(0.972 0.006 280);
+  --surface: oklch(1 0 0);
+  --surface-2: oklch(0.975 0.005 285);
+  --surface-hover: oklch(0.955 0.008 285);
+  --border: oklch(0.905 0.01 285);
+  --border-soft: oklch(0.935 0.008 285);
+
+  --text: oklch(0.235 0.032 285);
+  --text-dim: oklch(0.47 0.025 285);
+  --text-faint: oklch(0.62 0.02 285);
+
+  --shadow-sm: 0 1px 2px oklch(0.4 0.03 285 / 0.1);
+  --shadow-md: 0 10px 30px -12px oklch(0.4 0.05 285 / 0.18);
+  --shadow-lg: 0 28px 64px -20px oklch(0.35 0.06 285 / 0.28);
+  --scrim: oklch(0.3 0.03 285 / 0.32);
+}
+
+/* ---- accents: derived from Mantine (already scheme-aware) ---- */
+[data-mantine-color-scheme] {
+  --primary: var(--mantine-primary-color-filled);
+  --primary-strong: var(--mantine-primary-color-filled-hover);
+  --on-primary: var(--mantine-primary-color-contrast);
+  --primary-soft: var(--mantine-primary-color-light);
+  --primary-line: color-mix(in oklab, var(--primary) 35%, transparent);
+
+  --violet: var(--mantine-color-violet-filled);
+  --violet-soft: var(--mantine-color-violet-light);
+  --blue: var(--mantine-color-blue-filled);
+  --blue-soft: var(--mantine-color-blue-light);
+  --green: var(--mantine-color-green-filled);
+  --green-soft: var(--mantine-color-green-light);
+  --yellow: var(--mantine-color-yellow-filled);
+  --yellow-soft: var(--mantine-color-yellow-light);
+  --red: var(--mantine-color-red-filled);
+  --red-soft: var(--mantine-color-red-light);
+}

--- a/packages/memory/src/web/docs.ts
+++ b/packages/memory/src/web/docs.ts
@@ -156,19 +156,25 @@ export function listBundledDocs(): DocEntry[] {
  * the resolved absolute path escapes the docs roots (path-traversal).
  */
 export function readDoc(docPath: string): string | null {
-  const { pkgTopLevel, repoTopLevel } = resolveDocsRoots();
-  const roots = [pkgTopLevel, repoTopLevel].filter((r): r is string => r !== null);
-  for (const root of roots) {
-    const candidate = resolve(root, docPath);
-    if (!candidate.startsWith(resolve(root) + "/") && candidate !== resolve(root)) {
-      continue;
-    }
-    if (existsSync(candidate) && statSync(candidate).isFile()) {
-      try {
-        return readFileSync(candidate, "utf8");
-      } catch {
-        return null;
-      }
+  const { pkgGuides, pkgTopLevel, repoGuides, repoTopLevel } = resolveDocsRoots();
+  // Resolve against the same roots listBundledDocs emits paths from: guide
+  // paths (`guides/<name>`) live under the guides dir (which is itself under
+  // `<root>/docs/guides`), top-level docs (README.md, …) under the doc root.
+  const isGuide = docPath.startsWith("guides/");
+  const root = isGuide ? (pkgGuides ?? repoGuides) : (pkgTopLevel ?? repoTopLevel);
+  if (!root) return null;
+  const rel = isGuide ? docPath.slice("guides/".length) : docPath;
+  const rootResolved = resolve(root);
+  const candidate = resolve(rootResolved, rel);
+  // Path-traversal guard: the resolved file must stay inside the root.
+  if (!candidate.startsWith(rootResolved + "/") && candidate !== rootResolved) {
+    return null;
+  }
+  if (existsSync(candidate) && statSync(candidate).isFile()) {
+    try {
+      return readFileSync(candidate, "utf8");
+    } catch {
+      return null;
     }
   }
   return null;

--- a/packages/memory/src/web/routes/discovery.ts
+++ b/packages/memory/src/web/routes/discovery.ts
@@ -158,6 +158,22 @@ async function countActiveDocuments(ctx: WebContext): Promise<number> {
   return count ?? 0;
 }
 
+async function getCorpusTotals(
+  ctx: WebContext,
+): Promise<{ total_chunks: number; total_chars: number }> {
+  // Degrade to zeros if the RPC isn't deployed yet (upgrade window: the web
+  // server may be updated before `cerefox server deploy` applies rpcs.sql).
+  const { data, error } = await ctx.supabase.rpc("cerefox_corpus_totals");
+  if (error) return { total_chunks: 0, total_chars: 0 };
+  const row = (Array.isArray(data) ? data[0] : data) as
+    | { total_chunks: number | string; total_chars: number | string }
+    | undefined;
+  return {
+    total_chunks: Number(row?.total_chunks ?? 0),
+    total_chars: Number(row?.total_chars ?? 0),
+  };
+}
+
 async function countDocumentsForProject(
   ctx: WebContext,
   projectId: string,
@@ -525,10 +541,11 @@ export function registerDiscoveryRoutes(app: Hono, ctx: WebContext): void {
 
   // ── /dashboard ─────────────────────────────────────────────────────────────
   app.get("/api/v1/dashboard", async (c) => {
-    const [recentDocs, projects, docCount] = await Promise.all([
+    const [recentDocs, projects, docCount, totals] = await Promise.all([
       listDocuments(ctx, { limit: 10 }),
       listAllProjects(ctx),
       countActiveDocuments(ctx),
+      getCorpusTotals(ctx),
     ]);
     const projectIds = projects.map((p) => String(p.id));
     const docIds = recentDocs.map((d) => String(d.id));
@@ -553,6 +570,8 @@ export function registerDiscoveryRoutes(app: Hono, ctx: WebContext): void {
 
     return c.json({
       doc_count: docCount,
+      total_chunks: totals.total_chunks,
+      total_chars: totals.total_chars,
       project_count: projects.length,
       recent_docs: recent,
       projects: projectsOut,

--- a/packages/memory/src/web/routes/discovery.ts
+++ b/packages/memory/src/web/routes/discovery.ts
@@ -174,6 +174,24 @@ async function getCorpusTotals(
   };
 }
 
+async function getRecentDocAuthors(
+  ctx: WebContext,
+  docIds: string[],
+): Promise<Record<string, { author: string; author_type: string }>> {
+  if (docIds.length === 0) return {};
+  // Degrade to {} if the RPC isn't deployed yet — the Author column then
+  // falls back to the document's source channel.
+  const { data, error } = await ctx.supabase.rpc("cerefox_recent_doc_authors", {
+    p_doc_ids: docIds,
+  });
+  if (error) return {};
+  const out: Record<string, { author: string; author_type: string }> = {};
+  for (const r of (data ?? []) as Array<{ document_id: string; author: string; author_type: string }>) {
+    out[String(r.document_id)] = { author: r.author, author_type: r.author_type };
+  }
+  return out;
+}
+
 async function countDocumentsForProject(
   ctx: WebContext,
   projectId: string,
@@ -549,15 +567,21 @@ export function registerDiscoveryRoutes(app: Hono, ctx: WebContext): void {
     ]);
     const projectIds = projects.map((p) => String(p.id));
     const docIds = recentDocs.map((d) => String(d.id));
-    const [docProjectsMap, counts] = await Promise.all([
+    const [docProjectsMap, counts, authors] = await Promise.all([
       getProjectsForDocuments(ctx, docIds, projects),
       getProjectDocCounts(ctx, projectIds),
+      getRecentDocAuthors(ctx, docIds),
     ]);
 
     const recent = recentDocs.map((d) => {
       const id = String(d.id);
       const pids = (docProjectsMap[id] ?? []).map((p) => String(p.id));
-      return dashboardDocFromRow(d, pids);
+      const a = authors[id];
+      return {
+        ...dashboardDocFromRow(d, pids),
+        author: a?.author ?? null,
+        author_type: a?.author_type ?? null,
+      };
     });
 
     const projectsOut = projects.map((p) => ({

--- a/packages/memory/src/web/routes/preferences.ts
+++ b/packages/memory/src/web/routes/preferences.ts
@@ -1,0 +1,60 @@
+/**
+ * Web UI preferences — durable, machine-local settings stored in
+ * `~/.cerefox/web-prefs.json` (the user-state dir). Currently just the
+ * color-scheme choice.
+ *
+ *   GET /api/v1/preferences        → { theme }
+ *   PUT /api/v1/preferences        → { theme }   (body: { theme })
+ *
+ * File-based and Supabase-independent, so it registers unconditionally
+ * (works even when the DB isn't configured). Mantine's own localStorage
+ * is the no-flash fast path on first paint; this file is the durable
+ * source reconciled on mount, surviving a browser cache clear.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { Hono } from "hono";
+
+import { userStateDir } from "../../../../../_shared/config/index.ts";
+
+type Theme = "auto" | "light" | "dark";
+
+function isTheme(v: unknown): v is Theme {
+  return v === "auto" || v === "light" || v === "dark";
+}
+
+function prefsFile(): string {
+  return join(userStateDir(), "web-prefs.json");
+}
+
+function readPrefs(): { theme: Theme } {
+  try {
+    const raw = JSON.parse(readFileSync(prefsFile(), "utf8")) as Record<string, unknown>;
+    if (isTheme(raw.theme)) return { theme: raw.theme };
+  } catch {
+    /* missing or invalid file → fall through to default */
+  }
+  return { theme: "auto" };
+}
+
+export function registerPreferencesRoutes(app: Hono): void {
+  app.get("/api/v1/preferences", (c) => c.json(readPrefs()));
+
+  app.put("/api/v1/preferences", async (c) => {
+    const body = (await c.req.json().catch(() => ({}))) as { theme?: unknown };
+    if (!isTheme(body.theme)) {
+      return c.json({ detail: "theme must be one of: auto, light, dark" }, 400);
+    }
+    const next = { ...readPrefs(), theme: body.theme };
+    try {
+      const dir = userStateDir();
+      if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+      writeFileSync(prefsFile(), `${JSON.stringify(next, null, 2)}\n`);
+    } catch (err) {
+      return c.json({ detail: err instanceof Error ? err.message : String(err) }, 500);
+    }
+    return c.json(next);
+  });
+}

--- a/packages/memory/src/web/server.ts
+++ b/packages/memory/src/web/server.ts
@@ -40,6 +40,7 @@ import { registerDocumentReadRoutes } from "./routes/documents-read.ts";
 import { registerDocumentWriteRoutes } from "./routes/documents-write.ts";
 import { registerIngestRoutes } from "./routes/ingest.ts";
 import { registerMetaRoutes } from "./routes/meta.ts";
+import { registerPreferencesRoutes } from "./routes/preferences.ts";
 import { registerProjectsRoutes } from "./routes/projects.ts";
 import {
   ROOT_REDIRECT_HTML,
@@ -80,6 +81,8 @@ export function buildApp(ctx: WebContext | null = buildWebContext()): Hono {
 
   // (1) JSON API — registered first.
   registerMetaRoutes(app, ctx);
+  // Machine-local UI prefs (file-based; no DB) — works without Supabase.
+  registerPreferencesRoutes(app);
   if (ctx) {
     registerDiscoveryRoutes(app, ctx);
     registerDocumentReadRoutes(app, ctx);

--- a/src/cerefox/db/rpcs.sql
+++ b/src/cerefox/db/rpcs.sql
@@ -1749,3 +1749,26 @@ AS $$
            FROM cerefox_documents
           WHERE deleted_at IS NULL)::BIGINT AS total_chars;
 $$;
+
+
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- Recent-doc authors (dashboard "Author" column)
+-- ─────────────────────────────────────────────────────────────────────────
+-- The latest audit author (+ type) per document, for the given doc ids.
+-- "Latest editor" — used by the /dashboard recent-docs list so the Author
+-- column can show who last touched a doc (agent vs human). Read-only.
+
+CREATE OR REPLACE FUNCTION cerefox_recent_doc_authors(p_doc_ids UUID[])
+RETURNS TABLE (document_id UUID, author TEXT, author_type TEXT)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+    SELECT DISTINCT ON (a.document_id)
+        a.document_id, a.author, a.author_type
+    FROM cerefox_audit_log a
+    WHERE a.document_id = ANY(p_doc_ids)
+    ORDER BY a.document_id, a.created_at DESC;
+$$;

--- a/src/cerefox/db/rpcs.sql
+++ b/src/cerefox/db/rpcs.sql
@@ -1721,3 +1721,31 @@ AS $$
           AND p.proname = p_name
     );
 $$;
+
+
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- Corpus totals (dashboard aggregates)
+-- ─────────────────────────────────────────────────────────────────────────
+-- Cheap global aggregates for the dashboard stat strip: total current chunks
+-- (version_id IS NULL, on non-deleted documents) and total characters across
+-- active documents. SUM cannot be expressed over the Data API, so it lives
+-- here as a single STABLE function the /dashboard route calls once.
+
+CREATE OR REPLACE FUNCTION cerefox_corpus_totals()
+RETURNS TABLE (total_chunks BIGINT, total_chars BIGINT)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+    SELECT
+        (SELECT COUNT(*)
+           FROM cerefox_chunks c
+           JOIN cerefox_documents d ON d.id = c.document_id
+          WHERE c.version_id IS NULL
+            AND d.deleted_at IS NULL)::BIGINT AS total_chunks,
+        (SELECT COALESCE(SUM(total_chars), 0)
+           FROM cerefox_documents
+          WHERE deleted_at IS NULL)::BIGINT AS total_chars;
+$$;


### PR DESCRIPTION
## Summary

A full redesign of the web client (the human operator's console), plus a few supporting backend reads. All changes are additive and data-honest.

**Theme & foundation**
- Adopt the design-handoff Mantine theme (fox-orange primary, indigo-tinted dark ramp, Geist / Space Grotesk / JetBrains Mono) with accents derived from Mantine vars (single source of truth).
- Semantic token layer (`tokens.css`), shared primitives module (`redesign.module.css`), ambient background.
- Header: "Cere**fox**" wordmark + gradient accent line; eyebrows (super-titles) on every page.
- **Theme switcher** (auto/light/dark) persisted to `~/.cerefox/web-prefs.json` via a new file-based `/api/v1/preferences` endpoint (localStorage = no-flash fast path).

**Core pages redesigned**
- **Dashboard** — hero, 4-card stat strip (Documents, Indexed chunks, Projects, Agent activity over 30d from the usage log), "Recently changed documents" table with an **Author** column (real last-editor, agent/human chip), projects rail with fill bars, CLI-mirror card.
- **Search** — granularity (Documents/Chunks) + ranker (Hybrid/Keyword/Semantic) controls, result cards with a score ring (normalized relative to the set when scores aren't 0–1), breadcrumb, snippet, expand.
- **Document** — header + review pill, Rendered/Source/Chunks toggle with its own scroll, sticky rail (Contents TOC, Details + metadata, Versions w/ actions menu, Activity timeline).
- **Ingest** — Paste/Upload tabs (stable common fields), drop zone, project chips + filter, pipeline + CLI rail.

**Reusable list/table pattern**
- New config-driven `ListPage` component; **Audit Log**, **Trash**, **Projects**, **Metadata Search** rebuilt on it (search, filters, client pagination, row actions). Audit gains date/limit filters; Trash gains restore/purge inline confirm + limit; Projects gains doc-count columns + create/edit modals.

**Other**
- Per-page **CLI-parity hints** (mono command + copy + cli-docs link) on Search/Metadata/Projects/Audit/Trash/Help, themed like the dashboard CLI card.
- **Help**: kept the embedded docs reader + added a guide filter (skipped the prototype's fictional-taxonomy landing). **Fixed** guide-content 404 (`readDoc` source-mode resolution).
- Backend reads (additive, read-only, graceful-degrading): `/dashboard` corpus totals (chunks + chars) and recent-doc author join.

## Deploy note
- Adds two read-only RPCs (`cerefox_corpus_totals`, `cerefox_recent_doc_authors`) to `rpcs.sql` → run **`cerefox server deploy`** on release (re-applies `rpcs.sql`). Routes degrade gracefully if not yet deployed.
- **No Edge Function changes** → no `EF_VERSION` bump.
- New web routes (`/preferences`, dashboard fields) ship in the npm package; restart `cerefox web` after upgrade.

## Test plan
- [ ] Dashboard: stats, Author column, projects rail, agent-activity card
- [ ] Theme switcher persists across reload + cache clear (`~/.cerefox/web-prefs.json`)
- [ ] Search: Documents vs Chunks + ranker dropdown; result score rings; title link
- [ ] Document: Rendered/Source/Chunks, TOC scroll, version actions, review toggle, delete/restore
- [ ] Ingest: paste + file upload, project filter, update-existing
- [ ] Audit/Trash/Projects/Metadata: filters, pagination, row actions, CLI hints
- [ ] Help: guide list filter + content loads (no 404)
- [ ] Light + dark modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)