### PR TITLE
schema_version bump + cut_release guard (v0.9.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,38 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
-Open roadmap.
+**Schema version now signals required server redeploys, enforced by the
+release tooling.**
+
+> **Upgrade:** run `cerefox server deploy` (this re-applies `rpcs.sql`).
+> `cerefox doctor` / the web banner now correctly report "newer server
+> available" until you do.
+
+### Fixed
+
+- **`cerefox doctor` / the schema banner under-reported after v0.9.6.** v0.9.6
+  added two RPCs (`cerefox_corpus_totals`, `cerefox_recent_doc_authors`) — which
+  require `cerefox server deploy` — but left `schema_version` at `0.3.1`, so a
+  client upgraded *without* redeploying was told "schema up to date" while the
+  dashboard's new RPC-backed features silently fell back. Bumped `schema_version`
+  **0.3.1 → 0.4.0** (the `@version:` marker in `schema.sql` and the
+  `cerefox_schema_version()` literal in `rpcs.sql`, in lockstep). An
+  un-redeployed server now reports "newer server available — run
+  `cerefox server deploy`." (`minSchema` stays `0.3.1`: the routes degrade
+  gracefully, so this is a nudge, not a hard requirement.)
+
+### Changed
+
+- **`cut_release.ts` now enforces the schema version** (the symmetric
+  counterpart to the existing `EF_VERSION` guard): if anything under
+  `src/cerefox/db/` changed since the last tag, the cut **fails** unless
+  `schema_version` was bumped — and the two literals (`schema.sql @version:` and
+  `cerefox_schema_version()`) must agree. This turns the previously-manual
+  RELEASING.md step into a hard gate, so the v0.9.6 miss can't recur.
+- **Docs:** RELEASING.md (step 4 + the versioning table) now names *both*
+  literals and the new gate; CLAUDE.md instructs agents to follow the
+  RELEASING.md pre-release checklist on any release-intent PR and to bump
+  `schema_version` on any `src/cerefox/db/` change.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,6 +314,29 @@ The migrate/deploy logic is shared with `scripts/db_migrate.ts` /
 
 **When you change an Edge Function's request body or response shape, update the GPT Actions OpenAPI block in `docs/guides/connect-agents.md` in the same PR, and bump its `info.version` per SemVer.** That block is what ChatGPT users paste into a Custom GPT's Actions config; if it drifts from what the EFs actually accept/return, those GPTs silently break. There is no CI gate for this (a path-diff heuristic was too lossy) — the discipline lives here + in the release playbook (`RELEASING.md`). When an EF's `EF_VERSION` surface changes, also consider whether the client compatibility matrix (`_shared/compatibility/index.ts`) needs a `minEdgeFunctions` bump (see CONTRIBUTING.md).
 
+### Rule: bump `schema_version` on any `src/cerefox/db/` change
+
+**Whenever you change `schema.sql`, `rpcs.sql`, or add a migration, bump the
+schema version in two places, in lockstep:** the `-- @version:` marker in
+`src/cerefox/db/schema.sql` (the *bundled* value the client compares against)
+**and** the literal in `cerefox_schema_version()` at the bottom of `rpcs.sql`
+(the *deployed* value). Schema and RPCs deploy together via `cerefox server
+deploy`, so this single version is the "redeploy required" signal — bumping it
+is what makes `cerefox doctor` / the web banner tell users to redeploy.
+`cut_release.ts` **fails the cut** if `db/` changed without a bump or if the two
+literals disagree (the symmetric counterpart to the `EF_VERSION` guard). It's an
+independent semver line — do **not** sync it to the npm package version. This
+was missed in v0.9.6 (added RPCs without bumping); the gate exists so it can't
+recur.
+
+### Rule: before opening a release-intent PR, follow `RELEASING.md`
+
+**Any PR meant to ship a release (or that a release will be cut from) must run
+the `RELEASING.md` pre-release checklist** — CHANGELOG `[Unreleased]` populated,
+`schema_version` bumped if `db/` changed, compat-matrix minimums reviewed, GPT
+Actions OpenAPI block synced if EFs changed, tests green. `RELEASING.md` is the
+authoritative release playbook; read it at the start of any release work.
+
 ### Client Compatibility
 
 | Client | How to connect | Notes |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -19,7 +19,7 @@ Three version surfaces move independently:
 | Surface | Where | Bumped by |
 |---|---|---|
 | **Client** (`PKG_VERSION`) | `packages/memory/src/meta.ts` + every `package.json` | `cut_release.ts`, every release |
-| **Schema** (schema + RPCs) | `@version:` marker in `src/cerefox/db/schema.sql` | by hand, when `schema.sql`/`rpcs.sql` change |
+| **Schema** (schema + RPCs) | `@version:` marker in `src/cerefox/db/schema.sql` **and** the `cerefox_schema_version()` literal in `rpcs.sql` (kept in lockstep) | by hand, when `schema.sql`/`rpcs.sql`/migrations change — **gated by `cut_release.ts`** |
 | **Edge Functions** (`EF_VERSION`) | `_shared/ef-meta/index.ts` | `cut_release.ts`, only when EF source changed since the last tag |
 
 The client carries a **compatibility matrix** (`_shared/compatibility/index.ts`,
@@ -37,8 +37,18 @@ redeploy their server.
    release's client needs a newer server, raise `minSchema` /
    `minEdgeFunctions` and confirm the CHANGELOG calls out "redeploy
    required".
-4. **Schema version** — if `schema.sql` / `rpcs.sql` changed, bump the
-   `@version:` marker by hand.
+4. **Schema version** — if anything under `src/cerefox/db/` changed
+   (`schema.sql`, `rpcs.sql`, or a migration), bump the schema version in
+   **two** places, in lockstep: the `-- @version:` marker in `schema.sql`
+   (the *bundled* value the client compares against) **and** the literal in
+   `cerefox_schema_version()` at the bottom of `rpcs.sql` (the *deployed*
+   value). Schema and RPCs deploy together via `cerefox server deploy`, so this
+   one version is the single "redeploy required" signal — bumping it makes
+   `doctor` / the web banner tell users to redeploy. **`cut_release.ts` fails
+   the cut** if `db/` changed without a bump, or if the two literals disagree.
+   (Raise `minSchema` in the compat matrix only if the client *hard-requires*
+   the new surface; if it degrades gracefully, the version bump alone is the
+   nudge.)
 5. **GPT Actions OpenAPI block** (`docs/guides/connect-agents.md`) — if any
    Edge Function's request/response shape changed this cycle, update the
    OpenAPI block and bump its `info.version`. (See the CLAUDE.md rule;

--- a/scripts/cut_release.ts
+++ b/scripts/cut_release.ts
@@ -121,6 +121,70 @@ function efsChangedSinceLastTag(): boolean {
   return diff.stdout.trim().length > 0;
 }
 
+/**
+ * Schema/RPC version guard (the symmetric counterpart to the EF_VERSION
+ * mechanism). Schema and RPCs deploy together via `cerefox server deploy`, so
+ * `schema_version` is the single "redeploy required" signal for both. Unlike
+ * EF_VERSION (auto-bumped to the release version), the schema version is an
+ * independent semver chosen by hand — so this GATES the cut rather than
+ * auto-bumping: if anything under `src/cerefox/db/` changed since the last
+ * tag, the version must have been bumped, and the two literals must agree.
+ */
+const SCHEMA_SOURCE_PATHS = [
+  "src/cerefox/db/schema.sql",
+  "src/cerefox/db/rpcs.sql",
+  "src/cerefox/db/migrations",
+];
+const SCHEMA_SQL_PATH = join(REPO_ROOT, "src", "cerefox", "db", "schema.sql");
+const RPCS_SQL_PATH = join(REPO_ROOT, "src", "cerefox", "db", "rpcs.sql");
+
+/** Parse the `-- @version: X.Y.Z` marker from schema.sql text. */
+function parseSchemaMarker(text: string): string | null {
+  const m = text.match(/^--\s*@version:\s*([0-9][^\s]*)/m);
+  return m ? m[1] : null;
+}
+/** Parse the version literal from the `cerefox_schema_version()` body. */
+function parseRpcsSchemaVersion(text: string): string | null {
+  const m = text.match(/cerefox_schema_version[\s\S]*?SELECT\s*'([0-9][^']*)'/);
+  return m ? m[1] : null;
+}
+
+function assertSchemaVersionGuard(): void {
+  const marker = parseSchemaMarker(readFileSync(SCHEMA_SQL_PATH, "utf8"));
+  const deployedLit = parseRpcsSchemaVersion(readFileSync(RPCS_SQL_PATH, "utf8"));
+  if (!marker || !deployedLit) {
+    die(
+      "Could not read schema_version — expected a `-- @version:` marker in " +
+        "schema.sql and a literal in cerefox_schema_version() in rpcs.sql.",
+    );
+  }
+  if (marker !== deployedLit) {
+    die(
+      `schema_version mismatch: schema.sql @version=${marker} but ` +
+        `cerefox_schema_version()=${deployedLit}. Bump both in lockstep ` +
+        "(RELEASING.md step 4) — doctor compares bundled (schema.sql) vs " +
+        "deployed (the RPC), so they must agree.",
+    );
+  }
+  const lastTag = run("git", ["describe", "--tags", "--abbrev=0"]).stdout.trim();
+  if (!lastTag) return;
+  const dbChanged =
+    run("git", ["diff", "--name-only", `${lastTag}..HEAD`, "--", ...SCHEMA_SOURCE_PATHS])
+      .stdout.trim().length > 0;
+  if (!dbChanged) return;
+  const prevMarker = parseSchemaMarker(
+    run("git", ["show", `${lastTag}:src/cerefox/db/schema.sql`]).stdout,
+  );
+  if (prevMarker && prevMarker === marker) {
+    die(
+      `src/cerefox/db/ changed since ${lastTag} but schema_version is still ` +
+        `${marker}. Schema + RPCs deploy together — bump the @version marker in ` +
+        "schema.sql AND cerefox_schema_version() in rpcs.sql (RELEASING.md step 4) " +
+        "so doctor / the banner tells users to run `cerefox server deploy`.",
+    );
+  }
+}
+
 const SEMVER_RE = /^\d+\.\d+\.\d+(?:[.-][A-Za-z0-9.-]+)?$/;
 
 // ── tiny shell helper ────────────────────────────────────────────────────
@@ -513,6 +577,11 @@ async function main(): Promise<void> {
     newVersion,
   );
   ok("CHANGELOG sections parsed; [Unreleased] has content.");
+
+  // Schema/RPC version guard: any src/cerefox/db/ change since the last tag
+  // requires a schema_version bump (and the two literals must agree).
+  assertSchemaVersionGuard();
+  ok("schema_version guard passed.");
 
   // EF_VERSION bumps only when EF code changed since the last tag.
   const bumpEf = efsChangedSinceLastTag();

--- a/src/cerefox/db/rpcs.sql
+++ b/src/cerefox/db/rpcs.sql
@@ -1692,7 +1692,9 @@ STABLE
 SECURITY DEFINER
 SET search_path = public, pg_catalog
 AS $$
-    SELECT '0.3.1'::TEXT;
+    -- Keep in lockstep with the `@version:` marker in schema.sql (cut_release.ts
+    -- enforces it). Bump whenever schema.sql OR rpcs.sql changes.
+    SELECT '0.4.0'::TEXT;
 $$;
 
 

--- a/src/cerefox/db/schema.sql
+++ b/src/cerefox/db/schema.sql
@@ -5,12 +5,14 @@
 -- Requires extensions: vector (pgvector), uuid-ossp
 -- These are enabled at the top of db_deploy.py before this file is applied.
 --
--- @version: 0.3.1
+-- @version: 0.4.0
 -- The `@version` marker above is read by the schema-version-mismatch banner
--- (see /api/v1/schema-version). Bump it whenever schema.sql or rpcs.sql
--- changes in a way that requires `python scripts/db_deploy.py` to be re-run.
--- The deployed value is exposed via the `cerefox_schema_version()` RPC at
--- the bottom of rpcs.sql.
+-- (see /api/v1/schema-version). Bump it whenever schema.sql OR rpcs.sql
+-- changes in a way that requires `cerefox server deploy` to be re-run —
+-- schema and RPCs deploy together, so this version covers both. You MUST
+-- bump it in lockstep with the `cerefox_schema_version()` literal at the
+-- bottom of rpcs.sql (the deployed value); `cut_release.ts` fails the cut if
+-- `src/cerefox/db/` changed without this bump, or if the two disagree.
 
 -- ── Projects ──────────────────────────────────────────────────────────────────
 -- Lightweight user-defined categories. No predefined taxonomy.


### PR DESCRIPTION
## Summary

Fixes the v0.9.6 miss (and prevents recurrence): v0.9.6 added two RPCs — which require `cerefox server deploy` — but left `schema_version` at `0.3.1`, so `cerefox doctor` / the web banner falsely reported "schema up to date" for un-redeployed servers while the new dashboard features silently fell back.

- **Bump `schema_version` 0.3.1 → 0.4.0**, in lockstep across both literals: the `-- @version:` marker in `src/cerefox/db/schema.sql` (bundled value) and `cerefox_schema_version()` in `rpcs.sql` (deployed value). An un-redeployed server now reports "newer server available — run `cerefox server deploy`." `minSchema` stays `0.3.1` (routes degrade gracefully → nudge, not a block).
- **`cut_release.ts` guard** (symmetric to the existing `EF_VERSION` mechanism): if anything under `src/cerefox/db/` changed since the last tag, the cut **fails** unless `schema_version` was bumped, and the two literals must agree. Turns the previously-manual RELEASING.md step into a hard gate. Verified: passes when bumped, fails with a clear message when not.
- **Docs**: RELEASING.md (step 4 + versioning table) names both literals + the gate; CLAUDE.md adds "bump `schema_version` on any `db/` change" and "follow RELEASING.md on any release-intent PR".

v0.9.6 stays published (not data-unsafe; a published tag never moves per RELEASING.md — ship a patch). This branch is cut as **v0.9.7**.

## Upgrade
Run `cerefox server deploy` (re-applies `rpcs.sql`). No Edge Function changes (no `EF_VERSION` bump).

## Test plan
- [x] `cut_release.ts --dry-run` passes the guard with the bump
- [x] Guard fails the cut when `db/` changed but `schema_version` wasn't (verified on a throwaway branch)
- [x] `_shared` unit tests green (177/177)
- [ ] After merge: `cut_release.ts 0.9.7`, then `cerefox server deploy`; confirm `doctor` shows schema `0.4.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)