### PR TITLE
v0.9.9: view archived versions in place + docs/completion polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
   completion system has been initialized yet, so cerefox completion registers
   even on a bare shell. It's a no-op when `compinit` already ran (no double
   init).
-- **Quickstart** title no longer claims "5 Minutes"; the intro states up front
-  that a Supabase project is the one prerequisite.
+- **Quickstart** title no longer claims "5 Minutes"; adds a dedicated **Step 0:
+  Create a Supabase project** (linking `setup-supabase.md`) so the prerequisite
+  is explicit rather than buried.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,28 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
-Open roadmap.
+**Document version UX + docs/completion polish. Client-only — no server deploy.**
+
+### Added
+
+- **View an archived version in place** — clicking a version number (or "Open
+  this version" in its ⋯ menu) opens that snapshot read-only at
+  `/document/:id?version=<id>`, with a "Previous version: vN" banner and a
+  "View current version" link back. In version view the header offers only
+  **Download** and a **Protect / Unprotect** toggle (the version's
+  archive/cleanup-protection flag); Edit, Delete, the review pill, and the
+  Chunks tab are hidden.
+- **Per-version size** in the Versions card — each row now shows
+  `N chunks · M chars`, and the actively-viewed version is highlighted.
+
+### Changed
+
+- **`cerefox completion install` (zsh)** now self-bootstraps `compinit` if no
+  completion system has been initialized yet, so cerefox completion registers
+  even on a bare shell. It's a no-op when `compinit` already ran (no double
+  init).
+- **Quickstart** title no longer claims "5 Minutes"; the intro states up front
+  that a Supabase project is the one prerequisite.
 
 ---
 

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -18,6 +18,21 @@ install and setup below is about 5 minutes.
 
 ---
 
+## 0. Create a Supabase project
+
+Cerefox stores everything in your own Supabase (Postgres + pgvector), so create
+a free project first — provisioning takes a few minutes:
+
+1. Sign up / log in at [supabase.com](https://supabase.com) and create a new project.
+2. Keep its **Project URL**, **API keys**, and **database password** handy —
+   `cerefox init` (Step 2) prompts for these.
+
+A fresh, empty project is all you need; `cerefox init` / `cerefox server deploy`
+deploy the schema, RPCs, and Edge Functions for you. Full walkthrough (keys,
+where to find them, what each is for): [`setup-supabase.md`](setup-supabase.md).
+
+---
+
 ## 1. Install
 
 ```bash

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -1,7 +1,9 @@
-# Quickstart -- Zero to First Document in 5 Minutes
+# Quickstart -- Zero to First Document
 
 Get Cerefox running on your machine via the npm install path. **No source
-clone, no Python required.**
+clone, no Python required.** Once you have a Supabase project (the one
+prerequisite — provisioning a free one takes a few minutes), the Cerefox
+install and setup below is about 5 minutes.
 
 > **Upgrading from an earlier version?** See [`upgrading.md`](upgrading.md)
 > for migration steps instead.

--- a/frontend/src/pages/DocumentPage.module.css
+++ b/frontend/src/pages/DocumentPage.module.css
@@ -237,16 +237,49 @@
 .verList {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
 }
 .verRow {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 6px 8px;
+  border: 1px solid transparent;
+  border-radius: 9px;
+}
+.verRowActive {
+  border-color: var(--primary-line);
+  background: var(--primary-soft);
+}
+.verRowTop {
   display: flex;
   align-items: center;
   gap: 8px;
 }
+.verLink {
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: filter 0.12s;
+}
+.verLink:hover {
+  filter: brightness(1.08);
+  text-decoration: underline;
+}
+.verMeta {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--text-faint);
+  padding-left: 2px;
+}
 .verLock {
   color: var(--blue);
   display: inline-flex;
+}
+
+/* version-view banner — blue accent variant of the (red) trash banner */
+.versionBanner {
+  border-color: var(--blue);
+  background: var(--blue-soft);
 }
 
 .actList {

--- a/frontend/src/pages/DocumentPage.tsx
+++ b/frontend/src/pages/DocumentPage.tsx
@@ -468,7 +468,7 @@ export function DocumentPage() {
           <div className={ui.row} style={{ gap: 8 }}>
             <span className={`${ui.badge} ${ui.bBlue}`}>
               <IconHistory size={12} />
-              Previous version: v{viewedVersion!.version_number}
+              This is a previous version: v{viewedVersion!.version_number}
             </span>
             <span style={{ fontSize: 13 }}>
               Read-only snapshot from {new Date(viewedVersion!.created_at).toLocaleDateString()}.

--- a/frontend/src/pages/DocumentPage.tsx
+++ b/frontend/src/pages/DocumentPage.tsx
@@ -7,7 +7,9 @@ import {
   IconDownload,
   IconEdit,
   IconFileText,
+  IconHistory,
   IconLock,
+  IconLockOpen,
   IconMapPin,
   IconSparkles,
   IconStack2,
@@ -17,7 +19,7 @@ import {
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
 import ReactMarkdown from "react-markdown";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import remarkGfm from "remark-gfm";
 
 import { fetchAuditLog, setReviewStatus, setVersionArchived } from "../api/audit";
@@ -107,6 +109,8 @@ function originChip(source: string | null): { icon: typeof IconMapPin; label: st
 
 export function DocumentPage() {
   const { id } = useParams<{ id: string }>();
+  const [searchParams] = useSearchParams();
+  const versionParam = searchParams.get("version");
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [confirmDelete, setConfirmDelete] = useState(false);
@@ -114,8 +118,8 @@ export function DocumentPage() {
   const [view, setView] = useState<View>("rendered");
 
   const { data: doc, isLoading, error } = useQuery({
-    queryKey: ["document", id],
-    queryFn: () => fetchDocument(id!),
+    queryKey: ["document", id, versionParam],
+    queryFn: () => fetchDocument(id!, versionParam ?? undefined),
     enabled: !!id,
   });
   const { data: chunks, isLoading: chunksLoading } = useQuery({
@@ -249,6 +253,16 @@ export function DocumentPage() {
   const chip = originChip(doc.doc_source);
   const ChipIcon = chip.icon;
 
+  // Viewing an archived snapshot (?version=<id>): read-only mode that only
+  // offers Download + Protect/Unprotect for that version.
+  const viewedVersion = versionParam
+    ? doc.versions.find((v) => v.version_id === versionParam)
+    : undefined;
+  const isVersionView = !!viewedVersion;
+  // The chunks tab fetches the *current* chunks, so it's meaningless for an
+  // archived snapshot — fall back to rendered while in version view.
+  const effectiveView: View = isVersionView && view === "chunks" ? "rendered" : view;
+
   return (
     <div className={styles.wrap}>
       <button
@@ -298,8 +312,9 @@ export function DocumentPage() {
             {doc.updated_at && (
               <span className={`${ui.mono} ${ui.faint}`}>updated {formatDateTime(doc.updated_at)}</span>
             )}
-            {/* Review status is an optional gate — irrelevant for a trashed doc, so hide the pill + toggle there. */}
-            {!doc.deleted_at && (
+            {/* Review status is an optional gate — irrelevant for a trashed doc or an
+                archived-version snapshot, so hide the pill + toggle there. */}
+            {!doc.deleted_at && !isVersionView && (
               <button
                 type="button"
                 className={styles.reviewPill}
@@ -322,6 +337,38 @@ export function DocumentPage() {
           </div>
         </div>
         <div className={ui.row} style={{ gap: 8, flexShrink: 0 }}>
+          {isVersionView ? (
+            /* Older-version view: only Download + Protect/Unprotect for this snapshot. */
+            <>
+              <a
+                className={`${ui.btn} ${ui.btnGhost}`}
+                href={getDownloadUrl(id!, viewedVersion!.version_id)}
+              >
+                <IconDownload size={14} />
+                Download
+              </a>
+              <button
+                type="button"
+                className={`${ui.btn} ${ui.btnGhost} ${viewedVersion!.archived ? ui.btnWarn : ""}`}
+                title={
+                  viewedVersion!.archived
+                    ? "Remove protection — this version becomes eligible for cleanup"
+                    : "Protect this version from automatic cleanup"
+                }
+                onClick={() =>
+                  archiveMutation.mutate({
+                    versionId: viewedVersion!.version_id,
+                    archived: !viewedVersion!.archived,
+                  })
+                }
+                disabled={archiveMutation.isPending}
+              >
+                {viewedVersion!.archived ? <IconLockOpen size={14} /> : <IconLock size={14} />}
+                {viewedVersion!.archived ? "Unprotect" : "Protect"}
+              </button>
+            </>
+          ) : (
+          <>
           {/* Download is useful either way. Edit/Delete only for live docs;
               deleted docs get Restore/Purge instead. */}
           <a className={`${ui.btn} ${ui.btnGhost}`} href={getDownloadUrl(id!)}>
@@ -411,8 +458,32 @@ export function DocumentPage() {
               )}
             </>
           )}
+          </>
+          )}
         </div>
       </div>
+
+      {isVersionView && (
+        <div className={`${styles.trashBanner} ${styles.versionBanner}`}>
+          <div className={ui.row} style={{ gap: 8 }}>
+            <span className={`${ui.badge} ${ui.bBlue}`}>
+              <IconHistory size={12} />
+              Previous version: v{viewedVersion!.version_number}
+            </span>
+            <span style={{ fontSize: 13 }}>
+              Read-only snapshot from {new Date(viewedVersion!.created_at).toLocaleDateString()}.
+              {viewedVersion!.archived ? " Protected from cleanup." : ""}
+            </span>
+          </div>
+          <button
+            type="button"
+            className={`${ui.btn} ${ui.btnSubtle}`}
+            onClick={() => navigate(`/document/${id}`)}
+          >
+            View current version
+          </button>
+        </div>
+      )}
 
       {doc.deleted_at && (
         <div className={styles.trashBanner}>
@@ -439,7 +510,7 @@ export function DocumentPage() {
               <div className={ui.seg}>
                 <button
                   type="button"
-                  className={`${ui.segBtn} ${view === "rendered" ? ui.segBtnOn : ""}`}
+                  className={`${ui.segBtn} ${effectiveView === "rendered" ? ui.segBtnOn : ""}`}
                   onClick={() => setView("rendered")}
                 >
                   <IconFileText size={14} />
@@ -447,20 +518,23 @@ export function DocumentPage() {
                 </button>
                 <button
                   type="button"
-                  className={`${ui.segBtn} ${view === "source" ? ui.segBtnOn : ""}`}
+                  className={`${ui.segBtn} ${effectiveView === "source" ? ui.segBtnOn : ""}`}
                   onClick={() => setView("source")}
                 >
                   <IconTerminal2 size={14} />
                   Source
                 </button>
-                <button
-                  type="button"
-                  className={`${ui.segBtn} ${view === "chunks" ? ui.segBtnOn : ""}`}
-                  onClick={() => setView("chunks")}
-                >
-                  <IconStack2 size={14} />
-                  Chunks
-                </button>
+                {/* Chunks reflect the current version only — hide for archived snapshots. */}
+                {!isVersionView && (
+                  <button
+                    type="button"
+                    className={`${ui.segBtn} ${effectiveView === "chunks" ? ui.segBtnOn : ""}`}
+                    onClick={() => setView("chunks")}
+                  >
+                    <IconStack2 size={14} />
+                    Chunks
+                  </button>
+                )}
               </div>
               <span className={`${ui.mono} ${ui.faint}`} style={{ fontSize: 12 }}>
                 {doc.total_chars.toLocaleString()} chars
@@ -469,7 +543,7 @@ export function DocumentPage() {
             <div className={ui.divider} />
 
             <div className={styles.contentScroll}>
-            {view === "rendered" && (
+            {effectiveView === "rendered" && (
               <div className={styles.mdBody}>
                 <div className={md.markdown}>
                   <ReactMarkdown remarkPlugins={[remarkGfm]} components={mdComponents}>
@@ -478,8 +552,8 @@ export function DocumentPage() {
                 </div>
               </div>
             )}
-            {view === "source" && <pre className={styles.docSource}>{doc.full_content}</pre>}
-            {view === "chunks" && (
+            {effectiveView === "source" && <pre className={styles.docSource}>{doc.full_content}</pre>}
+            {effectiveView === "chunks" && (
               <div className={styles.chunkList}>
                 {chunksLoading ? (
                   <div style={{ padding: 18 }}>
@@ -580,55 +654,79 @@ export function DocumentPage() {
                 </Popover>
               </div>
               <div className={styles.verList}>
-                {doc.versions.map((v) => (
-                  <div key={v.version_id} className={styles.verRow}>
-                    <span className={`${ui.badge} ${ui.bNeutral} ${ui.mono}`}>v{v.version_number}</span>
-                    <span className={`${ui.faint} ${ui.mono}`} style={{ fontSize: 11 }}>
-                      {new Date(v.created_at).toLocaleDateString()}
-                    </span>
-                    {v.archived && (
-                      <span className={styles.verLock} title="Archived — protected from cleanup">
-                        <IconLock size={12} />
+                {doc.versions.map((v) => {
+                  const active = v.version_id === versionParam;
+                  return (
+                  <div
+                    key={v.version_id}
+                    className={`${styles.verRow} ${active ? styles.verRowActive : ""}`}
+                  >
+                    <div className={styles.verRowTop}>
+                      <button
+                        type="button"
+                        className={`${ui.badge} ${active ? ui.bPrimary : ui.bNeutral} ${ui.mono} ${styles.verLink}`}
+                        title={active ? "Currently viewing this version" : `View version v${v.version_number}`}
+                        onClick={() => navigate(`/document/${id}?version=${v.version_id}`)}
+                      >
+                        v{v.version_number}
+                      </button>
+                      <span className={`${ui.faint} ${ui.mono}`} style={{ fontSize: 11 }}>
+                        {new Date(v.created_at).toLocaleDateString()}
                       </span>
-                    )}
-                    <Menu position="bottom-end" withinPortal shadow="md" width={180}>
-                      <Menu.Target>
-                        <button
-                          type="button"
-                          className={ui.iconBtn}
-                          style={{ width: 26, height: 26, marginLeft: "auto" }}
-                          aria-label="Version actions"
-                        >
-                          <IconDots size={14} />
-                        </button>
-                      </Menu.Target>
-                      <Menu.Dropdown>
-                        <Menu.Item
-                          leftSection={<IconArrowsDiff size={14} />}
-                          onClick={() => openDiff(v.version_id, v.version_number)}
-                        >
-                          Diff vs current
-                        </Menu.Item>
-                        <Menu.Item
-                          leftSection={<IconDownload size={14} />}
-                          component="a"
-                          href={getDownloadUrl(id!, v.version_id)}
-                        >
-                          Download
-                        </Menu.Item>
-                        <Menu.Item
-                          leftSection={<IconLock size={14} />}
-                          color={v.archived ? "yellow" : undefined}
-                          onClick={() =>
-                            archiveMutation.mutate({ versionId: v.version_id, archived: !v.archived })
-                          }
-                        >
-                          {v.archived ? "Remove protection" : "Archive (protect)"}
-                        </Menu.Item>
-                      </Menu.Dropdown>
-                    </Menu>
+                      {v.archived && (
+                        <span className={styles.verLock} title="Archived — protected from cleanup">
+                          <IconLock size={12} />
+                        </span>
+                      )}
+                      <Menu position="bottom-end" withinPortal shadow="md" width={180}>
+                        <Menu.Target>
+                          <button
+                            type="button"
+                            className={ui.iconBtn}
+                            style={{ width: 26, height: 26, marginLeft: "auto" }}
+                            aria-label="Version actions"
+                          >
+                            <IconDots size={14} />
+                          </button>
+                        </Menu.Target>
+                        <Menu.Dropdown>
+                          <Menu.Item
+                            leftSection={<IconHistory size={14} />}
+                            onClick={() => navigate(`/document/${id}?version=${v.version_id}`)}
+                          >
+                            Open this version
+                          </Menu.Item>
+                          <Menu.Item
+                            leftSection={<IconArrowsDiff size={14} />}
+                            onClick={() => openDiff(v.version_id, v.version_number)}
+                          >
+                            Diff vs current
+                          </Menu.Item>
+                          <Menu.Item
+                            leftSection={<IconDownload size={14} />}
+                            component="a"
+                            href={getDownloadUrl(id!, v.version_id)}
+                          >
+                            Download
+                          </Menu.Item>
+                          <Menu.Item
+                            leftSection={<IconLock size={14} />}
+                            color={v.archived ? "yellow" : undefined}
+                            onClick={() =>
+                              archiveMutation.mutate({ versionId: v.version_id, archived: !v.archived })
+                            }
+                          >
+                            {v.archived ? "Remove protection" : "Archive (protect)"}
+                          </Menu.Item>
+                        </Menu.Dropdown>
+                      </Menu>
+                    </div>
+                    <span className={styles.verMeta}>
+                      {v.chunk_count} chunks · {v.total_chars.toLocaleString()} chars
+                    </span>
                   </div>
-                ))}
+                  );
+                })}
               </div>
             </div>
           )}

--- a/packages/memory/src/cli/commands/completion.ts
+++ b/packages/memory/src/cli/commands/completion.ts
@@ -170,6 +170,12 @@ _cerefox() {
     _cerefox_candidates "$path"
     compadd -- \${=REPLY}
 }
+# Self-bootstrap the completion system if no \`compinit\` has run yet (e.g. this
+# file is sourced from an rc that never initialized completions). No-op when
+# \`compdef\` already exists, so it never re-runs compinit unnecessarily.
+if ! whence compdef >/dev/null 2>&1; then
+    autoload -Uz compinit && compinit
+fi
 compdef _cerefox cerefox
 `;
 }


### PR DESCRIPTION
## Summary

Client-only changes — **no server deploy** (no `src/cerefox/db` or
`supabase/functions` changes; `schema_version`/compat-matrix untouched).

- **View an archived version in place** — clicking a version number (or "Open
  this version" in its ⋯ menu) opens that snapshot read-only at
  `/document/:id?version=<id>`, with a "This is a previous version: vN" banner
  and a "View current version" link back. In version view the header offers only
  **Download** and a **Protect / Unprotect** toggle (the version's
  archive/cleanup-protection flag); Edit, Delete, the review pill, and the
  Chunks tab are hidden.
- **Versions card** — each row shows `N chunks · M chars`, the version number
  links to its snapshot, and the actively-viewed version is highlighted.
- **`cerefox completion install` (zsh)** self-bootstraps `compinit` when no
  completion system has been initialized, so completion registers even on a bare
  shell. No-op (no double-init) when `compinit` already ran.
- **Quickstart** — drops the misleading "5 Minutes" title and adds a dedicated
  **Step 0: Create a Supabase project** linking `setup-supabase.md`.

## Test plan

- [x] Frontend builds clean (`tsc -b && vite build`)
- [x] Version view: banner, Download + Protect/Unprotect, hidden Edit/Delete/review pill/Chunks — reviewed on a local `cerefox web`
- [x] Versions card: per-version size, version link, active-row highlight — reviewed
- [x] `cerefox completion install` (zsh) self-bootstrap verified: registers on a bare shell, no double `compinit` when one already ran
- [ ] Fresh `npm`/`bun` install + `cerefox` smoke (release burn-in)