### PR TITLE
Fix: web UI usage logging (Analytics page was empty)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,14 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
-Open roadmap.
+### Fixed
+
+- **Web UI analytics now records usage.** The `/api/v1` web routes never called the
+  usage-logging RPC, so the Analytics page stayed empty even with usage tracking
+  enabled (only the CLI and MCP tools logged). The web layer now logs `search`,
+  `get-document`, and `ingest` operations (`access_path = "webapp"`, fire-and-forget,
+  best-effort — never blocks the response). The `cerefox_log_usage` RPC, config gate,
+  and report query were all already correct; this closes the missing call sites.
 
 ---
 

--- a/packages/memory/src/web/routes/discovery.ts
+++ b/packages/memory/src/web/routes/discovery.ts
@@ -15,6 +15,7 @@ import { Hono } from "hono";
 
 import { getEmbedding } from "../../../../../_shared/embeddings/index.js";
 import type { WebContext } from "../context.ts";
+import { logWebUsage } from "../usage.ts";
 
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -480,6 +481,8 @@ export function registerDiscoveryRoutes(app: Hono, ctx: WebContext): void {
         );
       }
     }
+
+    logWebUsage(ctx, { operation: "search", query_text: q, result_count: results.length });
 
     return c.json({
       results,

--- a/packages/memory/src/web/routes/documents-read.ts
+++ b/packages/memory/src/web/routes/documents-read.ts
@@ -21,6 +21,7 @@
 import { Hono } from "hono";
 
 import type { WebContext } from "../context.ts";
+import { logWebUsage } from "../usage.ts";
 
 interface DocReconRow {
   document_id?: string;
@@ -152,6 +153,8 @@ export function registerDocumentReadRoutes(app: Hono, ctx: WebContext): void {
     const meta = await getDocumentRow(ctx, documentId);
     const projectIds = await listDocumentProjectIds(ctx, documentId);
     const versions = await listDocumentVersions(ctx, documentId);
+
+    logWebUsage(ctx, { operation: "get-document", document_id: documentId });
 
     return c.json({
       document_id: documentId,

--- a/packages/memory/src/web/routes/ingest.ts
+++ b/packages/memory/src/web/routes/ingest.ts
@@ -25,6 +25,7 @@ import { Hono } from "hono";
 import { fileToMarkdown } from "../../ingestion/file-to-markdown.ts";
 import { IngestionPipeline } from "../../ingestion/pipeline.ts";
 import type { WebContext } from "../context.ts";
+import { logWebUsage } from "../usage.ts";
 
 interface IngestResponse {
   success: boolean;
@@ -86,6 +87,7 @@ export function registerIngestRoutes(app: Hono, ctx: WebContext): void {
         updated: result.reindexed,
       };
       if (result.note) resp.note = result.note;
+      logWebUsage(ctx, { operation: "ingest", document_id: result.documentId });
       return c.json(resp, 200);
     } catch (err) {
       return c.json(
@@ -153,6 +155,7 @@ export function registerIngestRoutes(app: Hono, ctx: WebContext): void {
         authorType: "user",
       });
       const skipped = result.action === "skipped";
+      logWebUsage(ctx, { operation: "ingest", document_id: result.documentId });
       return c.json(
         {
           success: !skipped,
@@ -223,6 +226,7 @@ export function registerIngestRoutes(app: Hono, ctx: WebContext): void {
         author: "web-ui",
         authorType: "user",
       });
+      logWebUsage(ctx, { operation: "ingest", document_id: result.documentId });
       return c.json(
         {
           success: true,

--- a/packages/memory/src/web/usage.ts
+++ b/packages/memory/src/web/usage.ts
@@ -1,0 +1,36 @@
+/**
+ * Fire-and-forget usage logging for the web UI (`access_path = "webapp"`).
+ *
+ * The CLI and MCP tools log to `cerefox_usage_log`, but the web `/api/v1` routes
+ * did not — so the Analytics page showed nothing for web-only usage even with
+ * `usage_tracking_enabled = true`. This adds the missing web-side logging.
+ *
+ * Best-effort, exactly like the CLI/MCP `logUsage`: never throws, never blocks the
+ * response (the `cerefox_log_usage` RPC itself returns early when tracking is off).
+ */
+
+import type { WebContext } from "./context.ts";
+
+export interface WebUsageParams {
+  operation: string;
+  document_id?: string | null;
+  project_id?: string | null;
+  query_text?: string | null;
+  result_count?: number | null;
+  requestor?: string | null;
+}
+
+export function logWebUsage(ctx: WebContext, params: WebUsageParams): void {
+  Promise.resolve(
+    ctx.supabase.rpc("cerefox_log_usage", {
+      p_operation: params.operation,
+      p_access_path: "webapp",
+      p_requestor: params.requestor ?? "web-ui",
+      p_document_id: params.document_id ?? null,
+      p_project_id: params.project_id ?? null,
+      p_query_text: params.query_text ?? null,
+      p_result_count: params.result_count ?? null,
+      p_extra: {},
+    }),
+  ).catch(() => {});
+}


### PR DESCRIPTION
## Summary

The web `/api/v1` routes never called `cerefox_log_usage`, so the **Analytics page
stayed empty** for web-only usage even with `usage_tracking_enabled = true` — only the
CLI and MCP tools logged. This adds a fire-and-forget web logger (`access_path =
"webapp"`) and instruments the core operations: **search, get-document, ingest** (all
3 ingest modes).

The RPC, the config gate, and the report query were all already correct (a direct
`cerefox_log_usage` call inserts a row); this just closes the missing web call sites.

**Client/web-only — no schema/RPC/Edge-Function changes, no deploy needed.** Not
local-specific (it was reproduced on the local backend, but the gap is in the shared
web layer, so this fixes cloud too).

## Test plan

- [x] Builds clean (`bun run build`).
- [x] Verified the RPC inserts when called directly (config gate works).
- [x] End-to-end against a local Postgres + PostgREST: `ingest`, `search`, and
      `get-document` each produced a `cerefox_usage_log` row (`access_path=webapp`,
      `requestor=web-ui`).
- [ ] After release, confirm the Analytics page populates on a normal Supabase deploy.

## Notes

- Scope is the high-value operations (search / read / ingest). Extending coverage to
  edits/deletes and list endpoints can follow if wanted.
- Target: **v0.9.11** (patch on v0.9.10).