### PR TITLE
v0.9.10: bypass stale manifest cache in installer + self-update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,18 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
-Open roadmap.
+**Installer/upgrade reliability. Client-only — no server deploy.**
+
+### Fixed
+
+- **Stale-manifest-cache upgrades** — `install.sh` and `cerefox self-update`
+  now bypass the package manager's cached registry manifest (`--no-cache` for
+  bun, `--prefer-online` for npm) when installing/upgrading. Previously, if a
+  new version was published soon after a prior install, bun could reuse a
+  still-"fresh" cached manifest that didn't list the new version — so a
+  re-install resolved `@latest` to the old version (and even an explicit
+  `@<new>` failed with "No version matching"). Forcing a fresh manifest fetch
+  makes upgrades deterministic regardless of release cadence.
 
 ---
 

--- a/install.sh
+++ b/install.sh
@@ -20,8 +20,9 @@ PACKAGE="@cerefox/memory"
 # Default to the `latest` dist-tag (not a bare name). A bare
 # `bun install -g @cerefox/memory` treats an already-installed global as
 # satisfied and skips the upgrade, so a re-install kept the old version;
-# pinning `@latest` forces bun/npm to re-resolve and upgrade. Overridden by
-# the VERSION env below.
+# pinning `@latest` re-resolves the dist-tag (and the install below bypasses
+# the stale manifest cache — see the note there). Overridden by the VERSION
+# env below.
 VERSION_HINT="@latest"
 
 # Allow opting into a specific version via env: VERSION=0.5.0-rc.1 sh install.sh
@@ -82,12 +83,18 @@ fi
 echo "→ Using ${INSTALLER_DESCRIPTION} to install ${PACKAGE}${VERSION_HINT}…"
 echo ""
 
+# Force a fresh registry manifest fetch. `@latest` alone is not enough: bun
+# (and npm) cache the package *manifest* locally and may reuse a stale copy
+# that predates a just-published version — so a re-install soon after the
+# previous one can resolve `@latest` to the OLD version, or fail to find a
+# pinned new version. `--no-cache` (bun) / `--prefer-online` (npm) bypass that
+# manifest cache so the newly published version is always seen.
 case "${INSTALLER}" in
   bun)
-    bun install -g "${PACKAGE}${VERSION_HINT}"
+    bun install -g --no-cache "${PACKAGE}${VERSION_HINT}"
     ;;
   npm)
-    npm install -g "${PACKAGE}${VERSION_HINT}"
+    npm install -g --prefer-online "${PACKAGE}${VERSION_HINT}"
     ;;
 esac
 

--- a/packages/memory/src/cli/commands/self-update.ts
+++ b/packages/memory/src/cli/commands/self-update.ts
@@ -52,10 +52,15 @@ function detectRuntime(): ResolvedRuntime {
   // availability).
   const bin = (process.argv[1] ?? "").toLowerCase();
 
+  // `--no-cache` (bun) / `--prefer-online` (npm) force a fresh registry
+  // manifest fetch. We already resolved the real target version from the
+  // registry above, but bun/npm may hold a stale cached manifest that doesn't
+  // list it yet — without these flags `bun install …@<new>` can fail with
+  // "No version matching" until the cache expires. (pnpm/yarn left as-is.)
   if (bin.includes(".bun") || bin.includes("/bun/")) {
     return {
       command: "bun",
-      args: (v) => ["install", "-g", `@cerefox/memory@${v}`],
+      args: (v) => ["install", "-g", "--no-cache", `@cerefox/memory@${v}`],
       description: "Bun",
     };
   }
@@ -75,7 +80,7 @@ function detectRuntime(): ResolvedRuntime {
   }
   return {
     command: "npm",
-    args: (v) => ["install", "-g", `@cerefox/memory@${v}`],
+    args: (v) => ["install", "-g", "--prefer-online", `@cerefox/memory@${v}`],
     description: "npm",
   };
 }


### PR DESCRIPTION
## Summary

Client-only — **no server deploy** (no `src/cerefox/db` or `supabase/functions`
changes).

Fixes the upgrade footgun where a re-install soon after the previous one could
keep the **old** version. Root cause: bun/npm cache the package's registry
**manifest** locally and may reuse a still-"fresh" copy that predates a
just-published version — so `@latest` resolves to the old version (and an
explicit `@<new>` fails with *"No version matching"*). This bit a 0.9.8→0.9.9
upgrade cut ~3.75h apart, inside bun's manifest-cache freshness window.

- **`install.sh`** — bun branch uses `--no-cache`; npm branch uses
  `--prefer-online`. Corrected the now-inaccurate `@latest` comment.
- **`cerefox self-update` / `upgrade`** — same flags on the bun/npm runtime
  args (it already resolves the real latest from the registry, but then tripped
  on the stale manifest). pnpm/yarn left as-is to avoid invalid flags.

## Test plan

- [x] Package bin builds clean (`bun run build`)
- [x] No test asserts the install args (`self-update --check` returns before `detectRuntime`)
- [x] Verified bun flags exist: `--no-cache` ("Ignore manifest cache entirely"), npm `--prefer-online`
- [ ] Cut 0.9.10, then a quick follow-up patch close together, and confirm the installer/`self-update` pick up the newest version with no manual `bun pm cache rm`