### PR TITLE
Web UI polish + CLI parity (v0.9.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,45 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
-Open roadmap.
+**Web UI polish + a CLI parity addition. Client-only — no server deploy.**
+
+### Added
+
+- **`cerefox document list --deleted`** — list soft-deleted (trashed) documents
+  from the CLI (newest-deleted first, with a `deleted_at` column), closing the
+  loop with `document restore` / `document delete`. Documented in `cli.md`;
+  shell completion picks it up automatically.
+- **Reusable multi-line CLI card** on the Dashboard, Ingest, Trash, and Projects
+  pages — the `cerefox …` commands equivalent to each page, each independently
+  copyable (with a ✓ confirmation), no fake example-output lines.
+- **In-trash document view** — opening a trashed document now shows a clear
+  "In trash" banner and swaps the header actions to **Restore / Purge** (Edit,
+  Delete, and the review pill are hidden); `/documents/{id}` now returns
+  `deleted_at` so the UI can detect it.
+- **Pagination controls** on all list views: a **rows-per-page** dropdown
+  (10/25/50/100, persisted in `localStorage` as one global preference) and
+  **first / prev / next / last** arrows.
+
+### Changed
+
+- **Project documents view** (`/projects/:id/documents`) rebuilt to match the
+  redesigned list pattern (styled table, eyebrow, CLI hint, consistent
+  pagination footer), keeping its server-side paging.
+- **Copy buttons** (CLI cards, search result reference) flip to a green ✓ for
+  ~1.2s on click as clipboard confirmation.
+- **Delete affordances** are consistent — every delete/purge highlights red on
+  hover (shared `.btnDanger`); the Document page's Delete is a labelled ghost
+  button matching Edit/Download. Trash/Projects row actions are always visible
+  (no longer hover-only).
+- **Document page**: project tags above the title are clickable (open the
+  project's document list); the origin chip now has a prompt Mantine tooltip.
+- **Analytics**: a tooltip on the usage-tracking toggle explaining what it logs.
+
+### Fixed
+
+- The slow native `title` tooltip on the Document origin chip (easy to miss) is
+  now a Mantine tooltip; the Trash/Projects CLI cards were widened so commands
+  aren't clipped.
 
 ---
 

--- a/_shared/schemas/documents.ts
+++ b/_shared/schemas/documents.ts
@@ -37,6 +37,8 @@ export const DocumentDetailResponse = z.object({
   review_status: z.string().default("approved"),
   created_at: z.string().nullable().optional(),
   updated_at: z.string().nullable().optional(),
+  /** Set when the document is soft-deleted (in trash); null/absent otherwise. */
+  deleted_at: z.string().nullable().optional(),
   versions: z.array(DocumentVersionResponse).default([]),
 });
 export type DocumentDetailResponse = z.infer<typeof DocumentDetailResponse>;

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -198,9 +198,10 @@ cerefox document list [OPTIONS]
 |---|---|---|---|
 | `--project <name>` (`-p`) | str | _none_ | Filter by project name. |
 | `--limit <n>` (`-l`) | int | `100` | Max rows. |
+| `--deleted` | flag | off | List soft-deleted (trashed) documents instead of active ones, newest-deleted first. Pair the ids with `cerefox document restore` / `cerefox document delete`. |
 | `--json` | flag | off | Machine-readable JSON output. |
 
-**Output**: tabular `id | chunk_count | total_chars | title` listing. CLI-only — there is no MCP equivalent.
+**Output**: tabular `id | title | source | status | updated_at` listing (or `deleted_at` with `--deleted`). CLI-only — there is no MCP equivalent.
 
 ---
 

--- a/frontend/src/components/CliCard.tsx
+++ b/frontend/src/components/CliCard.tsx
@@ -1,0 +1,86 @@
+import { IconCheck, IconCopy, IconTerminal2 } from "@tabler/icons-react";
+import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+import ui from "../styles/redesign.module.css";
+
+interface Cmd {
+  cmd: string;
+  args?: string;
+}
+
+/**
+ * CLI-parity card: a titled terminal block listing the `cerefox …` commands
+ * equivalent to the current page, each independently copyable (with a brief ✓
+ * confirmation), plus a "cli docs" link. Used in page rails (Dashboard,
+ * Ingest) and list-page headers (Trash, Projects). No fake output lines.
+ */
+export function CliCard({
+  title,
+  commands,
+  docPath = "guides/cli.md",
+}: {
+  title: string;
+  commands: Cmd[];
+  docPath?: string;
+}) {
+  const navigate = useNavigate();
+  const [copiedIdx, setCopiedIdx] = useState<number | null>(null);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => () => {
+    if (timer.current) clearTimeout(timer.current);
+  }, []);
+
+  const copy = (idx: number, c: Cmd) => {
+    navigator.clipboard?.writeText(c.args ? `${c.cmd} ${c.args}` : c.cmd);
+    setCopiedIdx(idx);
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => setCopiedIdx(null), 1200);
+  };
+
+  return (
+    <div className={`${ui.card} ${ui.cliCard} ${ui.rise}`}>
+      <div className={ui.row} style={{ gap: 8, marginBottom: 10 }}>
+        <IconTerminal2 size={15} />
+        <span style={{ fontWeight: 600, fontSize: 13.5 }}>{title}</span>
+        <button
+          type="button"
+          className={ui.whatis}
+          style={{ marginLeft: "auto" }}
+          onClick={() => navigate(`/help/${docPath}`)}
+        >
+          cli docs
+        </button>
+      </div>
+      <div className={ui.cliBlock}>
+        {commands.map((c, i) => (
+          <div className={ui.cliLine} key={i}>
+            <span className={ui.cliLineCmd}>
+              <span className={ui.cliP}>$</span>
+              {c.cmd}
+              {c.args && (
+                <>
+                  {" "}
+                  <span className={ui.cliS}>{c.args}</span>
+                </>
+              )}
+            </span>
+            <button
+              type="button"
+              className={ui.cliCopyBtn}
+              title={copiedIdx === i ? "Copied!" : "Copy command to clipboard"}
+              onClick={() => copy(i, c)}
+            >
+              {copiedIdx === i ? (
+                <IconCheck size={13} style={{ color: "var(--green)" }} />
+              ) : (
+                <IconCopy size={13} />
+              )}
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/CliHint.tsx
+++ b/frontend/src/components/CliHint.tsx
@@ -1,4 +1,5 @@
-import { IconCopy } from "@tabler/icons-react";
+import { IconCheck, IconCopy } from "@tabler/icons-react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import ui from "../styles/redesign.module.css";
@@ -6,8 +7,8 @@ import ui from "../styles/redesign.module.css";
 /**
  * Compact CLI-parity hint for page headers: a mini terminal snippet styled
  * like the dashboard's CLI-mirror card ($ prompt in primary, args in green),
- * that copies the command on click, plus a "cli docs" link. Lighter than the
- * full CLI card.
+ * that copies the command on click (with a brief checkmark confirmation),
+ * plus a "cli docs" link.
  */
 export function CliHint({
   cmd,
@@ -19,19 +20,37 @@ export function CliHint({
   docPath?: string;
 }) {
   const navigate = useNavigate();
+  const [copied, setCopied] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const full = args ? `${cmd} ${args}` : cmd;
+
+  useEffect(() => () => {
+    if (timer.current) clearTimeout(timer.current);
+  }, []);
+
+  const copy = () => {
+    navigator.clipboard?.writeText(full);
+    setCopied(true);
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => setCopied(false), 1200);
+  };
+
   return (
     <span style={{ display: "inline-flex", alignItems: "center", gap: 8, flexWrap: "wrap", justifyContent: "flex-end" }}>
       <button
         type="button"
         className={ui.cliHintBlock}
-        title="Copy command to clipboard"
-        onClick={() => navigator.clipboard?.writeText(full)}
+        title={copied ? "Copied!" : "Copy command to clipboard"}
+        onClick={copy}
       >
         <span style={{ color: "var(--primary)" }}>$</span>
         <span>{cmd}</span>
         {args && <span className={ui.cliHintArgs}>{args}</span>}
-        <IconCopy size={12} style={{ color: "var(--text-faint)", flexShrink: 0 }} />
+        {copied ? (
+          <IconCheck size={12} style={{ color: "var(--green)", flexShrink: 0 }} />
+        ) : (
+          <IconCopy size={12} style={{ color: "var(--text-faint)", flexShrink: 0 }} />
+        )}
       </button>
       <button type="button" className={ui.whatis} onClick={() => navigate(`/help/${docPath}`)}>
         cli docs

--- a/frontend/src/components/ListPage.module.css
+++ b/frontend/src/components/ListPage.module.css
@@ -87,15 +87,12 @@
 }
 
 /* ---- row actions (reveal on hover) ---- */
+/* Row actions are always visible (the row's background still highlights on
+   hover for focus); previously they were hover-reveal, which hid affordances. */
 .actions {
   display: flex;
   gap: 6px;
   justify-content: flex-end;
-  opacity: 0;
-  transition: opacity 0.12s;
-}
-.tbl tbody tr:hover .actions {
-  opacity: 1;
 }
 
 /* ---- pagination foot ---- */

--- a/frontend/src/components/ListPage.tsx
+++ b/frontend/src/components/ListPage.tsx
@@ -1,6 +1,8 @@
-import { IconChevronLeft, IconChevronRight, IconSearch } from "@tabler/icons-react";
+import { IconSearch } from "@tabler/icons-react";
 import { type ReactNode, useMemo, useState } from "react";
 
+import { useRowsPerPage } from "../hooks/useRowsPerPage";
+import { PaginationFoot } from "./PaginationFoot";
 import ui from "../styles/redesign.module.css";
 import styles from "./ListPage.module.css";
 
@@ -30,7 +32,6 @@ interface ListPageProps<T> {
   rowKey: (row: T) => string;
   rowClick?: (row: T) => void;
   actions?: (row: T) => ReactNode;
-  pageSize?: number;
   loading?: boolean;
   emptyText?: string;
 }
@@ -50,11 +51,11 @@ export function ListPage<T>({
   rowKey,
   rowClick,
   actions,
-  pageSize = 10,
   loading = false,
   emptyText = "No matching rows.",
 }: ListPageProps<T>) {
   const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useRowsPerPage();
 
   const filtered = useMemo(() => {
     const q = searchValue.trim().toLowerCase();
@@ -145,23 +146,17 @@ export function ListPage<T>({
             )}
           </tbody>
         </table>
-        <div className={styles.foot}>
-          <span className={styles.faint}>
-            {total === 0 ? "0" : `${cur * pageSize + 1}–${Math.min(total, cur * pageSize + pageSize)}`} of{" "}
-            {total}
-          </span>
-          <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-            <button type="button" className={styles.pgBtn} disabled={cur === 0} onClick={() => setPage(cur - 1)} aria-label="Previous page">
-              <IconChevronLeft size={14} />
-            </button>
-            <span className={styles.faint}>
-              page {cur + 1} / {pages}
-            </span>
-            <button type="button" className={styles.pgBtn} disabled={cur >= pages - 1} onClick={() => setPage(cur + 1)} aria-label="Next page">
-              <IconChevronRight size={14} />
-            </button>
-          </div>
-        </div>
+        <PaginationFoot
+          page={cur + 1}
+          pageCount={pages}
+          total={total}
+          pageSize={pageSize}
+          onPage={(p) => setPage(p - 1)}
+          onPageSize={(n) => {
+            setPageSize(n);
+            setPage(0);
+          }}
+        />
       </div>
     </div>
   );

--- a/frontend/src/components/PaginationFoot.tsx
+++ b/frontend/src/components/PaginationFoot.tsx
@@ -1,0 +1,82 @@
+import {
+  IconChevronLeft,
+  IconChevronRight,
+  IconChevronsLeft,
+  IconChevronsRight,
+} from "@tabler/icons-react";
+
+import { ROWS_PER_PAGE_OPTIONS } from "../hooks/useRowsPerPage";
+import ui from "../styles/redesign.module.css";
+import lp from "./ListPage.module.css";
+
+/**
+ * Shared list pagination footer: "N–M of T" range, a rows-per-page dropdown,
+ * and first/prev/next/last controls. Page numbers are 1-based.
+ */
+export function PaginationFoot({
+  page,
+  pageCount,
+  total,
+  pageSize,
+  onPage,
+  onPageSize,
+  loading = false,
+}: {
+  page: number;
+  pageCount: number;
+  total: number;
+  pageSize: number;
+  onPage: (page: number) => void;
+  onPageSize: (size: number) => void;
+  loading?: boolean;
+}) {
+  const start = total === 0 ? 0 : (page - 1) * pageSize + 1;
+  const end = Math.min(total, (page - 1) * pageSize + pageSize);
+  const atStart = page <= 1;
+  const atEnd = page >= pageCount;
+
+  return (
+    <div className={lp.foot}>
+      <span className={lp.faint}>
+        {total === 0 ? "0" : `${start}–${end}`} of {total}
+        {loading ? " · loading…" : ""}
+      </span>
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <span className={lp.faint} style={{ fontSize: 11.5 }}>
+          Rows
+        </span>
+        <span className={ui.selectWrap} style={{ height: 28 }}>
+          <select
+            className={ui.selectEl}
+            value={pageSize}
+            onChange={(e) => onPageSize(Number(e.currentTarget.value))}
+            aria-label="Rows per page"
+          >
+            {ROWS_PER_PAGE_OPTIONS.map((n) => (
+              <option key={n} value={n}>
+                {n}
+              </option>
+            ))}
+          </select>
+        </span>
+        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <button type="button" className={lp.pgBtn} disabled={atStart} onClick={() => onPage(1)} aria-label="First page">
+            <IconChevronsLeft size={14} />
+          </button>
+          <button type="button" className={lp.pgBtn} disabled={atStart} onClick={() => onPage(page - 1)} aria-label="Previous page">
+            <IconChevronLeft size={14} />
+          </button>
+          <span className={lp.faint}>
+            page {page} / {pageCount}
+          </span>
+          <button type="button" className={lp.pgBtn} disabled={atEnd} onClick={() => onPage(page + 1)} aria-label="Next page">
+            <IconChevronRight size={14} />
+          </button>
+          <button type="button" className={lp.pgBtn} disabled={atEnd} onClick={() => onPage(pageCount)} aria-label="Last page">
+            <IconChevronsRight size={14} />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/SearchResults.tsx
+++ b/frontend/src/components/SearchResults.tsx
@@ -1,6 +1,7 @@
 import { Alert, Loader } from "@mantine/core";
 import {
   IconAlertCircle,
+  IconCheck,
   IconChevronDown,
   IconChevronRight,
   IconCopy,
@@ -8,7 +9,7 @@ import {
   IconSearch,
   IconTerminal2,
 } from "@tabler/icons-react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import type { ChunkSearchResult, DocSearchResult, SearchMode, SearchResponse } from "../api/types";
@@ -41,6 +42,17 @@ interface SearchResultsProps {
 export function SearchResults({ data, isLoading, error, hasQuery }: SearchResultsProps) {
   const navigate = useNavigate();
   const [expanded, setExpanded] = useState<string | null>(null);
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+  const copyTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => {
+    if (copyTimer.current) clearTimeout(copyTimer.current);
+  }, []);
+  const copyRef = (id: string, text: string) => {
+    navigator.clipboard?.writeText(text);
+    setCopiedId(id);
+    if (copyTimer.current) clearTimeout(copyTimer.current);
+    copyTimer.current = setTimeout(() => setCopiedId(null), 1200);
+  };
 
   if (!hasQuery) {
     return (
@@ -223,14 +235,18 @@ export function SearchResults({ data, isLoading, error, hasQuery }: SearchResult
                       type="button"
                       className={`${ui.btn} ${ui.btnSubtle}`}
                       style={{ marginLeft: "auto" }}
-                      title="Copy CLI command to clipboard"
-                      onClick={() => navigator.clipboard?.writeText(`cerefox document get ${docId}`)}
+                      title={copiedId === id ? "Copied!" : "Copy CLI command to clipboard"}
+                      onClick={() => copyRef(id, `cerefox document get ${docId}`)}
                     >
                       <IconTerminal2 size={14} />
                       <span className={ui.mono} style={{ fontSize: 12 }}>
                         cerefox document get {docId.slice(0, 8)}…
                       </span>
-                      <IconCopy size={13} />
+                      {copiedId === id ? (
+                        <IconCheck size={13} style={{ color: "var(--green)" }} />
+                      ) : (
+                        <IconCopy size={13} />
+                      )}
                     </button>
                   </div>
                 </div>

--- a/frontend/src/hooks/useRowsPerPage.ts
+++ b/frontend/src/hooks/useRowsPerPage.ts
@@ -1,0 +1,32 @@
+import { useState } from "react";
+
+/**
+ * Global "rows per page" preference, shared across all list views and
+ * persisted in localStorage so it sticks across sessions and pages.
+ */
+const STORAGE_KEY = "cerefox:rowsPerPage";
+export const ROWS_PER_PAGE_OPTIONS = [10, 25, 50, 100];
+const DEFAULT = 10;
+
+function read(): number {
+  try {
+    const v = Number(localStorage.getItem(STORAGE_KEY));
+    if (ROWS_PER_PAGE_OPTIONS.includes(v)) return v;
+  } catch {
+    /* ignore */
+  }
+  return DEFAULT;
+}
+
+export function useRowsPerPage(): [number, (n: number) => void] {
+  const [size, setSizeState] = useState<number>(read);
+  const setSize = (n: number) => {
+    setSizeState(n);
+    try {
+      localStorage.setItem(STORAGE_KEY, String(n));
+    } catch {
+      /* ignore */
+    }
+  };
+  return [size, setSize];
+}

--- a/frontend/src/pages/AnalyticsPage.tsx
+++ b/frontend/src/pages/AnalyticsPage.tsx
@@ -12,6 +12,7 @@ import {
   Text,
   TextInput,
   Title,
+  Tooltip,
 } from "@mantine/core";
 import { ResponsiveBar } from "@nivo/bar";
 import { ResponsivePie } from "@nivo/pie";
@@ -179,14 +180,23 @@ export function AnalyticsPage() {
       <Group justify="space-between" mb="md">
         <Title order={2}>Analytics</Title>
         <Group gap="md">
-          <Switch
-            label="Usage tracking"
-            checked={isEnabled}
-            onChange={(e) => toggleMutation.mutate(e.currentTarget.checked)}
-            size="sm"
-            color="green"
-            disabled={toggleMutation.isPending}
-          />
+          <Tooltip
+            label="Opt-in. Logs each read/write (operation metadata only — no content) to the usage log, powering these charts and the dashboard's agent-activity card."
+            multiline
+            w={300}
+            withArrow
+            openDelay={120}
+            position="bottom"
+          >
+            <Switch
+              label="Usage tracking"
+              checked={isEnabled}
+              onChange={(e) => toggleMutation.mutate(e.currentTarget.checked)}
+              size="sm"
+              color="green"
+              disabled={toggleMutation.isPending}
+            />
+          </Tooltip>
           <Button
             variant="subtle"
             leftSection={<IconDownload size={16} />}

--- a/frontend/src/pages/AuditLogPage.tsx
+++ b/frontend/src/pages/AuditLogPage.tsx
@@ -172,7 +172,6 @@ export function AuditLogPage() {
       rowClick={(e) => e.document_id && navigate(`/document/${e.document_id}`)}
       loading={isLoading}
       emptyText="No audit log entries found."
-      pageSize={12}
     />
   );
 }

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -20,6 +20,7 @@ import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { fetchUsageSummary } from "../api/analytics";
+import { CliCard } from "../components/CliCard";
 import { fetchDashboard } from "../api/dashboard";
 import type { DashboardDoc } from "../api/types";
 import ui from "../styles/redesign.module.css";
@@ -360,35 +361,13 @@ export function DashboardPage() {
             </div>
           </section>
 
-          <section className={`${ui.card} ${ui.cliCard} ${ui.rise}`}>
-            <div className={ui.row} style={{ gap: 8, marginBottom: 10 }}>
-              <IconTerminal2 size={15} />
-              <span style={{ fontWeight: 600, fontSize: 13.5 }}>Same memory, your terminal</span>
-              <button
-                type="button"
-                className={ui.whatis}
-                style={{ marginLeft: "auto" }}
-                onClick={() => navigate("/help/guides/cli.md")}
-              >
-                cli docs
-              </button>
-            </div>
-            <div className={ui.cliBlock}>
-              <div>
-                <span className={ui.cliP}>$</span> cerefox search{" "}
-                <span className={ui.cliS}>"retry backoff"</span>
-              </div>
-              <div className={ui.cliOut}>→ 5 results · top 92% match</div>
-              <div style={{ marginTop: 6 }}>
-                <span className={ui.cliP}>$</span> cerefox document ingest ./rfc-018.md
-              </div>
-              <div className={ui.cliOut}>→ staged in research-notes</div>
-            </div>
-            <p className={ui.faint} style={{ fontSize: 12, margin: "10px 0 0", lineHeight: 1.5 }}>
-              The same memory from your terminal or any MCP agent — most actions
-              have CLI, MCP, and web parity.
-            </p>
-          </section>
+          <CliCard
+            title="Same memory, your terminal"
+            commands={[
+              { cmd: "cerefox search", args: '"retry backoff" --mode hybrid' },
+              { cmd: "cerefox document ingest", args: "./rfc-018.md --project-name infra" },
+            ]}
+          />
         </aside>
       </div>
     </div>

--- a/frontend/src/pages/DocumentPage.tsx
+++ b/frontend/src/pages/DocumentPage.tsx
@@ -1,4 +1,4 @@
-import { Loader, Menu, Modal, Popover, Text } from "@mantine/core";
+import { Loader, Menu, Modal, Popover, Text, Tooltip } from "@mantine/core";
 import {
   IconArrowLeft,
   IconArrowsDiff,
@@ -282,36 +282,43 @@ export function DocumentPage() {
           </div>
           <h1 className={styles.docTitle}>{doc.doc_title || "Untitled"}</h1>
           <div className={styles.docMeta}>
-            <span
-              className={`${ui.srcChip} ${chip.agent ? ui.srcChipAgent : ""}`}
-              title="Origin — how this document was added"
+            <Tooltip
+              label="Origin — how this document was added"
+              openDelay={120}
+              withArrow
+              position="top"
             >
-              <ChipIcon size={12} />
-              {chip.label}
-            </span>
+              <span className={`${ui.srcChip} ${chip.agent ? ui.srcChipAgent : ""}`}>
+                <ChipIcon size={12} />
+                {chip.label}
+              </span>
+            </Tooltip>
             <span className={`${ui.mono} ${ui.faint}`}>{doc.chunk_count} chunks</span>
             <span className={`${ui.mono} ${ui.faint}`}>{doc.total_chars.toLocaleString()} chars</span>
             {doc.updated_at && (
               <span className={`${ui.mono} ${ui.faint}`}>updated {formatDateTime(doc.updated_at)}</span>
             )}
-            <button
-              type="button"
-              className={styles.reviewPill}
-              title="Click to toggle review status"
-              onClick={() => reviewMutation.mutate(approved ? "pending_review" : "approved")}
-              disabled={reviewMutation.isPending}
-            >
-              <span
-                className="dot"
-                style={{
-                  width: 7,
-                  height: 7,
-                  borderRadius: "50%",
-                  background: approved ? "var(--green)" : "var(--yellow)",
-                }}
-              />
-              {approved ? "Approved" : "Pending"}
-            </button>
+            {/* Review status is an optional gate — irrelevant for a trashed doc, so hide the pill + toggle there. */}
+            {!doc.deleted_at && (
+              <button
+                type="button"
+                className={styles.reviewPill}
+                title="Click to toggle review status"
+                onClick={() => reviewMutation.mutate(approved ? "pending_review" : "approved")}
+                disabled={reviewMutation.isPending}
+              >
+                <span
+                  className="dot"
+                  style={{
+                    width: 7,
+                    height: 7,
+                    borderRadius: "50%",
+                    background: approved ? "var(--green)" : "var(--yellow)",
+                  }}
+                />
+                {approved ? "Approved" : "Pending"}
+              </button>
+            )}
           </div>
         </div>
         <div className={ui.row} style={{ gap: 8, flexShrink: 0 }}>

--- a/frontend/src/pages/DocumentPage.tsx
+++ b/frontend/src/pages/DocumentPage.tsx
@@ -266,9 +266,16 @@ export function DocumentPage() {
             {doc.project_ids
               .filter((pid) => projectMap.has(pid))
               .map((pid) => (
-                <span key={pid} className={`${ui.badge} ${ui.bNeutral}`}>
+                <button
+                  key={pid}
+                  type="button"
+                  className={`${ui.badge} ${ui.bNeutral}`}
+                  style={{ cursor: "pointer", border: "1px solid transparent" }}
+                  title={`View documents in ${projectMap.get(pid)}`}
+                  onClick={() => navigate(`/projects/${pid}/documents`)}
+                >
                   {projectMap.get(pid)}
-                </span>
+                </button>
               ))}
           </div>
           <h1 className={styles.docTitle}>{doc.doc_title || "Untitled"}</h1>
@@ -318,12 +325,12 @@ export function DocumentPage() {
           {!confirmDelete ? (
             <button
               type="button"
-              className={`${ui.btn} ${ui.btnSubtle}`}
-              style={{ color: "var(--text-faint)" }}
-              title="Delete"
+              className={`${ui.btn} ${ui.btnGhost} ${ui.btnDanger}`}
+              title="Delete document"
               onClick={() => setConfirmDelete(true)}
             >
               <IconTrash size={14} />
+              Delete
             </button>
           ) : (
             <div className={ui.row} style={{ gap: 6 }}>

--- a/frontend/src/pages/DocumentPage.tsx
+++ b/frontend/src/pages/DocumentPage.tsx
@@ -3,6 +3,7 @@ import {
   IconArrowLeft,
   IconArrowsDiff,
   IconDots,
+  IconArrowBackUp,
   IconDownload,
   IconEdit,
   IconFileText,
@@ -109,6 +110,7 @@ export function DocumentPage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [confirmDelete, setConfirmDelete] = useState(false);
+  const [confirmPurge, setConfirmPurge] = useState(false);
   const [view, setView] = useState<View>("rendered");
 
   const { data: doc, isLoading, error } = useQuery({
@@ -280,7 +282,10 @@ export function DocumentPage() {
           </div>
           <h1 className={styles.docTitle}>{doc.doc_title || "Untitled"}</h1>
           <div className={styles.docMeta}>
-            <span className={`${ui.srcChip} ${chip.agent ? ui.srcChipAgent : ""}`}>
+            <span
+              className={`${ui.srcChip} ${chip.agent ? ui.srcChipAgent : ""}`}
+              title="Origin — how this document was added"
+            >
               <ChipIcon size={12} />
               {chip.label}
             </span>
@@ -310,46 +315,94 @@ export function DocumentPage() {
           </div>
         </div>
         <div className={ui.row} style={{ gap: 8, flexShrink: 0 }}>
-          <button
-            type="button"
-            className={`${ui.btn} ${ui.btnGhost}`}
-            onClick={() => navigate(`/document/${id}/edit`)}
-          >
-            <IconEdit size={14} />
-            Edit
-          </button>
+          {/* Download is useful either way. Edit/Delete only for live docs;
+              deleted docs get Restore/Purge instead. */}
           <a className={`${ui.btn} ${ui.btnGhost}`} href={getDownloadUrl(id!)}>
             <IconDownload size={14} />
             Download
           </a>
-          {!confirmDelete ? (
-            <button
-              type="button"
-              className={`${ui.btn} ${ui.btnGhost} ${ui.btnDanger}`}
-              title="Delete document"
-              onClick={() => setConfirmDelete(true)}
-            >
-              <IconTrash size={14} />
-              Delete
-            </button>
+
+          {doc.deleted_at ? (
+            <>
+              <button
+                type="button"
+                className={`${ui.btn} ${ui.btnGhost} ${ui.btnWarn}`}
+                title="Restore from trash"
+                onClick={() => restoreMutation.mutate()}
+              >
+                <IconArrowBackUp size={14} />
+                Restore
+              </button>
+              {!confirmPurge ? (
+                <button
+                  type="button"
+                  className={`${ui.btn} ${ui.btnGhost} ${ui.btnDanger}`}
+                  title="Permanently delete (cannot be undone)"
+                  onClick={() => setConfirmPurge(true)}
+                >
+                  <IconTrash size={14} />
+                  Purge
+                </button>
+              ) : (
+                <div className={ui.row} style={{ gap: 6 }}>
+                  <button
+                    type="button"
+                    className={ui.btn}
+                    style={{ background: "var(--red)", color: "#fff" }}
+                    onClick={() => purgeMutation.mutate()}
+                  >
+                    Confirm purge
+                  </button>
+                  <button
+                    type="button"
+                    className={`${ui.btn} ${ui.btnSubtle}`}
+                    onClick={() => setConfirmPurge(false)}
+                  >
+                    Cancel
+                  </button>
+                </div>
+              )}
+            </>
           ) : (
-            <div className={ui.row} style={{ gap: 6 }}>
+            <>
               <button
                 type="button"
-                className={ui.btn}
-                style={{ background: "var(--red)", color: "#fff" }}
-                onClick={() => deleteMutation.mutate()}
+                className={`${ui.btn} ${ui.btnGhost}`}
+                onClick={() => navigate(`/document/${id}/edit`)}
               >
-                Confirm
+                <IconEdit size={14} />
+                Edit
               </button>
-              <button
-                type="button"
-                className={`${ui.btn} ${ui.btnSubtle}`}
-                onClick={() => setConfirmDelete(false)}
-              >
-                Cancel
-              </button>
-            </div>
+              {!confirmDelete ? (
+                <button
+                  type="button"
+                  className={`${ui.btn} ${ui.btnGhost} ${ui.btnDanger}`}
+                  title="Delete document"
+                  onClick={() => setConfirmDelete(true)}
+                >
+                  <IconTrash size={14} />
+                  Delete
+                </button>
+              ) : (
+                <div className={ui.row} style={{ gap: 6 }}>
+                  <button
+                    type="button"
+                    className={ui.btn}
+                    style={{ background: "var(--red)", color: "#fff" }}
+                    onClick={() => deleteMutation.mutate()}
+                  >
+                    Confirm
+                  </button>
+                  <button
+                    type="button"
+                    className={`${ui.btn} ${ui.btnSubtle}`}
+                    onClick={() => setConfirmDelete(false)}
+                  >
+                    Cancel
+                  </button>
+                </div>
+              )}
+            </>
           )}
         </div>
       </div>
@@ -357,25 +410,16 @@ export function DocumentPage() {
       {doc.deleted_at && (
         <div className={styles.trashBanner}>
           <div className={ui.row} style={{ gap: 8 }}>
-            <span className={`${ui.badge} ${ui.bNeutral}`} style={{ background: "var(--red)", color: "#fff" }}>
-              Deleted
+            <span
+              className={`${ui.badge} ${ui.bNeutral}`}
+              style={{ background: "var(--red)", color: "#fff" }}
+            >
+              In trash
             </span>
             <span style={{ fontSize: 13 }}>
-              In trash (deleted {doc.deleted_at.slice(0, 10)}) — excluded from search.
+              Deleted {doc.deleted_at.slice(0, 10)} — excluded from search until restored. Use
+              Restore or Purge above.
             </span>
-          </div>
-          <div className={ui.row} style={{ gap: 8 }}>
-            <button type="button" className={`${ui.btn} ${ui.btnGhost}`} onClick={() => restoreMutation.mutate()}>
-              Restore
-            </button>
-            <button
-              type="button"
-              className={ui.btn}
-              style={{ background: "var(--red)", color: "#fff" }}
-              onClick={() => purgeMutation.mutate()}
-            >
-              Delete permanently
-            </button>
           </div>
         </div>
       )}

--- a/frontend/src/pages/IngestPage.tsx
+++ b/frontend/src/pages/IngestPage.tsx
@@ -1,5 +1,5 @@
 import { Alert } from "@mantine/core";
-import { IconCheck, IconFileText, IconPlus, IconSearch, IconTerminal2, IconUpload, IconX } from "@tabler/icons-react";
+import { IconCheck, IconFileText, IconPlus, IconSearch, IconUpload, IconX } from "@tabler/icons-react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
@@ -7,6 +7,7 @@ import { useNavigate } from "react-router-dom";
 import { detectV07FromResponse } from "../api/client";
 import { checkFilename, ingestPaste } from "../api/documents";
 import type { FilenameCheckResponse, IngestResponse } from "../api/types";
+import { CliCard } from "../components/CliCard";
 import { MarkdownViewer } from "../components/MarkdownViewer";
 import { useMetadataKeys, useProjects } from "../hooks/useProjects";
 import { showError, showV07DeferredToast } from "../utils/notifications";
@@ -469,30 +470,15 @@ export function IngestPage() {
             </ol>
           </div>
 
-          <div className={`${ui.card} ${ui.cliCard} ${ui.rise}`}>
-            <div className={ui.row} style={{ gap: 8, marginBottom: 10 }}>
-              <IconTerminal2 size={15} />
-              <span style={{ fontWeight: 600, fontSize: 13.5 }}>CLI equivalent</span>
-              <button
-                type="button"
-                className={ui.whatis}
-                style={{ marginLeft: "auto" }}
-                onClick={() => navigate("/help/guides/cli.md")}
-              >
-                cli docs
-              </button>
-            </div>
-            <div className={ui.cliBlock}>
-              <div>
-                <span className={ui.cliP}>$</span> cerefox document ingest{" "}
-                <span className={ui.cliS}>./{file?.name ?? "doc.md"}</span> \
-              </div>
-              <div style={{ paddingLeft: 16 }}>
-                --project-name <span className={ui.cliS}>{firstProjectName}</span>
-              </div>
-              <div className={ui.cliOut}>→ ~{chunkEstimate || "?"} chunks · staged</div>
-            </div>
-          </div>
+          <CliCard
+            title="CLI equivalent"
+            commands={[
+              {
+                cmd: "cerefox document ingest",
+                args: `./${file?.name ?? "doc.md"} --project-name ${firstProjectName}`,
+              },
+            ]}
+          />
         </aside>
       </form>
     </div>

--- a/frontend/src/pages/ProjectDocumentsPage.tsx
+++ b/frontend/src/pages/ProjectDocumentsPage.tsx
@@ -1,22 +1,16 @@
-import {
-  Anchor,
-  Badge,
-  Container,
-  Group,
-  Loader,
-  Pagination,
-  Table,
-  Text,
-  Title,
-} from "@mantine/core";
-import { useQuery, keepPreviousData } from "@tanstack/react-query";
+import { Loader } from "@mantine/core";
+import { IconArrowLeft, IconChevronLeft, IconChevronRight } from "@tabler/icons-react";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 import { apiFetch } from "../api/client";
 import type { ProjectDocumentsResponse } from "../api/types";
+import { CliHint } from "../components/CliHint";
 import { useProjects } from "../hooks/useProjects";
 import { formatDate } from "../utils/dates";
+import ui from "../styles/redesign.module.css";
+import lp from "../components/ListPage.module.css";
 
 const PAGE_SIZE = 50;
 
@@ -38,8 +32,6 @@ export function ProjectDocumentsPage() {
         `/projects/${id}/documents?limit=${PAGE_SIZE}&offset=${offset}`,
       ),
     enabled: !!id,
-    // Keep current data visible while the next page loads — avoids a
-    // full-page loader flicker on every page-link click.
     placeholderData: keepPreviousData,
   });
 
@@ -50,110 +42,119 @@ export function ProjectDocumentsPage() {
   const lastOnPage = Math.min(offset + docs.length, total);
 
   return (
-    <Container size="lg">
-      <Group gap="xs" mb="md">
-        <Anchor size="sm" onClick={() => navigate("/projects")}>
-          Projects
-        </Anchor>
-        <Text size="sm" c="dimmed">
-          /
-        </Text>
-        <Title order={2}>{project?.name || "Project"}</Title>
-      </Group>
+    <div className={lp.wrap}>
+      <button
+        type="button"
+        className={`${ui.btn} ${ui.btnSubtle}`}
+        style={{ marginBottom: 12, paddingLeft: 6 }}
+        onClick={() => navigate("/projects")}
+      >
+        <IconArrowLeft size={15} />
+        Projects
+      </button>
 
-      {project?.description && (
-        <Text size="sm" c="dimmed" mb="md">
-          {project.description}
-        </Text>
-      )}
+      <div className={ui.pageHead}>
+        <div>
+          <p className={ui.eyebrow}>Memory space</p>
+          <h1 className={ui.pageTitle}>{project?.name || "Project"}</h1>
+          {project?.description && <p className={ui.pageSub}>{project.description}</p>}
+        </div>
+        <CliHint cmd="cerefox document list" args={`--project "${project?.name ?? "<name>"}"`} />
+      </div>
 
       {isLoading ? (
-        <Group justify="center" mt="xl">
+        <div style={{ display: "flex", justifyContent: "center", marginTop: 40 }}>
           <Loader />
-        </Group>
+        </div>
       ) : total === 0 ? (
-        <Text c="dimmed" ta="center" mt="xl">
-          No documents in this project.
-        </Text>
+        <div className={`${ui.card} ${lp.emptyRow}`}>No documents in this project.</div>
       ) : (
-        <>
-          <Group justify="space-between" mb="sm">
-            <Text size="sm" c="dimmed">
-              {total === 1
-                ? "1 document"
-                : `${total} documents — showing ${firstOnPage}–${lastOnPage}`}
-            </Text>
-            {isFetching && !isLoading && <Loader size="xs" />}
-          </Group>
-          <Table striped highlightOnHover>
-            <Table.Thead>
-              <Table.Tr>
-                <Table.Th>Title</Table.Th>
-                <Table.Th>Chunks</Table.Th>
-                <Table.Th>Size</Table.Th>
-                <Table.Th>Updated</Table.Th>
-              </Table.Tr>
-            </Table.Thead>
-            <Table.Tbody>
-              {docs.map((doc) => (
-                <Table.Tr key={doc.id}>
-                  <Table.Td>
-                    <Group gap="xs">
-                      <Anchor
-                        href={`/app/document/${doc.id}`}
-                        onClick={(e) => {
-                          e.preventDefault();
-                          navigate(`/document/${doc.id}`);
-                        }}
-                        fw={500}
-                        size="sm"
-                      >
-                        {doc.title || "Untitled"}
-                      </Anchor>
-                      {doc.project_ids
-                        .filter((pid) => pid !== id && projectMap.has(pid))
-                        .map((pid) => (
-                          <Badge key={pid} variant="light" size="xs">
-                            {projectMap.get(pid)}
-                          </Badge>
-                        ))}
-                      <Badge
-                        variant="light"
-                        size="xs"
-                        color={doc.review_status === "approved" ? "green" : "yellow"}
-                      >
-                        {doc.review_status === "approved" ? "Approved" : "Pending"}
-                      </Badge>
-                    </Group>
-                  </Table.Td>
-                  <Table.Td>
-                    <Text size="sm">{doc.chunk_count}</Text>
-                  </Table.Td>
-                  <Table.Td>
-                    <Text size="sm">{doc.total_chars.toLocaleString()}</Text>
-                  </Table.Td>
-                  <Table.Td>
-                    <Text size="sm" c="dimmed">
+        <div className={`${ui.card} ${ui.rise}`} style={{ overflow: "hidden" }}>
+          <table className={lp.tbl}>
+            <thead>
+              <tr>
+                <th>Document</th>
+                <th style={{ width: 90, textAlign: "right" }}>Chunks</th>
+                <th style={{ width: 110, textAlign: "right" }}>Size</th>
+                <th style={{ width: 120, textAlign: "right" }}>Updated</th>
+              </tr>
+            </thead>
+            <tbody>
+              {docs.map((doc) => {
+                const pending = doc.review_status !== "approved";
+                return (
+                  <tr
+                    key={doc.id}
+                    style={{ cursor: "pointer" }}
+                    onClick={() => navigate(`/document/${doc.id}`)}
+                  >
+                    <td>
+                      <span style={{ display: "inline-flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+                        <span className={ui.link} style={{ fontSize: 13.5 }}>
+                          {doc.title || "Untitled"}
+                        </span>
+                        {doc.project_ids
+                          .filter((pid) => pid !== id && projectMap.has(pid))
+                          .map((pid) => (
+                            <span key={pid} className={`${ui.badge} ${ui.bNeutral}`}>
+                              {projectMap.get(pid)}
+                            </span>
+                          ))}
+                        {pending && (
+                          <span className={`${ui.badge} ${ui.bYellow}`}>
+                            <span
+                              style={{ width: 6, height: 6, borderRadius: "50%", background: "currentColor" }}
+                            />
+                            pending review
+                          </span>
+                        )}
+                      </span>
+                    </td>
+                    <td className={`${ui.mono} ${ui.dim}`} style={{ textAlign: "right" }}>
+                      {doc.chunk_count}
+                    </td>
+                    <td className={`${ui.mono} ${ui.dim}`} style={{ textAlign: "right" }}>
+                      {doc.total_chars.toLocaleString()}
+                    </td>
+                    <td className={`${ui.faint}`} style={{ textAlign: "right" }}>
                       {formatDate(doc.updated_at)}
-                    </Text>
-                  </Table.Td>
-                </Table.Tr>
-              ))}
-            </Table.Tbody>
-          </Table>
-          {totalPages > 1 && (
-            <Group justify="center" mt="md">
-              <Pagination
-                value={page}
-                onChange={setPage}
-                total={totalPages}
-                size="sm"
-                withEdges
-              />
-            </Group>
-          )}
-        </>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+          <div className={lp.foot}>
+            <span className={lp.faint}>
+              {total === 0 ? "0" : `${firstOnPage}–${lastOnPage}`} of {total}
+              {isFetching && !isLoading ? " · loading…" : ""}
+            </span>
+            <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+              <button
+                type="button"
+                className={lp.pgBtn}
+                disabled={page <= 1}
+                onClick={() => setPage((p) => p - 1)}
+                aria-label="Previous page"
+              >
+                <IconChevronLeft size={14} />
+              </button>
+              <span className={lp.faint}>
+                page {page} / {totalPages}
+              </span>
+              <button
+                type="button"
+                className={lp.pgBtn}
+                disabled={page >= totalPages}
+                onClick={() => setPage((p) => p + 1)}
+                aria-label="Next page"
+              >
+                <IconChevronRight size={14} />
+              </button>
+            </div>
+          </div>
+        </div>
       )}
-    </Container>
+    </div>
   );
 }

--- a/frontend/src/pages/ProjectDocumentsPage.tsx
+++ b/frontend/src/pages/ProjectDocumentsPage.tsx
@@ -1,5 +1,5 @@
 import { Loader } from "@mantine/core";
-import { IconArrowLeft, IconChevronLeft, IconChevronRight } from "@tabler/icons-react";
+import { IconArrowLeft } from "@tabler/icons-react";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
@@ -7,13 +7,12 @@ import { useNavigate, useParams } from "react-router-dom";
 import { apiFetch } from "../api/client";
 import type { ProjectDocumentsResponse } from "../api/types";
 import { CliHint } from "../components/CliHint";
+import { PaginationFoot } from "../components/PaginationFoot";
 import { useProjects } from "../hooks/useProjects";
+import { useRowsPerPage } from "../hooks/useRowsPerPage";
 import { formatDate } from "../utils/dates";
 import ui from "../styles/redesign.module.css";
 import lp from "../components/ListPage.module.css";
-
-// Match the other list views (ListPage default is 10).
-const PAGE_SIZE = 10;
 
 export function ProjectDocumentsPage() {
   const { id } = useParams<{ id: string }>();
@@ -24,13 +23,14 @@ export function ProjectDocumentsPage() {
   const projectMap = new Map(projects?.map((p) => [p.id, p.name]) ?? []);
 
   const [page, setPage] = useState(1);
-  const offset = (page - 1) * PAGE_SIZE;
+  const [pageSize, setPageSize] = useRowsPerPage();
+  const offset = (page - 1) * pageSize;
 
   const { data, isLoading, isFetching } = useQuery({
-    queryKey: ["project-documents", id, page],
+    queryKey: ["project-documents", id, page, pageSize],
     queryFn: () =>
       apiFetch<ProjectDocumentsResponse>(
-        `/projects/${id}/documents?limit=${PAGE_SIZE}&offset=${offset}`,
+        `/projects/${id}/documents?limit=${pageSize}&offset=${offset}`,
       ),
     enabled: !!id,
     placeholderData: keepPreviousData,
@@ -38,9 +38,7 @@ export function ProjectDocumentsPage() {
 
   const docs = data?.documents ?? [];
   const total = data?.total ?? 0;
-  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
-  const firstOnPage = total === 0 ? 0 : offset + 1;
-  const lastOnPage = Math.min(offset + docs.length, total);
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
 
   return (
     <div className={lp.wrap}>
@@ -125,35 +123,18 @@ export function ProjectDocumentsPage() {
               })}
             </tbody>
           </table>
-          <div className={lp.foot}>
-            <span className={lp.faint}>
-              {total === 0 ? "0" : `${firstOnPage}–${lastOnPage}`} of {total}
-              {isFetching && !isLoading ? " · loading…" : ""}
-            </span>
-            <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-              <button
-                type="button"
-                className={lp.pgBtn}
-                disabled={page <= 1}
-                onClick={() => setPage((p) => p - 1)}
-                aria-label="Previous page"
-              >
-                <IconChevronLeft size={14} />
-              </button>
-              <span className={lp.faint}>
-                page {page} / {totalPages}
-              </span>
-              <button
-                type="button"
-                className={lp.pgBtn}
-                disabled={page >= totalPages}
-                onClick={() => setPage((p) => p + 1)}
-                aria-label="Next page"
-              >
-                <IconChevronRight size={14} />
-              </button>
-            </div>
-          </div>
+          <PaginationFoot
+            page={page}
+            pageCount={totalPages}
+            total={total}
+            pageSize={pageSize}
+            onPage={setPage}
+            onPageSize={(n) => {
+              setPageSize(n);
+              setPage(1);
+            }}
+            loading={isFetching && !isLoading}
+          />
         </div>
       )}
     </div>

--- a/frontend/src/pages/ProjectDocumentsPage.tsx
+++ b/frontend/src/pages/ProjectDocumentsPage.tsx
@@ -12,7 +12,8 @@ import { formatDate } from "../utils/dates";
 import ui from "../styles/redesign.module.css";
 import lp from "../components/ListPage.module.css";
 
-const PAGE_SIZE = 50;
+// Match the other list views (ListPage default is 10).
+const PAGE_SIZE = 10;
 
 export function ProjectDocumentsPage() {
   const { id } = useParams<{ id: string }>();

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -7,7 +7,7 @@ import { useNavigate } from "react-router-dom";
 import { fetchDashboard } from "../api/dashboard";
 import { createProject, deleteProject, updateProject } from "../api/projects";
 import type { Project } from "../api/types";
-import { CliHint } from "../components/CliHint";
+import { CliCard } from "../components/CliCard";
 import { ListPage, type ListColumn } from "../components/ListPage";
 import { useProjects } from "../hooks/useProjects";
 import { showError, showSuccess } from "../utils/notifications";
@@ -155,12 +155,23 @@ export function ProjectsPage() {
         title="Projects"
         subtitle="Scoped collections your agents read from and write to."
         headerRight={
-          <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 8 }}>
-            <CliHint cmd="cerefox project list" />
-            <button type="button" className={`${ui.btn} ${ui.btnPrimary}`} onClick={() => setCreateOpen(true)}>
+          <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 8, width: 320, maxWidth: "100%" }}>
+            <button
+              type="button"
+              className={`${ui.btn} ${ui.btnPrimary}`}
+              style={{ alignSelf: "flex-end" }}
+              onClick={() => setCreateOpen(true)}
+            >
               <IconPlus size={16} />
               New project
             </button>
+            <CliCard
+              title="CLI equivalent"
+              commands={[
+                { cmd: "cerefox project list" },
+                { cmd: "cerefox project create", args: "<name>" },
+              ]}
+            />
           </div>
         }
         searchValue={query}

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -155,7 +155,7 @@ export function ProjectsPage() {
         title="Projects"
         subtitle="Scoped collections your agents read from and write to."
         headerRight={
-          <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 8, width: 320, maxWidth: "100%" }}>
+          <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 8, width: 400, maxWidth: "100%" }}>
             <button
               type="button"
               className={`${ui.btn} ${ui.btnPrimary}`}

--- a/frontend/src/pages/TrashPage.tsx
+++ b/frontend/src/pages/TrashPage.tsx
@@ -131,7 +131,7 @@ export function TrashPage() {
       title="Trash"
       subtitle="Soft-deleted documents — excluded from search until restored or purged."
       headerRight={
-        <div style={{ width: 320, maxWidth: "100%" }}>
+        <div style={{ width: 400, maxWidth: "100%" }}>
           <CliCard
             title="CLI equivalent"
             commands={[

--- a/frontend/src/pages/TrashPage.tsx
+++ b/frontend/src/pages/TrashPage.tsx
@@ -5,7 +5,7 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { fetchTrash, purgeDocument, restoreDocument, type DeletedDocument } from "../api/trash";
-import { CliHint } from "../components/CliHint";
+import { CliCard } from "../components/CliCard";
 import { ListPage, type ListColumn } from "../components/ListPage";
 import { useProjects } from "../hooks/useProjects";
 import { showError, showSuccess } from "../utils/notifications";
@@ -130,7 +130,17 @@ export function TrashPage() {
       eyebrow="Recoverable"
       title="Trash"
       subtitle="Soft-deleted documents — excluded from search until restored or purged."
-      headerRight={<CliHint cmd="cerefox document list" args="--deleted" />}
+      headerRight={
+        <div style={{ width: 320, maxWidth: "100%" }}>
+          <CliCard
+            title="CLI equivalent"
+            commands={[
+              { cmd: "cerefox document list", args: "--deleted" },
+              { cmd: "cerefox document restore", args: "<id>" },
+            ]}
+          />
+        </div>
+      }
       searchValue={query}
       onSearchChange={setQuery}
       searchPlaceholder="Filter trashed documents…"

--- a/frontend/src/pages/TrashPage.tsx
+++ b/frontend/src/pages/TrashPage.tsx
@@ -173,8 +173,8 @@ export function TrashPage() {
           <>
             <button
               type="button"
-              className={`${ui.btn} ${ui.btnGhost}`}
-              title="Restore"
+              className={`${ui.btn} ${ui.btnGhost} ${ui.btnWarn}`}
+              title="Restore from trash"
               onClick={() => restoreMut.mutate(d.id)}
             >
               <IconArrowBackUp size={14} />
@@ -182,11 +182,12 @@ export function TrashPage() {
             </button>
             <button
               type="button"
-              className={`${ui.iconBtnSm} ${ui.iconBtnDanger}`}
-              title="Delete permanently"
+              className={`${ui.btn} ${ui.btnGhost} ${ui.btnDanger}`}
+              title="Permanently delete (cannot be undone)"
               onClick={() => setConfirmId(d.id)}
             >
               <IconTrash size={14} />
+              Purge
             </button>
           </>
         )

--- a/frontend/src/pages/TrashPage.tsx
+++ b/frontend/src/pages/TrashPage.tsx
@@ -130,7 +130,7 @@ export function TrashPage() {
       eyebrow="Recoverable"
       title="Trash"
       subtitle="Soft-deleted documents — excluded from search until restored or purged."
-      headerRight={<CliHint cmd="cerefox document restore" args="<id>" />}
+      headerRight={<CliHint cmd="cerefox document list" args="--deleted" />}
       searchValue={query}
       onSearchChange={setQuery}
       searchPlaceholder="Filter trashed documents…"

--- a/frontend/src/styles/redesign.module.css
+++ b/frontend/src/styles/redesign.module.css
@@ -107,6 +107,15 @@
   border-color: var(--red);
   background: var(--red-soft);
 }
+/* Warn/restore modifier — yellow at rest + hover (distinct, recoverable). */
+.btnWarn {
+  color: var(--yellow);
+}
+.btnWarn:hover {
+  color: var(--yellow);
+  border-color: var(--yellow);
+  background: var(--yellow-soft);
+}
 
 /* ---- cards ---- */
 .card {

--- a/frontend/src/styles/redesign.module.css
+++ b/frontend/src/styles/redesign.module.css
@@ -100,6 +100,13 @@
   background: var(--surface-2);
   color: var(--text);
 }
+/* Danger modifier — combine with .btn/.btnGhost; red on hover, matching the
+   icon-only .iconBtnDanger so every delete/trash affordance highlights alike. */
+.btnDanger:hover {
+  color: var(--red);
+  border-color: var(--red);
+  background: var(--red-soft);
+}
 
 /* ---- cards ---- */
 .card {

--- a/frontend/src/styles/redesign.module.css
+++ b/frontend/src/styles/redesign.module.css
@@ -392,6 +392,37 @@
   padding-left: 17px;
 }
 
+/* one copyable command line inside a CliCard's cliBlock */
+.cliLine {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.cliLine + .cliLine {
+  margin-top: 4px;
+}
+.cliLineCmd {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.cliCopyBtn {
+  flex-shrink: 0;
+  border: 0;
+  background: transparent;
+  color: var(--text-faint);
+  cursor: pointer;
+  display: inline-flex;
+  padding: 2px;
+  border-radius: 4px;
+}
+.cliCopyBtn:hover {
+  color: var(--text);
+  background: var(--surface-2);
+}
+
 /* compact inline terminal snippet (CliHint) — same theming as cliBlock */
 .cliHintBlock {
   display: inline-flex;

--- a/packages/memory/src/cli/commands/list-docs.ts
+++ b/packages/memory/src/cli/commands/list-docs.ts
@@ -25,9 +25,16 @@ interface DocRow {
   created_at: string;
   updated_at: string | null;
   review_status: string | null;
+  deleted_at: string | null;
 }
 
-async function action(options: { project?: string; limit?: string; json?: boolean }): Promise<void> {
+async function action(options: {
+  project?: string;
+  limit?: string;
+  json?: boolean;
+  deleted?: boolean;
+}): Promise<void> {
+  const deleted = !!options.deleted;
   const limit = parsePositiveInt(options.limit, "--limit", 100);
   const client = getClient();
 
@@ -51,9 +58,10 @@ async function action(options: { project?: string; limit?: string; json?: boolea
   let query = client.raw
     .from("cerefox_documents")
     .select("id, title, source, metadata, created_at, updated_at, review_status, deleted_at")
-    .is("deleted_at", null)
-    .order("updated_at", { ascending: false, nullsFirst: false })
     .limit(limit);
+  query = deleted
+    ? query.not("deleted_at", "is", null).order("deleted_at", { ascending: false, nullsFirst: false })
+    : query.is("deleted_at", null).order("updated_at", { ascending: false, nullsFirst: false });
 
   if (projectId) {
     // PostgREST embedding: filter docs through the M2M junction.
@@ -89,18 +97,22 @@ async function action(options: { project?: string; limit?: string; json?: boolea
   }
 
   if (rows.length === 0) {
-    process.stdout.write("(no documents)\n");
+    process.stdout.write(deleted ? "(trash is empty)\n" : "(no documents)\n");
     return;
   }
 
   printTable(
-    rows.map((doc) => ({
-      id: doc.id.slice(0, 8) + "…",
-      title: doc.title.length > 60 ? doc.title.slice(0, 57) + "…" : doc.title,
-      source: doc.source ?? "",
-      status: doc.review_status ?? "",
-      updated_at: (doc.updated_at ?? doc.created_at).slice(0, 19).replace("T", " "),
-    })),
+    rows.map((doc) => {
+      const base = {
+        id: doc.id.slice(0, 8) + "…",
+        title: doc.title.length > 60 ? doc.title.slice(0, 57) + "…" : doc.title,
+        source: doc.source ?? "",
+        status: doc.review_status ?? "",
+      };
+      return deleted
+        ? { ...base, deleted_at: (doc.deleted_at ?? "").slice(0, 19).replace("T", " ") }
+        : { ...base, updated_at: (doc.updated_at ?? doc.created_at).slice(0, 19).replace("T", " ") };
+    }),
   );
 }
 
@@ -110,6 +122,7 @@ export function registerListDocs(program: Command): void {
     .description("List documents in the knowledge base.")
     .option("-p, --project <name>", "Filter to a specific project.")
     .option("-l, --limit <n>", "Maximum docs to return.", "100")
+    .option("--deleted", "List soft-deleted (trashed) documents instead of active ones.")
     .option("--json", "Emit machine-readable JSON.")
     .action(action);
 }

--- a/packages/memory/src/web/routes/documents-read.ts
+++ b/packages/memory/src/web/routes/documents-read.ts
@@ -171,6 +171,7 @@ export function registerDocumentReadRoutes(app: Hono, ctx: WebContext): void {
         : "approved",
       created_at: meta ? ((meta.created_at as string | null) ?? null) : null,
       updated_at: meta ? ((meta.updated_at as string | null) ?? null) : null,
+      deleted_at: meta ? ((meta.deleted_at as string | null) ?? null) : null,
       versions: versions.map((v) => ({
         version_id: v.version_id,
         version_number: v.version_number,


### PR DESCRIPTION
## Summary

Client-only polish from a day of real use — **no server deploy** (no `db/`, RPC, or Edge Function changes; `cut_release` dry-run confirms `schema_version`/`EF_VERSION` stay put).

**Added**
- `cerefox document list --deleted` — list trashed docs from the CLI (newest-deleted first; closes the loop with `document restore`/`delete`). Documented in cli.md; completion auto-covers it.
- A reusable **multi-line CLI card** (Dashboard/Ingest/Trash/Projects) — each `cerefox …` line independently copyable (with ✓), no fake output.
- **In-trash document view** — "In trash" banner + Restore/Purge actions (Edit/Delete + review pill hidden); `/documents/{id}` now returns `deleted_at`.
- **Pagination controls** on all list views: a rows-per-page dropdown (10/25/50/100, persisted in `localStorage` as one global preference) + first/prev/next/last arrows.

**Changed**
- Project documents view rebuilt to the redesigned list pattern (keeps server-side paging).
- Copy buttons flip to a green ✓ on click; delete affordances consistently red-on-hover; Document Delete is a labelled ghost button; Trash/Projects row actions always visible.
- Document project tags are clickable (→ project docs); origin chip uses a prompt Mantine tooltip; Analytics usage-tracking toggle has an explanatory tooltip.

**Fixed**
- Slow/missable native tooltip → Mantine tooltip; widened Trash/Projects CLI cards so commands aren't clipped.

## Deploy
**None.** Frontend + CLI + npm-package web route only. `cerefox server deploy` not required; restart `cerefox web` after upgrading to pick up the `deleted_at` route + new UI.

## Test plan
- [ ] Trash: open a trashed doc → In-trash banner + Restore/Purge; `cerefox document list --deleted` from CLI
- [ ] Pagination: rows-per-page dropdown persists across views/reload; first/last arrows
- [ ] CLI cards copy (✓) on Dashboard/Ingest/Trash/Projects
- [ ] Project docs view paging + styling; clickable project tags on a document
- [ ] Light + dark

🤖 Generated with [Claude Code](https://claude.com/claude-code)