### PR TITLE
v0.10.0: local/self-hosted Cerefox (World B) — Docker-only, cerefox-local

### DIFF
--- a/.github/workflows/local-image.yml
+++ b/.github/workflows/local-image.yml
@@ -62,5 +62,9 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Drop the SLSA provenance/SBOM attestation manifests (the "unknown/unknown"
+          # entries) for a clean 2-arch manifest. Optional supply-chain metadata; the
+          # image is unaffected. Re-enable (provenance: mode=max) if attestations are wanted.
+          provenance: false
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/local-image.yml
+++ b/.github/workflows/local-image.yml
@@ -1,8 +1,11 @@
 # Build + publish the all-in-one LOCAL Cerefox image to GitHub Container Registry.
 #
-# Triggers ONLY on a published GitHub Release or a manual dispatch — never on push,
-# so it can't fire from a feature branch. Uses the built-in GITHUB_TOKEN (with
-# `packages: write`); no PAT/secret to install.
+# Triggers ONLY on a manual dispatch — never on push and never on `release: published`.
+# Publishing the image is an EXPLICIT opt-in: `cut_release.ts --docker-publish` dispatches
+# this (or run it from the Actions tab). This mirrors the npm `release.yml` policy — a
+# GitHub Release is a git milestone; shipping a user artifact is a separate decision — so
+# you can cut a Release without rebuilding + pushing a multi-arch image. Uses the built-in
+# GITHUB_TOKEN (`packages: write`); no PAT/secret to install.
 #
 # After the FIRST publish, set the package visibility to Public in its GitHub package
 # settings so users can `docker pull` without auth (one-time).
@@ -10,7 +13,7 @@
 # Note: amd64 is built under QEMU emulation on the ubuntu (amd64) runner, so the
 # arm64 build is the emulated/slow one — if build time becomes a problem, switch to a
 # native arm64 runner or split per-arch jobs. Pulls the image to:
-#   ghcr.io/<owner>/cerefox-local:<tag>   (+ :latest on releases)
+#   ghcr.io/<owner>/cerefox-local:<tag>   (+ :latest when publish_latest=true)
 
 name: Publish local image (ghcr.io)
 
@@ -21,8 +24,10 @@ on:
         description: "Image tag (e.g. v0.10.0 or dev)"
         required: true
         default: dev
-  release:
-    types: [published]
+      publish_latest:
+        description: "Also tag :latest (use for a stable release)"
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -50,8 +55,8 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository_owner }}/cerefox-local
           tags: |
-            type=raw,value=${{ github.event.inputs.tag || github.ref_name }}
-            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+            type=raw,value=${{ github.event.inputs.tag }}
+            type=raw,value=latest,enable=${{ github.event.inputs.publish_latest == 'true' }}
 
       - name: Build + push (multi-arch)
         uses: docker/build-push-action@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ are independent worlds — **separate installers, separate command names** (`cer
   (db-init → postgres/postgrest/cerefox-server). The container **self-generates its JWT
   secret on boot and mints the access token internally — the token never leaves the
   container.** Published multi-arch (amd64+arm64) to **ghcr.io/.../cerefox-local** by
-  `.github/workflows/local-image.yml` on release.
+  `.github/workflows/local-image.yml` — opt-in via `cut_release.ts --docker-publish`
+  (decoupled from cutting a Release, same policy as the npm publish).
 - **One-line local installer** (`docker/local/install-local.sh`, shipped as a Release
   asset): `curl -fsSL …/install-local.sh | sh`. Docker-only — pulls the image, runs it
   with `--restart unless-stopped`, waits for readiness, and installs a `cerefox-local`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,31 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
-Open roadmap.
+**Local / self-hosted Cerefox backend (new deployment mode).** Run Cerefox entirely
+on your own machine — Postgres + pgvector + PostgREST + cerefox-server in one
+container — with no cloud dependency. Reuses the existing schema, RPCs, MCP handlers,
+web app, and supabase-js data client unchanged (config-only); cloud deployments are
+unaffected.
+
+### Added
+
+- **All-in-one Docker image** (`docker/local/Dockerfile`): pgvector + pinned PostgREST
+  + the bundled app, supervised by **s6-overlay** (db-init → postgres/postgrest/
+  cerefox-server; auto-restart). Published multi-arch (amd64+arm64) to
+  **ghcr.io/.../cerefox-local** by `.github/workflows/local-image.yml` on release.
+- **`docker/local/install-local.sh`** — one-command local install: pulls the published
+  image, generates a per-install JWT secret, writes a **separate `~/.cerefox/local`
+  client config** (cloud `~/.cerefox/.env` untouched), and propagates the OpenAI key.
+- **`/rest/v1` reverse-proxy in cerefox-server** (`registerPostgrestProxy`), mounted
+  only when `CEREFOX_POSTGREST_UPSTREAM` is set — so it is **inert in cloud**. Makes the
+  server the single local gateway (UI + `/api/v1` + `/rest/v1`).
+- **Version-coupling CI** (`.github/workflows/version-coupling.yml`): runs the
+  read/write smoke against the pinned PostgREST so a `supabase-js` bump that breaks the
+  local stack fails CI.
+
+Design: `docs/research/local-cerefox-design.md`. Remaining (post-v0.10.0): fold the
+installer into the shared `install.sh`/`cerefox init`; minor `schema-version.bundled`
+cosmetic in the image.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,31 +9,51 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
-**Local / self-hosted Cerefox backend (new deployment mode).** Run Cerefox entirely
-on your own machine — Postgres + pgvector + PostgREST + cerefox-server in one
-container — with no cloud dependency. Reuses the existing schema, RPCs, MCP handlers,
-web app, and supabase-js data client unchanged (config-only); cloud deployments are
-unaffected.
+**Local / self-hosted Cerefox backend (new deployment mode — "World B").** Run Cerefox
+entirely on your own machine — Postgres + pgvector + PostgREST + cerefox-server in one
+Docker container — with **no cloud dependency and no Node/Bun on the host**. It reuses
+the existing schema, RPCs, MCP handlers, web app, and supabase-js data client unchanged
+(config-only); cloud (Supabase) deployments are completely unaffected. Cloud and local
+are independent worlds — **separate installers, separate command names** (`cerefox` vs
+`cerefox-local`).
 
 ### Added
 
-- **All-in-one Docker image** (`docker/local/Dockerfile`): pgvector + pinned PostgREST
-  + the bundled app, supervised by **s6-overlay** (db-init → postgres/postgrest/
-  cerefox-server; auto-restart). Published multi-arch (amd64+arm64) to
-  **ghcr.io/.../cerefox-local** by `.github/workflows/local-image.yml` on release.
-- **`docker/local/install-local.sh`** — one-command local install: pulls the published
-  image, generates a per-install JWT secret, writes a **separate `~/.cerefox/local`
-  client config** (cloud `~/.cerefox/.env` untouched), and propagates the OpenAI key.
-- **`/rest/v1` reverse-proxy in cerefox-server** (`registerPostgrestProxy`), mounted
-  only when `CEREFOX_POSTGREST_UPSTREAM` is set — so it is **inert in cloud**. Makes the
-  server the single local gateway (UI + `/api/v1` + `/rest/v1`).
-- **Version-coupling CI** (`.github/workflows/version-coupling.yml`): runs the
-  read/write smoke against the pinned PostgREST so a `supabase-js` bump that breaks the
-  local stack fails CI.
+- **All-in-one Docker image** (`docker/local/Dockerfile`): pgvector + pinned PostgREST +
+  the bundled app + the `cerefox-local` host script, supervised by **s6-overlay**
+  (db-init → postgres/postgrest/cerefox-server). The container **self-generates its JWT
+  secret on boot and mints the access token internally — the token never leaves the
+  container.** Published multi-arch (amd64+arm64) to **ghcr.io/.../cerefox-local** by
+  `.github/workflows/local-image.yml` on release.
+- **One-line local installer** (`docker/local/install-local.sh`, shipped as a Release
+  asset): `curl -fsSL …/install-local.sh | sh`. Docker-only — pulls the image, runs it
+  with `--restart unless-stopped`, waits for readiness, and installs a `cerefox-local`
+  command on PATH. The only host-side secret is `OPENAI_API_KEY` (in
+  `~/.cerefox/local/.env`); the cloud `~/.cerefox/.env` is never touched.
+- **`cerefox-local` command**: host-side lifecycle (`init`, `start`/`stop`/`restart`,
+  `upgrade`, `uninstall [--purge]`, `status`, `logs`, `configure-agent`) plus a proxy that
+  runs every KB verb (`search`, `document`, `project`, `mcp`, …) inside the container via
+  `docker exec` — so MCP stdio works and the same bundled binary serves the local backend.
+  **`cerefox-local init`** sets/rotates the OpenAI key after install.
+- **`CEREFOX_PROG_NAME`**: the bundled bin presents as `cerefox-local` in help/usage when
+  the shim sets it (one binary, no fork).
+- **`/rest/v1` reverse-proxy in cerefox-server** (`registerPostgrestProxy`), mounted only
+  when `CEREFOX_POSTGREST_UPSTREAM` is set — so it is **inert in cloud**. Makes the server
+  the single local gateway (UI + `/api/v1` + `/rest/v1`).
+- **`cut_release.ts`** now uploads `install-local.sh` as a Release asset (next to
+  `install.sh`).
+- **Version-coupling CI** (`.github/workflows/version-coupling.yml`): runs the read/write
+  smoke against the pinned PostgREST so a `supabase-js` bump that breaks the local stack
+  fails CI.
 
-Design: `docs/research/local-cerefox-design.md`. Remaining (post-v0.10.0): fold the
-installer into the shared `install.sh`/`cerefox init`; minor `schema-version.bundled`
-cosmetic in the image.
+### Fixed
+
+- **Local image Help page**: bundle the docs + agent guides into the image so `/app/help`
+  renders offline (was "No bundled docs available").
+
+Design: `docs/research/local-cerefox-design.md`; plan: `docs/plan.md` (Iteration 30).
+Polish deferred to v0.10.1: `cerefox-local --help` merge, in-bin `configure-agent
+--local` for non-Claude clients, and `cerefox-local` shell completion.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -60,49 +60,19 @@ Cerefox is **asynchronous shared memory, not a message bus**. It solves the pers
 
 ## Project status
 
-Cerefox is a single-maintainer open-source project, in the **v0.9.x** line and
-wrapping up its **"Polish & Distribution" arc** — the work that takes it from
-"runnable from a git clone" to "installable like any other modern CLI" (v0.8
-shipped the production-ready installer + `cerefox server deploy`; v0.9 hardened
-the CLI surface into a resource-verb shape and retired the Python runtime to a
-frozen husk, ahead of the v1.0 contract). Highlights of what's already shipped
-(full history in [`CHANGELOG.md`](CHANGELOG.md)):
+Cerefox is a single-maintainer open-source project. As of **v0.10.0** it runs
+two ways: against a hosted **Supabase** project, or **fully local / self-hosted**
+in a single Docker container (no cloud, no account). The whole runtime — CLI,
+MCP server, web UI, ingestion, and server-side deploy — ships in the
+[`@cerefox/memory`](https://www.npmjs.com/package/@cerefox/memory) npm package
+(no Python, no repo clone); the local backend bundles that same runtime plus
+Postgres + pgvector into one image.
 
-- A complete Cerefox feature surface: hybrid search, metadata-filtered search,
-  small-to-big retrieval, implicit versioning with a per-document audit log,
-  soft-delete with a trash bin, multi-project membership.
-- Three integration paths for AI agents: local stdio MCP, remote MCP via
-  Supabase Edge Functions, and a Custom GPT via GPT Actions. Plus a CLI fallback
-  for local coding agents.
-- A React + Mantine web UI at `/app/` with full read/write coverage of the
-  knowledge base.
-
-**Where the project is headed** is captured in
-[`docs/specs/polish-and-distribution-design.md`](docs/specs/polish-and-distribution-design.md)
-(also tracked iteration-by-iteration in [`docs/plan.md`](docs/plan.md)):
-
-| Release | Theme | Ships |
-|---|---|---|
-| v0.2.0 | Foundations + first TS artifact | `VERSION` source-of-truth · OSS hygiene files · SemVer + script-language policies · `scripts/cut_release.ts` (first TS script outside Edge Functions and frontend) |
-| v0.3.0 | "Install anywhere" | `~/.cerefox/` user-state root · `cerefox docs` CLI + `/app/help` web UI · schema-version-mismatch banner · first two Python scripts ported to TS (`sync_docs.ts`, `db_status.ts`) · `_shared/` TS module seeded |
-| v0.4.x | TS MCP server | Local `cerefox mcp` becomes a TypeScript Bun/Node process, published as [`@cerefox/memory`](https://www.npmjs.com/package/@cerefox/memory) on npm · 10th MCP tool `cerefox_get_help` · `_shared/mcp-tools/` shared by remote EF + local server · OIDC trusted publishing |
-| v0.5.0 | TS CLI | `cerefox` binary added to `@cerefox/memory` (same package, growing surface) — callable from any directory, no Python install needed · 6 new lifecycle commands (`init`, `doctor`, `status`, `configure-agent`, `self-update`, `sync-self-docs`) · automatic self-doc ingest (Layer 2 of MCP discoverability) · tab completion for bash/zsh/fish · documented exit codes · Python CLI deprecated (functional through v0.7) |
-| v0.6.0 | TS web server | FastAPI → Hono on Bun · all `/api/v1/*` endpoints + bundled SPA served by `cerefox web` from the same `@cerefox/memory` package · `configure-agent` adds Cursor + Codex + Gemini writers |
-| v0.7.0 | TS ingestion pipeline | Chunking + embedding orchestration + version snapshotting move to TS · `cerefox document ingest` / `ingest-dir` / `reindex` use the in-process pipeline (no Edge Function round-trip) · PDF/DOCX support dropped · `scripts/db_deploy.ts` + `db_migrate.ts` ported · Python web prints a deprecation banner at startup; Python MCP server unchanged |
-| **v0.8.0 – v0.9.x** (current) | Python retirement + CLI redesign | Deprecation banners → removal (Python CLI + web are husks; only `uv run cerefox mcp` survives, frozen); pytest retired in favor of `bun test`; CLI moved to a resource-verb shape (old flat verbs are husks); resource-verb tab-completion |
-| **v1.0.0** (next) | Stability commitment | Strict SemVer becomes binding; long-lived API contract |
-
-Until v1.0.0 the SemVer policy in [`CONTRIBUTING.md`](CONTRIBUTING.md) is
+Until **v1.0.0** the SemVer policy in [`CONTRIBUTING.md`](CONTRIBUTING.md) is
 aspirational — breaking changes can land in minor versions when there's a good
-reason. After v1.0.0 it's binding.
-
-**The npm install path is complete:** the entire runtime surface — CLI, MCP,
-web server, ingestion pipeline, *and* server-side deploy (schema + RPCs + Edge
-Functions via `cerefox server deploy`) — ships in `@cerefox/memory` with no
-Python and no repo clone required. End users install via the one-liner below or
-`npm install -g @cerefox/memory`. The Bun-run `scripts/*.ts` (db_deploy,
-db_migrate, sync_docs, …) remain for contributors working from a clone — they
-duplicate what the CLI does, not capabilities only available from source.
+reason; after v1.0.0 it's binding. Full release history is in
+[`CHANGELOG.md`](CHANGELOG.md); the roadmap and iteration log live in
+[`docs/plan.md`](docs/plan.md).
 
 ---
 
@@ -113,15 +83,15 @@ duplicate what the CLI does, not capabilities only available from source.
 > redirect) and the Python CLI/web were retired to husks. See
 > [`docs/guides/upgrading.md`](docs/guides/upgrading.md).
 
-Cerefox has **two install paths**. Pick the one that fits you — both are
-first-class and kept in sync.
+Cerefox runs **two ways — pick your backend.** Both expose the same features,
+web UI, and MCP tools; they differ only in where your data lives and how you
+install. (Contributors who want to run from source: see *Run from source* below.)
 
-### Path A — I just want to *use* Cerefox (no repo clone)
+### Option 1 — Cloud (Supabase)
 
-Everything is the `cerefox` command from the [`@cerefox/memory`](https://www.npmjs.com/package/@cerefox/memory)
-npm package. **No `git clone`, no Python, no build, no `scripts/`.** The whole
-runtime — CLI, MCP server, web UI, ingestion pipeline, *and* schema + Edge
-Function deploy — ships in that one package.
+Your data lives in **your own Supabase project** (free tier is enough). You use
+the `cerefox` command from the [`@cerefox/memory`](https://www.npmjs.com/package/@cerefox/memory)
+npm package. **No `git clone`, no Python, no build.**
 
 ```bash
 # 1. Install (one-liner; detects Bun, falls back to npm):
@@ -142,20 +112,40 @@ cerefox search "what did I decide about auth?"
 cerefox web              # web UI → http://localhost:8000/app/
 ```
 
-**Prerequisites:** Node 20+ or Bun 1.0+ · a Supabase account (free tier is
-enough) · an embedding API key (OpenAI `text-embedding-3-small` by default, or
-Fireworks AI).
+**Prerequisites:** Node 20+ or Bun 1.0+ · a Supabase account (free tier) · an
+embedding API key (OpenAI `text-embedding-3-small` by default, or Fireworks AI).
 
-**Try it with sample data:** `cerefox document ingest-dir test-data/`
-(the repo's `test-data/` has six diverse markdown docs — or point it at any
-folder of your own `.md` files).
+> **Full walkthrough:** [`docs/guides/quickstart.md`](docs/guides/quickstart.md)
+> (~15 min). Supabase specifics: [`docs/guides/setup-supabase.md`](docs/guides/setup-supabase.md).
 
-> **Full end-user walkthrough:** [`docs/guides/quickstart.md`](docs/guides/quickstart.md)
-> — zero to first ingested document and a connected agent in ~15 minutes.
-> Supabase specifics (API keys, connection pooling) are in
-> [`docs/guides/setup-supabase.md`](docs/guides/setup-supabase.md).
+### Option 2 — Local / self-hosted (Docker)
 
-### Path B — I want to *hack on* Cerefox (run from source)
+Everything runs in **one Docker container** on your machine — Postgres + pgvector
++ the Cerefox server. **No Supabase account, no Node/Bun on the host**, just
+Docker. You get a `cerefox-local` command (same KB verbs as `cerefox`).
+
+```bash
+# 1. Install (one-liner; pulls the all-in-one image, adds a `cerefox-local` command):
+curl -fsSL https://github.com/fstamatelopoulos/cerefox/releases/latest/download/install-local.sh | sh
+
+# 2. Set your OpenAI key (for embeddings) + wire up an AI agent:
+cerefox-local init                 # set/rotate the OpenAI key (re-creates the container)
+cerefox-local configure-agent      # wire an MCP client (e.g. Claude Code)
+
+# 3. Use it:
+cerefox-local document ingest my-notes.md --title "My notes"
+cerefox-local search "what did I decide about auth?"
+#    web UI → http://localhost:8000/app/   (manage: cerefox-local status | upgrade | stop)
+```
+
+**Prerequisites:** Docker (Docker Desktop or [Colima](https://github.com/abiosoft/colima))
+· an OpenAI API key (embeddings still use the OpenAI API).
+
+> **Full walkthrough:** [`docs/guides/setup-local.md`](docs/guides/setup-local.md).
+> Cloud and local are independent — different installer, different command name —
+> so they never collide if you happen to run both.
+
+### Run from source (contributors)
 
 Clone the repo and run from source. `bun` drives everything; `uv` is only for
 the legacy Python MCP fallback.
@@ -254,7 +244,7 @@ Full setup for every client — plus a manual per-client config appendix for whe
 | `docs/guides/agent-coordination.md` | Multi-agent coordination patterns and best practices |
 | `docs/guides/response-limits.md` | Response size limits: per-path behaviour and tuning |
 | `docs/guides/access-paths.md` | All access layers, credentials, and integration paths |
-| `docs/guides/setup-local.md` | Local Docker setup |
+| `docs/guides/setup-local.md` | Local / self-hosted (Docker) backend — install, `cerefox-local`, MCP |
 | `docs/guides/ops-scripts.md` | Backup, restore, migrate, sync docs |
 | `docs/guides/setup-cloud-run.md` | Google Cloud Run deployment |
 | `docs/guides/operational-cost.md` | Cost breakdown for all deployment options |

--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -53,7 +53,11 @@ COPY --from=builder /src/packages/memory/docs /opt/cerefox/docs
 COPY --from=builder /src/packages/memory/AGENT_GUIDE.md /opt/cerefox/AGENT_GUIDE.md
 COPY --from=builder /src/packages/memory/AGENT_QUICK_REFERENCE.md /opt/cerefox/AGENT_QUICK_REFERENCE.md
 COPY docker/local/roles.sql /opt/cerefox/roles.sql
-RUN printf '#!/bin/sh\nexec bun /opt/cerefox/dist/bin/cerefox.js "$@"\n' > /usr/local/bin/cerefox \
+# The host-side `cerefox-local` script is bundled here so the installer can `docker cp`
+# it onto the host (single source of truth; `cerefox-local upgrade` refreshes it).
+COPY docker/local/cerefox-local /opt/cerefox/cerefox-local
+RUN chmod +x /opt/cerefox/cerefox-local \
+ && printf '#!/bin/sh\nexec bun /opt/cerefox/dist/bin/cerefox.js "$@"\n' > /usr/local/bin/cerefox \
  && chmod +x /usr/local/bin/cerefox
 
 # s6 service tree: db-init (oneshot) → postgres / postgrest / cerefox-server (longruns).

--- a/docker/local/README.md
+++ b/docker/local/README.md
@@ -135,8 +135,9 @@ works and the JWT is sourced in-container). The bin reads `CEREFOX_PROG_NAME`, s
 `cerefox-local` by the shim, so help/usage read the right name.
 
 Default image: `ghcr.io/fstamatelopoulos/cerefox-local:latest` (published by
-`.github/workflows/local-image.yml` on a GitHub Release; pin via
-`CEREFOX_LOCAL_IMAGE=…:v0.10.0`). The one-liner ships as a Release asset:
+`.github/workflows/local-image.yml`, opt-in via `cut_release.ts --docker-publish`
+or a manual dispatch; pin via `CEREFOX_LOCAL_IMAGE=…:v0.10.0`). The one-liner ships as a
+Release asset:
 `curl -fsSL https://github.com/fstamatelopoulos/cerefox/releases/latest/download/install-local.sh | sh`.
 
 Validated: `/app/` + Help docs, project CRUD, ingest (768-dim OpenAI embeddings), and

--- a/docker/local/README.md
+++ b/docker/local/README.md
@@ -107,23 +107,37 @@ docker-compose -f docker/local/compose.yml down -v   # stop + WIPE the spike vol
 
 ## All-in-one image (P1) + installer (P2) — ✅ BUILT + VALIDATED
 
-The single-container image and the Model-B installer are done. Quickstart:
+The single-container image and the **World-B installer** are done. World B is the
+**Docker-only** local world: no Node/Bun on the host, its own `cerefox-local` command,
+and the JWT **never leaves the container** (db-init self-generates the secret + mints the
+`service_role` JWT into `/run` on boot; the host stores only `OPENAI_API_KEY`).
 
 ```sh
-# End-user path — installs + runs from the PUBLISHED multi-arch ghcr image
-# (pulled automatically; generates a per-install JWT secret; writes a SEPARATE client
-# config at ~/.cerefox/local; never touches your cloud ~/.cerefox/.env):
+# End-user path — installs + runs from the PUBLISHED multi-arch ghcr image and drops a
+# host `cerefox-local` command (symlinked into ~/.local/bin). Never touches cloud
+# ~/.cerefox/.env (only reads its OPENAI_API_KEY line as a convenience):
 OPENAI_API_KEY=sk-... sh docker/local/install-local.sh
 #   → http://localhost:8000/app/   (PORT=8017 etc. to change)
-#   CLI/MCP against local:  CEREFOX_CONFIG_DIR=~/.cerefox/local cerefox <cmd>
+#   Then:  cerefox-local status | search "…" | document ingest notes.md
+#          cerefox-local configure-agent       # wire an MCP client
+#          cerefox-local upgrade | stop | start | uninstall [--purge]
 
 # Contributor / pre-release — build locally and point the installer at it:
 docker build -f docker/local/Dockerfile -t cerefox-local:dev .
 CEREFOX_LOCAL_IMAGE=cerefox-local:dev sh docker/local/install-local.sh
 ```
 
-Default image: `ghcr.io/fstamatelopoulos/cerefox-local:latest` (published by the
-release workflow on a GitHub Release; pin a tag via `CEREFOX_LOCAL_IMAGE=…:v0.10.0`).
+`cerefox-local` is a host script bundled in the image at `/opt/cerefox/cerefox-local`;
+the installer `docker cp`s it out (single source of truth). It handles lifecycle verbs on
+the host and proxies KB verbs into the container via
+`docker exec -i … sh -c '. /run/cerefox-runtime.env; exec cerefox "$@"'` (so MCP stdio
+works and the JWT is sourced in-container). The bin reads `CEREFOX_PROG_NAME`, set to
+`cerefox-local` by the shim, so help/usage read the right name.
+
+Default image: `ghcr.io/fstamatelopoulos/cerefox-local:latest` (published by
+`.github/workflows/local-image.yml` on a GitHub Release; pin via
+`CEREFOX_LOCAL_IMAGE=…:v0.10.0`). The one-liner ships as a Release asset:
+`curl -fsSL https://github.com/fstamatelopoulos/cerefox/releases/latest/download/install-local.sh | sh`.
 
 Validated: `/app/` + Help docs, project CRUD, ingest (768-dim OpenAI embeddings), and
 hybrid search all work in one container; data persists in the named volume. Supervised

--- a/docker/local/README.md
+++ b/docker/local/README.md
@@ -110,26 +110,28 @@ docker-compose -f docker/local/compose.yml down -v   # stop + WIPE the spike vol
 The single-container image and the Model-B installer are done. Quickstart:
 
 ```sh
-# Build the image (from repo root):
-docker build -f docker/local/Dockerfile -t cerefox-local:dev .
-
-# Install + run (generates a per-install JWT secret, writes a SEPARATE client
-# config at ~/.cerefox/local, never touches your cloud ~/.cerefox/.env):
-PORT=8000 OPENAI_API_KEY=sk-... sh docker/local/install-local.sh
-#   → http://localhost:8000/app/
+# End-user path — installs + runs from the PUBLISHED multi-arch ghcr image
+# (pulled automatically; generates a per-install JWT secret; writes a SEPARATE client
+# config at ~/.cerefox/local; never touches your cloud ~/.cerefox/.env):
+OPENAI_API_KEY=sk-... sh docker/local/install-local.sh
+#   → http://localhost:8000/app/   (PORT=8017 etc. to change)
 #   CLI/MCP against local:  CEREFOX_CONFIG_DIR=~/.cerefox/local cerefox <cmd>
 
-# Or a bare run (self-generates the JWT; web UI works, external CLI needs the installer):
-docker run -d --name cerefox -p 8000:8000 -v cerefox_pgdata:/var/lib/postgresql/data \
-  -e OPENAI_API_KEY=sk-... cerefox-local:dev
+# Contributor / pre-release — build locally and point the installer at it:
+docker build -f docker/local/Dockerfile -t cerefox-local:dev .
+CEREFOX_LOCAL_IMAGE=cerefox-local:dev sh docker/local/install-local.sh
 ```
 
-Validated: `/app/`, project CRUD, ingest (768-dim OpenAI embeddings), and hybrid
-search all work in one container; data persists in the named volume. Supervised by
-**s6-overlay** (db-init oneshot → postgres/postgrest/cerefox-server longruns;
-auto-respawns a crashed service — validated).
-**Remaining (deferred):** ghcr.io multi-arch publish, folding the installer into the
-shared `install.sh` / `cerefox init`, and a `schema-version.bundled=null` cosmetic.
+Default image: `ghcr.io/fstamatelopoulos/cerefox-local:latest` (published by the
+release workflow on a GitHub Release; pin a tag via `CEREFOX_LOCAL_IMAGE=…:v0.10.0`).
+
+Validated: `/app/` + Help docs, project CRUD, ingest (768-dim OpenAI embeddings), and
+hybrid search all work in one container; data persists in the named volume. Supervised
+by **s6-overlay** (db-init oneshot → postgres/postgrest/cerefox-server longruns;
+auto-respawns a crashed service — validated). The published multi-arch image
+(amd64+arm64) pulls + runs from ghcr.
+**Remaining (deferred):** folding the installer into the shared `install.sh` /
+`cerefox init`, and a `schema-version.bundled=null` cosmetic.
 
 How the image is built (reference):
 

--- a/docker/local/cerefox-local
+++ b/docker/local/cerefox-local
@@ -79,7 +79,7 @@ case "$cmd" in
     if [ "$cmd" != "" ] && is_running; then
       echo; echo "--- knowledge-base verbs (from the container) ---"
       docker exec -e CEREFOX_PROG_NAME=cerefox-local "$CONTAINER" \
-        sh -c '. /run/cerefox-runtime.env 2>/dev/null; exec cerefox --help' 2>/dev/null || true
+        sh -c 'set -a; . /run/cerefox-runtime.env 2>/dev/null; set +a; exec cerefox --help' 2>/dev/null || true
     fi
     ;;
 
@@ -145,6 +145,6 @@ EOF
     # -i so stdio (notably `mcp`) passes through; -t only when attached to a TTY.
     tflag=""; [ -t 0 ] && [ -t 1 ] && tflag="-t"
     exec docker exec -i $tflag -e CEREFOX_PROG_NAME=cerefox-local "$CONTAINER" \
-      sh -c '. /run/cerefox-runtime.env 2>/dev/null; exec cerefox "$@"' cerefox "$cmd" "$@"
+      sh -c 'set -a; . /run/cerefox-runtime.env 2>/dev/null; set +a; exec cerefox "$@"' cerefox "$cmd" "$@"
     ;;
 esac

--- a/docker/local/cerefox-local
+++ b/docker/local/cerefox-local
@@ -109,13 +109,13 @@ case "$cmd" in
       # shellcheck disable=SC1090
       cur_port="$(. "$ENV_FILE"; echo "${CEREFOX_LOCAL_PORT:-8000}")"
     fi
-    if [ -z "$key" ] && [ -r /dev/tty ]; then
+    if [ -z "$key" ] && [ -t 0 ]; then
       if [ -n "$cur_key" ]; then
-        printf 'OpenAI API key [Enter to keep current …%s]: ' "$(printf '%s' "$cur_key" | tail -c 4)" >/dev/tty
+        printf 'OpenAI API key [Enter to keep current …%s]: ' "$(printf '%s' "$cur_key" | tail -c 4)"
       else
-        printf 'OpenAI API key (sk-…, Enter to skip): ' >/dev/tty
+        printf 'OpenAI API key (sk-…, Enter to skip): '
       fi
-      read -r key </dev/tty || true
+      read -r key || true
     fi
     [ -z "$key" ] && key="$cur_key"     # keep current when left blank
     [ -z "$port" ] && port="$cur_port"

--- a/docker/local/cerefox-local
+++ b/docker/local/cerefox-local
@@ -37,6 +37,10 @@ recreate() {
   # shellcheck disable=SC1090
   PORT="$(. "$ENV_FILE"; echo "${CEREFOX_LOCAL_PORT:-8000}")"
   OPENAI_API_KEY="$(. "$ENV_FILE"; echo "${OPENAI_API_KEY:-}")"
+  # Ensure the image is available BEFORE removing the running container, so a failed pull
+  # (offline, or a tag that doesn't exist yet) can't leave us with no container at all.
+  docker image inspect "$IMAGE" >/dev/null 2>&1 || docker pull "$IMAGE" \
+    || die "image '$IMAGE' not present locally and pull failed — container left running"
   docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
   # shellcheck disable=SC2086
   docker run -d --name "$CONTAINER" -p "$PORT:8000" \

--- a/docker/local/cerefox-local
+++ b/docker/local/cerefox-local
@@ -1,0 +1,150 @@
+#!/usr/bin/env sh
+# cerefox-local — the host-side command for the LOCAL (Docker) Cerefox world.
+#
+# Two kinds of verbs:
+#   1. HOST verbs (handled here) — manage the container + the host's MCP config:
+#        start | stop | restart | upgrade | uninstall | status | logs | configure-agent
+#   2. EVERYTHING ELSE — proxied INTO the container's bundled `cerefox` binary via
+#      `docker exec`, sourcing the in-container runtime env (the service_role JWT lives
+#      ONLY in the container; it never touches the host). So:
+#        cerefox-local search "…"      → in-container `cerefox search "…"`
+#        cerefox-local document list   → in-container `cerefox document list`
+#        cerefox-local mcp             → in-container `cerefox mcp` (stdio over docker exec -i)
+#
+# Installed by docker/local/install-local.sh. The cloud/Supabase world keeps using the
+# separate npm `cerefox` command — the two never collide.
+set -eu
+
+CONTAINER="${CEREFOX_LOCAL_CONTAINER:-cerefox-local}"
+CONFIG_DIR="${CEREFOX_LOCAL_CONFIG_DIR:-$HOME/.cerefox/local}"
+IMAGE="${CEREFOX_LOCAL_IMAGE:-ghcr.io/fstamatelopoulos/cerefox-local:latest}"
+VOLUME="${CEREFOX_LOCAL_VOLUME:-cerefox_local_pgdata}"
+ENV_FILE="$CONFIG_DIR/.env"
+
+die() { echo "✗ $*" >&2; exit 1; }
+need_docker() { command -v docker >/dev/null 2>&1 || die "docker not found"; }
+is_running() { [ "$(docker inspect -f '{{.State.Running}}' "$CONTAINER" 2>/dev/null || echo false)" = "true" ]; }
+host_port() {
+  # The published host port for container :8000 (so we can print the right URL).
+  docker inspect -f '{{range $p, $c := .NetworkSettings.Ports}}{{if eq $p "8000/tcp"}}{{(index $c 0).HostPort}}{{end}}{{end}}' "$CONTAINER" 2>/dev/null || true
+}
+
+# Recreate the container from the persisted config (used by `upgrade`). Reads the
+# host port + OPENAI key from $ENV_FILE so an upgrade preserves them.
+recreate() {
+  need_docker
+  [ -f "$ENV_FILE" ] || die "no config at $ENV_FILE — run install-local.sh first"
+  # shellcheck disable=SC1090
+  PORT="$(. "$ENV_FILE"; echo "${CEREFOX_LOCAL_PORT:-8000}")"
+  OPENAI_API_KEY="$(. "$ENV_FILE"; echo "${OPENAI_API_KEY:-}")"
+  docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+  # shellcheck disable=SC2086
+  docker run -d --name "$CONTAINER" -p "$PORT:8000" \
+    -v "$VOLUME:/var/lib/postgresql/data" \
+    ${OPENAI_API_KEY:+-e OPENAI_API_KEY=$OPENAI_API_KEY} \
+    "$IMAGE" >/dev/null
+  echo "✓ container (re)started → http://localhost:$PORT/app/"
+}
+
+usage() {
+  cat <<EOF
+cerefox-local — manage + use your local (Docker) Cerefox.
+
+Lifecycle (handled on the host):
+  start | up            start the stopped container
+  stop  | down          stop the container (data persists in the volume)
+  restart               restart the container
+  upgrade               pull the latest image + recreate (keeps your data + OPENAI key)
+  uninstall [--purge]   remove the container (--purge also DELETES the data volume)
+  status                show container state + URL
+  logs [-f]             show container logs
+  configure-agent       wire an MCP client to this local server (Claude Code, etc.)
+
+Knowledge base (run inside the container — same as the cloud CLI):
+  search · document · project · metadata · audit · config · guides · mcp · …
+  e.g.  cerefox-local search "release process"
+        cerefox-local document ingest notes.md --project-name personal
+
+Run 'cerefox-local <group> --help' for KB verbs.
+EOF
+}
+
+cmd="${1:-}"; [ "$#" -gt 0 ] && shift || true
+
+case "$cmd" in
+  ""|-h|--help|help)
+    usage
+    # Append the in-container KB help when the container is up, so a single
+    # `--help` shows both worlds. (The container's commander knows only the KB verbs.)
+    if [ "$cmd" != "" ] && is_running; then
+      echo; echo "--- knowledge-base verbs (from the container) ---"
+      docker exec -e CEREFOX_PROG_NAME=cerefox-local "$CONTAINER" \
+        sh -c '. /run/cerefox-runtime.env 2>/dev/null; exec cerefox --help' 2>/dev/null || true
+    fi
+    ;;
+
+  start|up)      need_docker; docker start "$CONTAINER" >/dev/null && echo "✓ started → http://localhost:$(host_port)/app/" ;;
+  stop|down)     need_docker; docker stop "$CONTAINER"  >/dev/null && echo "✓ stopped (data kept)" ;;
+  restart)       need_docker; docker restart "$CONTAINER" >/dev/null && echo "✓ restarted → http://localhost:$(host_port)/app/" ;;
+  status)
+    need_docker
+    if is_running; then echo "● running   $CONTAINER   → http://localhost:$(host_port)/app/";
+    elif docker inspect "$CONTAINER" >/dev/null 2>&1; then echo "○ stopped   $CONTAINER   (run: cerefox-local start)";
+    else echo "✗ not installed   (run install-local.sh)"; fi
+    ;;
+  logs)          need_docker; docker logs "$@" "$CONTAINER" ;;
+
+  upgrade)
+    need_docker
+    echo "Pulling $IMAGE …"; docker pull "$IMAGE"
+    recreate
+    # Refresh this host script from the new image (atomic rename → safe mid-run).
+    dst="$CONFIG_DIR/cerefox-local"; tmp="$CONFIG_DIR/.cerefox-local.new"
+    if docker cp "$CONTAINER:/opt/cerefox/cerefox-local" "$tmp" 2>/dev/null; then
+      chmod +x "$tmp"; mv "$tmp" "$dst" && echo "✓ refreshed cerefox-local from the new image"
+    fi
+    ;;
+
+  uninstall)
+    need_docker
+    purge=false; [ "${1:-}" = "--purge" ] && purge=true
+    docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+    echo "✓ container removed"
+    if [ "$purge" = true ]; then
+      docker volume rm "$VOLUME" >/dev/null 2>&1 || true
+      echo "✓ data volume '$VOLUME' DELETED"
+    else
+      echo "  data volume '$VOLUME' kept (use --purge to delete it)"
+    fi
+    ;;
+
+  configure-agent)
+    # Host-side: wire an MCP client to the local server. The MCP server runs INSIDE
+    # the container, launched per-session via `docker exec -i`. We register the host
+    # `cerefox-local mcp` wrapper so the client never needs the JWT.
+    self="$(command -v cerefox-local || echo "$CONFIG_DIR/cerefox-local")"
+    if command -v claude >/dev/null 2>&1; then
+      claude mcp add cerefox-local -- "$self" mcp && echo "✓ added MCP server 'cerefox-local' to Claude Code"
+    else
+      cat <<EOF
+Add this MCP server to your client (command + args form):
+
+  command: $self
+  args:    ["mcp"]
+
+For Claude Code:  claude mcp add cerefox-local -- $self mcp
+The container holds the credential; the client needs no token.
+EOF
+    fi
+    ;;
+
+  *)
+    # Proxy any other verb into the container's bundled cerefox binary.
+    need_docker
+    is_running || die "container '$CONTAINER' is not running — run: cerefox-local start"
+    # -i so stdio (notably `mcp`) passes through; -t only when attached to a TTY.
+    tflag=""; [ -t 0 ] && [ -t 1 ] && tflag="-t"
+    exec docker exec -i $tflag -e CEREFOX_PROG_NAME=cerefox-local "$CONTAINER" \
+      sh -c '. /run/cerefox-runtime.env 2>/dev/null; exec cerefox "$@"' cerefox "$cmd" "$@"
+    ;;
+esac

--- a/docker/local/cerefox-local
+++ b/docker/local/cerefox-local
@@ -52,6 +52,7 @@ usage() {
 cerefox-local — manage + use your local (Docker) Cerefox.
 
 Lifecycle (handled on the host):
+  init                  set/update the OpenAI API key (+ port), then (re)start
   start | up            start the stopped container
   stop  | down          stop the container (data persists in the volume)
   restart               restart the container
@@ -82,6 +83,52 @@ case "$cmd" in
       docker exec -e CEREFOX_PROG_NAME=cerefox-local "$CONTAINER" \
         sh -c 'set -a; . /run/cerefox-runtime.env 2>/dev/null; set +a; exec cerefox --help' 2>/dev/null || true
     fi
+    ;;
+
+  init)
+    # Post-install setup: set/update the OpenAI API key (+ optional port), persist to the
+    # host config, then recreate the container so it picks up the key. Interactive when a
+    # TTY is available; otherwise pass --openai-key / --port. Embeddings (ingest + semantic
+    # search) need the key; without it the server still runs (FTS only).
+    need_docker
+    key=""; port=""
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --openai-key) key="${2:-}"; shift 2 ;;
+        --openai-key=*) key="${1#*=}"; shift ;;
+        --port) port="${2:-}"; shift 2 ;;
+        --port=*) port="${1#*=}"; shift ;;
+        *) die "unknown init option: $1 (use --openai-key / --port)" ;;
+      esac
+    done
+    mkdir -p "$CONFIG_DIR"; chmod 700 "$CONFIG_DIR"
+    cur_key=""; cur_port="8000"
+    if [ -f "$ENV_FILE" ]; then
+      # shellcheck disable=SC1090
+      cur_key="$(. "$ENV_FILE"; echo "${OPENAI_API_KEY:-}")"
+      # shellcheck disable=SC1090
+      cur_port="$(. "$ENV_FILE"; echo "${CEREFOX_LOCAL_PORT:-8000}")"
+    fi
+    if [ -z "$key" ] && [ -r /dev/tty ]; then
+      if [ -n "$cur_key" ]; then
+        printf 'OpenAI API key [Enter to keep current …%s]: ' "$(printf '%s' "$cur_key" | tail -c 4)" >/dev/tty
+      else
+        printf 'OpenAI API key (sk-…, Enter to skip): ' >/dev/tty
+      fi
+      read -r key </dev/tty || true
+    fi
+    [ -z "$key" ] && key="$cur_key"     # keep current when left blank
+    [ -z "$port" ] && port="$cur_port"
+    umask 077
+    {
+      echo "# Cerefox LOCAL host config. The access token lives in the container, not here;"
+      echo "# only the OpenAI key + port are stored. Manage with: cerefox-local init"
+      echo "CEREFOX_LOCAL_PORT=$port"
+      [ -n "$key" ] && echo "OPENAI_API_KEY=$key"
+    } > "$ENV_FILE"
+    echo "✓ saved config to $ENV_FILE"
+    [ -n "$key" ] || echo "  (no OpenAI key set — ingest + semantic search stay disabled; re-run 'cerefox-local init' to add one)"
+    recreate
     ;;
 
   start|up)      need_docker; docker start "$CONTAINER" >/dev/null && echo "✓ started → http://localhost:$(host_port)/app/" ;;

--- a/docker/local/cerefox-local
+++ b/docker/local/cerefox-local
@@ -40,6 +40,7 @@ recreate() {
   docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
   # shellcheck disable=SC2086
   docker run -d --name "$CONTAINER" -p "$PORT:8000" \
+    --restart unless-stopped \
     -v "$VOLUME:/var/lib/postgresql/data" \
     ${OPENAI_API_KEY:+-e OPENAI_API_KEY=$OPENAI_API_KEY} \
     "$IMAGE" >/dev/null

--- a/docker/local/install-local.sh
+++ b/docker/local/install-local.sh
@@ -1,23 +1,22 @@
 #!/usr/bin/env sh
-# Install + run the Cerefox Local Server (the all-in-one image) — "Model B":
-# a per-install JWT secret is generated HERE, injected into the container, and the
-# matching service_role JWT is written to a SEPARATE client config so the local
-# setup coexists with any cloud setup. Your cloud ~/.cerefox/.env is NEVER touched.
+# Install + run the Cerefox Local Server — the all-in-one Docker image (Postgres+pgvector
+# + PostgREST + cerefox-server, supervised by s6) PLUS a host `cerefox-local` command.
+#
+# This is the LOCAL/self-hosted world. It is SEPARATE from the cloud/Supabase world
+# (the npm `cerefox` command): different installer, different command name, no collision.
+#
+# Docker-only — NO Node/Bun on the host. The container bundles the `cerefox` binary and
+# self-generates its own JWT secret on boot; the credential NEVER leaves the container.
+# The only host-side secret is OPENAI_API_KEY (for embeddings), kept in $CONFIG_DIR/.env
+# so `cerefox-local upgrade` can re-pass it on container recreate.
 #
 # Usage (pulls the published ghcr image by default):
-#   sh docker/local/install-local.sh
-#   PORT=8000 OPENAI_API_KEY=sk-... sh docker/local/install-local.sh
+#   curl -fsSL https://github.com/fstamatelopoulos/cerefox/releases/latest/download/install-local.sh | sh
+#   PORT=8017 OPENAI_API_KEY=sk-... sh install-local.sh
 #
-# Default image: ghcr.io/fstamatelopoulos/cerefox-local:latest (published by the
-# release workflow on a GitHub Release). Override for local builds / pinned tags:
-#   CEREFOX_LOCAL_IMAGE=cerefox-local:dev sh ...    # after `docker build -f docker/local/Dockerfile -t cerefox-local:dev .`
-#   CEREFOX_LOCAL_IMAGE=ghcr.io/fstamatelopoulos/cerefox-local:v0.10.0 sh ...
-#
-# Then use the CLI/MCP against local by pointing at the separate config dir:
-#   CEREFOX_CONFIG_DIR=~/.cerefox/local cerefox search "…"
-#
-# NOTE (P2 scaffolding): standalone + validated. Folding this into the shared
-# `install.sh` / `cerefox init` is deferred for review (it's the user-facing path).
+# Override the image (local build / pinned tag):
+#   CEREFOX_LOCAL_IMAGE=cerefox-local:dev sh install-local.sh    # after a local docker build
+#   CEREFOX_LOCAL_IMAGE=ghcr.io/fstamatelopoulos/cerefox-local:v0.10.0 sh install-local.sh
 set -eu
 
 IMAGE="${CEREFOX_LOCAL_IMAGE:-ghcr.io/fstamatelopoulos/cerefox-local:latest}"
@@ -25,58 +24,53 @@ PORT="${PORT:-8000}"
 CONFIG_DIR="${CEREFOX_LOCAL_CONFIG_DIR:-$HOME/.cerefox/local}"
 CONTAINER="${CEREFOX_LOCAL_CONTAINER:-cerefox-local}"
 VOLUME="${CEREFOX_LOCAL_VOLUME:-cerefox_local_pgdata}"
+BIN_DIR="${CEREFOX_LOCAL_BIN_DIR:-$HOME/.local/bin}"
 
-command -v docker  >/dev/null 2>&1 || { echo "✗ docker not found"; exit 1; }
-command -v openssl >/dev/null 2>&1 || { echo "✗ openssl not found"; exit 1; }
+command -v docker >/dev/null 2>&1 || { echo "✗ docker not found — install Docker (or Colima) first"; exit 1; }
 
 mkdir -p "$CONFIG_DIR"; chmod 700 "$CONFIG_DIR"
 
-# 1. Per-install JWT secret (persisted; stable across re-runs).
-SECRET_FILE="$CONFIG_DIR/jwt-secret"
-if [ -f "$SECRET_FILE" ]; then
-  SECRET=$(cat "$SECRET_FILE")
-else
-  SECRET=$(openssl rand -hex 32)
-  printf '%s' "$SECRET" > "$SECRET_FILE"; chmod 600 "$SECRET_FILE"
-fi
-
-# 2. Mint the matching service_role JWT (HS256) with openssl (no bun/node needed).
-b64url() { openssl base64 -A | tr '+/' '-_' | tr -d '='; }
-HEADER=$(printf '%s'  '{"alg":"HS256","typ":"JWT"}' | b64url)
-PAYLOAD=$(printf '%s' '{"role":"service_role"}'      | b64url)
-SIG=$(printf '%s' "$HEADER.$PAYLOAD" | openssl dgst -sha256 -hmac "$SECRET" -binary | b64url)
-JWT="$HEADER.$PAYLOAD.$SIG"
-
 # Embedder key: prefer the env; else pull ONLY the OPENAI_API_KEY line from the cloud
-# ~/.cerefox/.env so CLI/web ingest + search work. We never read its Supabase creds.
+# ~/.cerefox/.env if present (convenience). We never read its Supabase creds.
 if [ -z "${OPENAI_API_KEY:-}" ] && [ -f "$HOME/.cerefox/.env" ]; then
   OPENAI_API_KEY=$(grep -E '^OPENAI_API_KEY=' "$HOME/.cerefox/.env" | head -1 | sed -E 's/^OPENAI_API_KEY=//; s/^["'\'']//; s/["'\'']$//') || true
 fi
 
-# 3. (Re)start the container with the INJECTED secret (entrypoint uses env over self-gen).
-# Refresh the image first: pulls the newest published tag so a re-run picks up updates;
-# harmless (|| true) for a locally-built tag that isn't in a registry.
+# 1. Pull + (re)start the container. It self-generates PGRST_JWT_SECRET on first boot
+#    (persisted in the volume) and mints the service_role JWT internally — no host minting.
+echo "Pulling $IMAGE …"
 docker pull "$IMAGE" 2>/dev/null || true
 docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
 # shellcheck disable=SC2086
 docker run -d --name "$CONTAINER" -p "$PORT:8000" \
   -v "$VOLUME:/var/lib/postgresql/data" \
-  -e PGRST_JWT_SECRET="$SECRET" \
   ${OPENAI_API_KEY:+-e OPENAI_API_KEY=$OPENAI_API_KEY} \
   "$IMAGE" >/dev/null
 
-# 4. Write a SEPARATE client config — cloud ~/.cerefox/.env is NEVER touched.
+# 2. Write the host config (OPENAI key + the port, for `cerefox-local upgrade`).
+#    NO JWT/URL here — those live in the container. Cloud ~/.cerefox/.env is untouched.
 umask 077
-cat > "$CONFIG_DIR/.env" <<EOF
-# Cerefox LOCAL client config — separate from ~/.cerefox/.env so cloud + local coexist.
-# Generated fresh (never copied from the cloud .env). Use it via:
-#   CEREFOX_CONFIG_DIR=$CONFIG_DIR cerefox <cmd>
-CEREFOX_SUPABASE_URL=http://localhost:$PORT
-CEREFOX_SUPABASE_KEY=$JWT
-EOF
-[ -n "${OPENAI_API_KEY:-}" ] && printf 'OPENAI_API_KEY=%s\n' "$OPENAI_API_KEY" >> "$CONFIG_DIR/.env"
+{
+  echo "# Cerefox LOCAL host config — separate from ~/.cerefox/.env (cloud)."
+  echo "# The JWT lives in the container, not here. Only OPENAI + the port are stored."
+  echo "CEREFOX_LOCAL_PORT=$PORT"
+  [ -n "${OPENAI_API_KEY:-}" ] && echo "OPENAI_API_KEY=$OPENAI_API_KEY"
+} > "$CONFIG_DIR/.env"
+
+# 3. Extract the host `cerefox-local` script from the image (single source of truth) and
+#    put it on PATH via a symlink in $BIN_DIR.
+docker cp "$CONTAINER:/opt/cerefox/cerefox-local" "$CONFIG_DIR/cerefox-local"
+chmod +x "$CONFIG_DIR/cerefox-local"
+mkdir -p "$BIN_DIR"
+ln -sf "$CONFIG_DIR/cerefox-local" "$BIN_DIR/cerefox-local"
 
 echo "✓ Cerefox Local Server starting → http://localhost:$PORT/app/"
-echo "  CLI/MCP against local:  CEREFOX_CONFIG_DIR=$CONFIG_DIR cerefox <cmd>"
-echo "  Client config: $CONFIG_DIR/.env   (your cloud ~/.cerefox/.env is untouched)"
-[ -n "${OPENAI_API_KEY:-}" ] || echo "  (no OPENAI_API_KEY in env or ~/.cerefox/.env → ingest/search disabled until set)"
+echo "  Command:  cerefox-local <verb>   (installed at $BIN_DIR/cerefox-local)"
+echo "  e.g.      cerefox-local status | search \"…\" | document ingest notes.md"
+echo "  MCP:      cerefox-local configure-agent"
+case ":$PATH:" in
+  *":$BIN_DIR:"*) ;;
+  *) echo "  ⚠ $BIN_DIR is not on your PATH — add it:";
+     echo "      echo 'export PATH=\"$BIN_DIR:\$PATH\"' >> ~/.zshrc  &&  source ~/.zshrc" ;;
+esac
+[ -n "${OPENAI_API_KEY:-}" ] || echo "  (no OPENAI_API_KEY set → ingest/search disabled; re-run with OPENAI_API_KEY=sk-...)"

--- a/docker/local/install-local.sh
+++ b/docker/local/install-local.sh
@@ -30,10 +30,12 @@ command -v docker >/dev/null 2>&1 || { echo "✗ docker not found — install Do
 
 mkdir -p "$CONFIG_DIR"; chmod 700 "$CONFIG_DIR"
 
-# Embedder key: prefer the env; else pull ONLY the OPENAI_API_KEY line from the cloud
-# ~/.cerefox/.env if present (convenience). We never read its Supabase creds.
+# Embedder key: prefer the env; else, ONLY if a cloud ~/.cerefox/.env happens to exist,
+# borrow its OPENAI_API_KEY line as a convenience (we never read its Supabase creds).
+OPENAI_FROM_CLOUD_ENV=false
 if [ -z "${OPENAI_API_KEY:-}" ] && [ -f "$HOME/.cerefox/.env" ]; then
   OPENAI_API_KEY=$(grep -E '^OPENAI_API_KEY=' "$HOME/.cerefox/.env" | head -1 | sed -E 's/^OPENAI_API_KEY=//; s/^["'\'']//; s/["'\'']$//') || true
+  [ -n "${OPENAI_API_KEY:-}" ] && OPENAI_FROM_CLOUD_ENV=true
 fi
 
 # 1. Pull + (re)start the container. It self-generates PGRST_JWT_SECRET on first boot
@@ -55,8 +57,8 @@ docker run -d --name "$CONTAINER" -p "$PORT:8000" \
 #    NO JWT/URL here — those live in the container. Cloud ~/.cerefox/.env is untouched.
 umask 077
 {
-  echo "# Cerefox LOCAL host config — separate from ~/.cerefox/.env (cloud)."
-  echo "# The JWT lives in the container, not here. Only OPENAI + the port are stored."
+  echo "# Cerefox LOCAL host config. The access token lives in the container, not here;"
+  echo "# only the OpenAI key + port are stored. Manage with: cerefox-local init"
   echo "CEREFOX_LOCAL_PORT=$PORT"
   [ -n "${OPENAI_API_KEY:-}" ] && echo "OPENAI_API_KEY=$OPENAI_API_KEY"
 } > "$CONFIG_DIR/.env"
@@ -87,4 +89,8 @@ case ":$PATH:" in
   *) echo "  ⚠ $BIN_DIR is not on your PATH — add it:";
      echo "      echo 'export PATH=\"$BIN_DIR:\$PATH\"' >> ~/.zshrc  &&  source ~/.zshrc" ;;
 esac
-[ -n "${OPENAI_API_KEY:-}" ] || echo "  (no OPENAI_API_KEY set → ingest/search disabled; re-run with OPENAI_API_KEY=sk-...)"
+if [ -n "${OPENAI_API_KEY:-}" ]; then
+  [ "$OPENAI_FROM_CLOUD_ENV" = true ] && echo "  (used the OPENAI_API_KEY found in your existing ~/.cerefox/.env)"
+else
+  echo "  ▸ Set your OpenAI key to enable ingest + search:  cerefox-local init"
+fi

--- a/docker/local/install-local.sh
+++ b/docker/local/install-local.sh
@@ -4,9 +4,14 @@
 # matching service_role JWT is written to a SEPARATE client config so the local
 # setup coexists with any cloud setup. Your cloud ~/.cerefox/.env is NEVER touched.
 #
-# Usage:
+# Usage (pulls the published ghcr image by default):
 #   sh docker/local/install-local.sh
 #   PORT=8000 OPENAI_API_KEY=sk-... sh docker/local/install-local.sh
+#
+# Default image: ghcr.io/fstamatelopoulos/cerefox-local:latest (published by the
+# release workflow on a GitHub Release). Override for local builds / pinned tags:
+#   CEREFOX_LOCAL_IMAGE=cerefox-local:dev sh ...    # after `docker build -f docker/local/Dockerfile -t cerefox-local:dev .`
+#   CEREFOX_LOCAL_IMAGE=ghcr.io/fstamatelopoulos/cerefox-local:v0.10.0 sh ...
 #
 # Then use the CLI/MCP against local by pointing at the separate config dir:
 #   CEREFOX_CONFIG_DIR=~/.cerefox/local cerefox search "…"
@@ -15,7 +20,7 @@
 # `install.sh` / `cerefox init` is deferred for review (it's the user-facing path).
 set -eu
 
-IMAGE="${CEREFOX_LOCAL_IMAGE:-cerefox-local:dev}"
+IMAGE="${CEREFOX_LOCAL_IMAGE:-ghcr.io/fstamatelopoulos/cerefox-local:latest}"
 PORT="${PORT:-8000}"
 CONFIG_DIR="${CEREFOX_LOCAL_CONFIG_DIR:-$HOME/.cerefox/local}"
 CONTAINER="${CEREFOX_LOCAL_CONTAINER:-cerefox-local}"
@@ -49,6 +54,9 @@ if [ -z "${OPENAI_API_KEY:-}" ] && [ -f "$HOME/.cerefox/.env" ]; then
 fi
 
 # 3. (Re)start the container with the INJECTED secret (entrypoint uses env over self-gen).
+# Refresh the image first: pulls the newest published tag so a re-run picks up updates;
+# harmless (|| true) for a locally-built tag that isn't in a registry.
+docker pull "$IMAGE" 2>/dev/null || true
 docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
 # shellcheck disable=SC2086
 docker run -d --name "$CONTAINER" -p "$PORT:8000" \

--- a/docker/local/install-local.sh
+++ b/docker/local/install-local.sh
@@ -41,8 +41,12 @@ fi
 echo "Pulling $IMAGE …"
 docker pull "$IMAGE" 2>/dev/null || true
 docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+# `--restart unless-stopped`: survive host reboots AND a transient first-boot PostgREST
+# crash (a known GHC-startup segfault) — Docker re-runs the container and the 2nd boot is
+# clean. It does NOT override a manual `cerefox-local stop`.
 # shellcheck disable=SC2086
 docker run -d --name "$CONTAINER" -p "$PORT:8000" \
+  --restart unless-stopped \
   -v "$VOLUME:/var/lib/postgresql/data" \
   ${OPENAI_API_KEY:+-e OPENAI_API_KEY=$OPENAI_API_KEY} \
   "$IMAGE" >/dev/null
@@ -64,7 +68,17 @@ chmod +x "$CONFIG_DIR/cerefox-local"
 mkdir -p "$BIN_DIR"
 ln -sf "$CONFIG_DIR/cerefox-local" "$BIN_DIR/cerefox-local"
 
-echo "✓ Cerefox Local Server starting → http://localhost:$PORT/app/"
+# 4. Wait for the web server to actually answer (a fresh first boot initializes Postgres
+#    + deploys the schema, and may take one restart cycle), so the URL we print is live.
+printf "Waiting for the server to come up"
+i=0
+until curl -fsS -o /dev/null "http://localhost:$PORT/api/v1/projects" 2>/dev/null; do
+  i=$((i + 1)); [ "$i" -gt 45 ] && { echo " — still starting; check 'cerefox-local logs'."; break; }
+  printf "."; sleep 2
+done
+[ "$i" -le 45 ] && echo " ready."
+
+echo "✓ Cerefox Local Server → http://localhost:$PORT/app/"
 echo "  Command:  cerefox-local <verb>   (installed at $BIN_DIR/cerefox-local)"
 echo "  e.g.      cerefox-local status | search \"…\" | document ingest notes.md"
 echo "  MCP:      cerefox-local configure-agent"

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -67,22 +67,6 @@ These are "input adapters" -- Cerefox is the backend, these tools are the author
 - [ ] **Validate Docker/local deployment** -- `Dockerfile` and `docker-compose.yml` have never been tested end-to-end. Low priority.
 - [ ] **Standalone binaries** (`cerefox`, `cerefox.exe`) per design doc §6d "Phase 2". Bundle Bun/Node runtime + JS code into a single executable per OS/arch (macOS-arm64, macOS-x86_64, Linux-x86_64, Windows-x86_64). ~70 MB per binary, ~280 MB total per release. Eliminates the Node/Bun install step for end users. **Deferred** beyond v1.0 per 2026-05-29 maintainer call (Fotis-23): the complexity (cross-compile gotchas, code-signing — $99/year Apple Developer Program for macOS, security concerns around bundling runtimes) doesn't justify the friction reduction for Cerefox's tech-savvy user base. Revisit if a real demand surfaces post-v1.0.
 
-### Local / self-hosted (World B) — polish
-Deferred from the v0.10.0 World-B build (2026-06-05); the core flow shipped without them.
-- [ ] **`cerefox-local --help` preamble vs. accept-partial** — the host script intercepts
-  lifecycle verbs the in-container commander doesn't know, so a single `--help` can't list
-  both natively. Current: the shim prints its own host-verb usage and appends the
-  container's KB `--help`. Decide whether to merge them more cleanly (e.g. inject a synthetic
-  command group) or leave the two-section help as-is.
-- [ ] **`configure-agent` first-class `--local` mode** — currently the host `cerefox-local
-  configure-agent` shells out to `claude mcp add` (or prints a snippet). Consider a proper
-  in-bin `configure-agent --local`/docker-exec mode so other clients (Cursor, Codex, Gemini)
-  get auto-wired config too, instead of manual snippets.
-- [ ] **Shell completion for `cerefox-local`** — `cerefox completion` hardcodes the root
-  binding (`complete -F _cerefox_completion cerefox`, `#compdef cerefox`), so completion is
-  cloud-only. Parameterize the binding name (read the prog name) so `cerefox-local completion`
-  emits a `cerefox-local` script.
-
 ### Backup & Sync
 - [ ] Scheduled automatic backups
 - [ ] Backup verification (compare DB state with backup)

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -67,6 +67,22 @@ These are "input adapters" -- Cerefox is the backend, these tools are the author
 - [ ] **Validate Docker/local deployment** -- `Dockerfile` and `docker-compose.yml` have never been tested end-to-end. Low priority.
 - [ ] **Standalone binaries** (`cerefox`, `cerefox.exe`) per design doc §6d "Phase 2". Bundle Bun/Node runtime + JS code into a single executable per OS/arch (macOS-arm64, macOS-x86_64, Linux-x86_64, Windows-x86_64). ~70 MB per binary, ~280 MB total per release. Eliminates the Node/Bun install step for end users. **Deferred** beyond v1.0 per 2026-05-29 maintainer call (Fotis-23): the complexity (cross-compile gotchas, code-signing — $99/year Apple Developer Program for macOS, security concerns around bundling runtimes) doesn't justify the friction reduction for Cerefox's tech-savvy user base. Revisit if a real demand surfaces post-v1.0.
 
+### Local / self-hosted (World B) — polish
+Deferred from the v0.10.0 World-B build (2026-06-05); the core flow shipped without them.
+- [ ] **`cerefox-local --help` preamble vs. accept-partial** — the host script intercepts
+  lifecycle verbs the in-container commander doesn't know, so a single `--help` can't list
+  both natively. Current: the shim prints its own host-verb usage and appends the
+  container's KB `--help`. Decide whether to merge them more cleanly (e.g. inject a synthetic
+  command group) or leave the two-section help as-is.
+- [ ] **`configure-agent` first-class `--local` mode** — currently the host `cerefox-local
+  configure-agent` shells out to `claude mcp add` (or prints a snippet). Consider a proper
+  in-bin `configure-agent --local`/docker-exec mode so other clients (Cursor, Codex, Gemini)
+  get auto-wired config too, instead of manual snippets.
+- [ ] **Shell completion for `cerefox-local`** — `cerefox completion` hardcodes the root
+  binding (`complete -F _cerefox_completion cerefox`, `#compdef cerefox`), so completion is
+  cloud-only. Parameterize the binding name (read the prog name) so `cerefox-local completion`
+  emits a `cerefox-local` script.
+
 ### Backup & Sync
 - [ ] Scheduled automatic backups
 - [ ] Backup verification (compare DB state with backup)

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -8,6 +8,11 @@ install and setup below is about 5 minutes.
 > **Upgrading from an earlier version?** See [`upgrading.md`](upgrading.md)
 > for migration steps instead.
 
+> **Want no cloud at all?** Cerefox also runs **fully local** — one Docker
+> container, no Supabase account, no Node/Bun on the host. See
+> [`setup-local.md`](setup-local.md). This quickstart covers the hosted-Supabase
+> path.
+
 ---
 
 ## Prerequisites

--- a/docs/guides/setup-local.md
+++ b/docs/guides/setup-local.md
@@ -1,184 +1,149 @@
-# Local Setup Guide
+# Local / Self-Hosted Setup (Docker)
 
-Run the Cerefox web server and database on your own machine using Docker for Postgres+pgvector. Embeddings use the OpenAI API — an `OPENAI_API_KEY` is required even for local setups.
+Run Cerefox **fully on your own machine** — no hosted Supabase, no cloud database. One
+Docker container bundles everything: Postgres + pgvector, the PostgREST Data API, and the
+Cerefox web server. You get the same web UI, CLI, and MCP server as the cloud setup.
 
-This guide is aimed at **contributors** who want a fully local stack (no hosted Supabase). End users on a hosted Supabase project should follow [`quickstart.md`](quickstart.md) instead.
+> **Embeddings still use the OpenAI API.** An `OPENAI_API_KEY` is required even for a
+> local setup (the database and web server are local; embedding generation is not). A
+> fully offline embedder is on the roadmap.
+
+## Cloud vs. Local — pick one
+
+Cerefox has two independent "worlds". Most people run **one or the other**:
+
+| | Cloud / Supabase | **Local / self-hosted (this guide)** |
+|---|---|---|
+| Install | `curl … install.sh \| sh` (npm) | `curl … install-local.sh \| sh` (Docker) |
+| Command | `cerefox` | `cerefox-local` |
+| Backend | hosted Supabase | a Docker container on your machine |
+| Host runtime | Node/Bun | **Docker only** |
+
+The two never collide — different installer, different command name — so even if you run
+both, your cloud `~/.cerefox/.env` is never touched by the local installer.
 
 ---
 
 ## Prerequisites
 
-- Docker and Docker Compose
-- **Node.js 20+** or **Bun 1.0+** (the CLI runtime)
-- An OpenAI API key (for embeddings — [platform.openai.com/api-keys](https://platform.openai.com/api-keys))
+- **Docker** (Docker Desktop, or [Colima](https://github.com/abiosoft/colima): `colima start`).
+- An **OpenAI API key** — [platform.openai.com/api-keys](https://platform.openai.com/api-keys).
 
-> The Python implementation is legacy and slated for removal in a future release; only the Python MCP server remains as a fallback. `uv` is only needed if you intend to run that fallback (`uv run cerefox mcp`).
-
----
-
-## Step 1 — Clone and install
-
-```bash
-git clone https://github.com/fstamatelopoulos/cerefox.git
-cd cerefox
-bun install
-```
+That's it. No Node, Bun, Postgres, or repo clone needed.
 
 ---
 
-## Step 2 — Start Postgres with pgvector
-
-The included `docker-compose.yml` spins up a Postgres 16 instance with the pgvector extension pre-installed:
+## Step 1 — Install
 
 ```bash
-docker compose up -d postgres
+OPENAI_API_KEY=sk-... sh -c "$(curl -fsSL https://github.com/fstamatelopoulos/cerefox/releases/latest/download/install-local.sh)"
 ```
 
-Default connection details (overridable in `.env`):
+This pulls the published multi-arch image (`amd64` + `arm64`), starts the container, and
+installs a `cerefox-local` command (symlinked into `~/.local/bin`). Pick a different port
+with `PORT=8017 …`.
 
-| Setting | Default |
-|---------|---------|
-| Host | `localhost` |
-| Port | `5432` |
-| User | `cerefox` |
-| Password | `cerefox` |
-| Database | `cerefox` |
+> If the installer warns that `~/.local/bin` isn't on your `PATH`, add it:
+> ```bash
+> echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc && source ~/.zshrc
+> ```
+
+The web UI is now at **http://localhost:8000/app/** (or your chosen port).
+
+**How the credential works:** the container generates its own JWT secret on first boot and
+mints the access token internally — the token never leaves the container. The only secret
+stored on your host is `OPENAI_API_KEY` (in `~/.cerefox/local/.env`), so `upgrade` can
+re-supply it.
 
 ---
 
-## Step 3 — Create a `.env` file
+## Step 2 — Use the CLI
+
+`cerefox-local` runs the same commands as the cloud `cerefox`, but against your local
+container:
 
 ```bash
-cp .env.example .env
+cerefox-local status                                   # is it running? what URL?
+cerefox-local document ingest my-notes.md --project-name personal
+cerefox-local search "what did I write about planning?"
+cerefox-local document list
 ```
 
-Edit `.env` for local Docker:
-
-```env
-# Local Postgres (Docker)
-CEREFOX_DATABASE_URL=postgresql://cerefox:cerefox@localhost:5432/cerefox
-
-# For local-only use, Supabase keys are not required.
-# The web UI and CLI will work without them if you skip the Supabase MCP integration.
-CEREFOX_SUPABASE_URL=
-CEREFOX_SUPABASE_KEY=
-
-# OpenAI API key for embeddings (text-embedding-3-small)
-OPENAI_API_KEY=sk-...
-```
+KB verbs (`search`, `document`, `project`, `metadata`, `audit`, `config`, `guides`, `mcp`)
+run inside the container; lifecycle verbs run on the host (next section).
 
 ---
 
-## Step 4 — Deploy the schema
+## Step 3 — Connect an AI agent (MCP)
 
 ```bash
-bun scripts/db_deploy.ts
+cerefox-local configure-agent
 ```
 
-This creates all tables, indexes, and RPC functions. Run with `--dry-run` to preview SQL without executing.
-
-To start fresh:
-
-```bash
-bun scripts/db_deploy.ts --reset   # drops all cerefox_ tables first (typed-`yes` guard)
-```
-
-> End users on a hosted Supabase project use `cerefox server deploy` instead (no clone). The `bun scripts/db_*.ts` scripts are the low-level contributor path.
+If the `claude` CLI is present this registers an MCP server named `cerefox-local` with
+Claude Code automatically. Otherwise it prints the snippet to add to your client — the MCP
+command is simply `cerefox-local mcp` (stdio), which the client launches per session. The
+client never needs a token; the container holds it.
 
 ---
 
-## Step 5 — Verify the setup
+## Managing the container
+
+All host-side, via `cerefox-local`:
 
 ```bash
-bun scripts/db_migrate.ts --status
+cerefox-local start          # start a stopped container
+cerefox-local stop           # stop it (your data persists in the Docker volume)
+cerefox-local restart
+cerefox-local logs -f        # follow the logs
+cerefox-local upgrade        # pull the latest image + recreate (keeps data + OPENAI key)
+cerefox-local uninstall          # remove the container, KEEP the data volume
+cerefox-local uninstall --purge  # remove the container AND delete the data volume
 ```
 
-You should see the schema reported as up to date with all migrations applied.
+`upgrade` is the single update path: it pulls the newest image, recreates the container,
+and refreshes the `cerefox-local` script itself. Because the CLI, web server, PostgREST,
+and database schema all ship together in one versioned image, they never drift out of
+sync.
 
 ---
 
-## Step 6 — Ingest your first document
+## Where things live
 
-```bash
-# Ingest a markdown file
-cerefox document ingest my-notes.md --project-name "personal"
-
-# Or paste content from stdin
-echo "# Quick Note\n\nThis is a quick note." | cerefox document ingest --paste --title "Quick Note"
-```
-
-Each ingest calls the OpenAI embedding API once per batch of chunks (fast, typically under a second).
-
----
-
-## Step 7 — Start the web UI
-
-```bash
-cerefox web
-```
-
-Open [http://localhost:8000](http://localhost:8000) in your browser.
-
-For development with auto-reload:
-
-```bash
-cerefox web --reload
-```
-
----
-
-## Step 8 — Search from the CLI
-
-```bash
-# Hybrid search (recommended)
-cerefox search "what did I write about project planning?"
-
-# Keyword-only search
-cerefox search "meeting notes" --mode fts
-
-# Semantic search
-cerefox search "ideas about creativity" --mode semantic
-```
-
----
-
-## Running everything at once
-
-The `docker-compose.yml` also includes a `cerefox` service that runs the web UI:
-
-```bash
-docker compose up -d
-```
-
-Web UI will be at [http://localhost:8000](http://localhost:8000).
-
----
-
-## Stopping services
-
-```bash
-docker compose down          # stop, keep data
-docker compose down -v       # stop and delete database volume
-```
-
----
-
-## Updating the schema
-
-When a new version of Cerefox introduces schema changes, run:
-
-```bash
-bun scripts/db_migrate.ts            # --status to preview, --dry-run to see SQL
-```
-
-This applies incremental migrations without losing data. Always back up first (see `ops-scripts.md`). End users on a hosted Supabase project run `cerefox server deploy` instead.
+| Thing | Location |
+|---|---|
+| Container | name `cerefox-local` (override: `CEREFOX_LOCAL_CONTAINER`) |
+| Your data | Docker volume `cerefox_local_pgdata` (survives `stop`/`upgrade`) |
+| Host config | `~/.cerefox/local/.env` (OPENAI key + port only — **no token**) |
+| Host command | `~/.cerefox/local/cerefox-local`, symlinked to `~/.local/bin/cerefox-local` |
 
 ---
 
 ## Troubleshooting
 
-**pgvector extension not found**
-Make sure you're using the `pgvector/pgvector:pg16` Docker image (included in `docker-compose.yml`). Raw Postgres images do not include pgvector.
+**`docker not found` / can't connect** — start Docker Desktop, or `colima start`.
 
-**"Supabase is not configured" error**
-The CLI and web UI show this error if `CEREFOX_SUPABASE_URL` / `CEREFOX_SUPABASE_KEY` are empty. For local Docker setups, the app uses the direct Postgres URL (`CEREFOX_DATABASE_URL`) for schema deployment but the Supabase client for queries. Set up a local Supabase instance or use the hosted free tier (see `setup-supabase.md`).
+**`cerefox-local: command not found`** — `~/.local/bin` isn't on your `PATH` (see Step 1).
+
+**`container 'cerefox-local' is not running`** — `cerefox-local start` (or `status` to
+check). After a reboot the container may be stopped depending on your Docker settings.
+
+**Ingest/search fail with no embeddings** — `OPENAI_API_KEY` wasn't set at install time.
+Re-run the installer with the key, or set it and `cerefox-local upgrade`.
+
+**Port already in use** — re-install with a free port: `PORT=8017 sh -c "$(curl -fsSL …/install-local.sh)"`.
+
+---
+
+## Contributor notes
+
+To build + test the image from a checkout (instead of pulling ghcr):
+
+```bash
+docker build -f docker/local/Dockerfile -t cerefox-local:dev .
+CEREFOX_LOCAL_IMAGE=cerefox-local:dev sh docker/local/install-local.sh
+```
+
+See [`docker/local/README.md`](../../docker/local/README.md) for the image internals
+(s6-overlay supervision, the `/rest/v1` proxy, the pinned PostgREST version) and
+`docs/research/local-cerefox-design.md` for the design of record.

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -3282,12 +3282,13 @@ Two sequencing options:
   `_shared/compatibility` + `cerefox doctor`. Test on laptop + workstation + a 4 GB NAS.
   **Acceptance:** `docker run` + volume → working local Cerefox that survives container
   recreate; CI compat suite green.
-- **P2 — distribution + installer + init:** *(status 2026-06-02: the installer is ✅
-  validated — `docker/local/install-local.sh`, Model B: per-install openssl secret →
-  inject (`-e PGRST_JWT_SECRET`) → mint `service_role` JWT → SEPARATE `~/.cerefox/local`
-  client config so cloud + local coexist (cloud `.env` untouched). CLI-against-local
-  confirmed. **Remaining: ghcr.io multi-arch publish; fold into the shared install.sh /
-  cerefox init.**)*
+- **P2 — distribution + installer + init:** *(status 2026-06-05: the first-cut
+  installer is ✅ validated — `docker/local/install-local.sh`, Model B: per-install
+  openssl secret → inject (`-e PGRST_JWT_SECRET`) → mint `service_role` JWT → SEPARATE
+  `~/.cerefox/local` client config. **SUPERSEDED by the "P2 finalized" subsection below
+  (2026-06-05): host-side JWT minting is dropped — the JWT never leaves the container —
+  and the local world gets its own `cerefox-local` host script instead of reusing the
+  npm CLI.** ghcr.io multi-arch publish is ✅ done + validated.)*
   multi-arch (`amd64`+`arm64`) build + push to
   **ghcr.io** via `release.yml` (`docker buildx`); 2-service split compose (official
   pgvector + app image) for independent app updates; **thin installer wrapper** (extend
@@ -3305,9 +3306,74 @@ Two sequencing options:
   `cerefox-mcp` handlers over HTTP) for LAN/remote agents. Deferred per "build/test
   everything else first."
 
+### P2 finalized (2026-06-05): two parallel install "worlds" — design locked
+
+**Framing (maintainer):** cloud (Supabase) and local are **mutually exclusive worlds** —
+practically nobody runs both. Don't blend them: two separate installers, two separate
+command names, so they can't collide *even if* one person runs both (e.g. local for
+opencaw/nemo/hermes, cloud for other work).
+
+- **World A — cloud/Supabase (UNCHANGED):** existing `install.sh` one-liner → npm
+  `@cerefox/memory` → `cerefox` (CLI + local web + local MCP) → talks to Supabase.
+- **World B — local/self-hosted (NEW):** a *separate* one-liner installs the all-in-one
+  container **plus a host `cerefox-local` script**. **Docker-only — no Node/Bun on the
+  host** (the image already bundles the `cerefox` binary at `/usr/local/bin/cerefox`).
+
+**Key simplification vs. the first-cut Model-B installer — the JWT never leaves the
+container.** Every JWT consumer (web server, CLI, MCP) runs *inside* the container, so:
+- db-init **self-generates** `PGRST_JWT_SECRET` on boot and mints the `service_role`
+  JWT into `/run/cerefox-runtime.env` (tmpfs). No host openssl mint, no
+  `-e PGRST_JWT_SECRET`, no JWT persisted anywhere — regenerated + re-consumed
+  in-container each boot.
+- The **only** host-side secret is `OPENAI_API_KEY`, kept in a minimal
+  `~/.cerefox/local/.env` (OPENAI-only) so `upgrade` can re-pass it on container recreate.
+
+**`cerefox-local` — one host script; handles host concerns, proxies KB verbs into the
+container** (the host-vs-in-container split):
+- **Host-handled verbs:** `start|up`, `stop|down`, `restart`, `upgrade` (pull + recreate,
+  re-pass OPENAI), `uninstall` (`rm -f`; `--purge` for the volume), `status`, `logs [-f]`,
+  and **`configure-agent`** (must write the *host's* MCP client config — the in-container
+  CLI can't reach `~/.claude.json`).
+- **Proxied (everything KB-touching):**
+  `docker exec -i <container> sh -c '. /run/cerefox-runtime.env; exec cerefox "$@"'` — so
+  `cerefox-local search/ingest/document/project/.../mcp` run the in-container binary
+  against the local server, JWT sourced at exec time. MCP stdio passes through
+  `docker exec -i`.
+
+**Program name:** the bin reads `CEREFOX_PROG_NAME` →
+`program.name(process.env.CEREFOX_PROG_NAME ?? "cerefox")`; the shim sets
+`-e CEREFOX_PROG_NAME=cerefox-local` so help/usage/completion read `cerefox-local`. **One
+binary, no fork.** Gap: host-only verbs aren't in the container's commander → the shim
+prints a short preamble for them and delegates the rest of `--help` to the container.
+Completion = deferred polish.
+
+**Installer (path-2; replaces host-mint Model B):** (1) `docker pull` + `docker run` the
+image (`-e OPENAI_API_KEY`, `-p PORT:8000`, named volume) — container self-gens the JWT;
+(2) write `~/.cerefox/local/{.env (OPENAI only), cerefox-local}` + put the script on PATH
+(symlink into `~/.local/bin`); (3) optional `cerefox-local configure-agent`; (4) ships as
+a Release asset → `curl -fsSL …/releases/latest/download/install-local.sh | sh`.
+
+**`cut_release.ts`:** upload `install-local.sh` as a Release asset (mirrors `install.sh`).
+The ghcr image build+push **already auto-fires** via `local-image.yml` on
+`release: published` (no build step belongs in the script) — just add a post-cut note
+pointing at the Actions run.
+
+**Docs:** rewrite `docs/guides/setup-local.md` around World B (one-liner + `cerefox-local`
+lifecycle + MCP wiring); pointer from `quickstart.md`; include in the **bundled** guides
+(so `cerefox guides` + the Help page show it).
+
+**Scope + validation:** all of the above is **in v0.10.0** (decision 2026-06-05).
+Validation requires cutting v0.10.0 and publishing to **both** npm + ghcr, then running
+**both** one-liners on a clean machine.
+
+**Open micro-decisions (resolve during build):** `--help` preamble vs. accept-partial
+help; whether `configure-agent` gets a first-class in-bin `--local` (docker-exec) mode or
+stays installer-written; PATH mechanism (`~/.local/bin` symlink vs. shell-rc export).
+
 ### Risks / build-time decisions
 - **Version coupling** (supabase-js ↔ pinned PostgREST) — CI compat suite is the
-  mitigation (design §6-coupling).
+  mitigation (design §6-coupling). **Note:** World B mitigates this *by construction* —
+  CLI/web/server/PostgREST/schema all ship in one versioned image, so they can't drift.
 - **Untested `docker-compose.yml`** — P0 replaces/validates it.
 - **Security** — localhost-bound by default; `PGRST_JWT_SECRET` + token (and/or reverse
   proxy) for LAN; least-privilege PostgREST DB role.
@@ -3331,10 +3397,16 @@ for npm) so re-installs always resolve the newest published version.
 
 **Two near-term tracks** (iteration numbers are planning IDs, **not** ship order;
 ship order by version: **iter-30 `v0.10.0` → iter-28 `v1.0` → iter-29 `v1.1`**):
-1. **Iteration 30 — Local / Self-Hosted Cerefox Backend (D1)**, target **v0.10.0**
-   (version/sequencing-vs-v1.0 is a maintainer decision — see the iteration above).
+1. **Iteration 30 — Local / Self-Hosted Cerefox Backend (D1)**, target **v0.10.0**.
    Design of record: [`docs/research/local-cerefox-design.md`](research/local-cerefox-design.md).
-   In progress on `feat/local-cerefox` (design + plan only so far).
+   On `feat/local-cerefox`: P0 spike, the all-in-one s6 image, the `/rest/v1` proxy, and
+   the **ghcr multi-arch publish** are ✅ done + validated. **Next (this is the remaining
+   v0.10.0 work — see "P2 finalized" above): the World-B user workflow** — the
+   `cerefox-local` host script (lifecycle + KB-proxy via `docker exec`), container
+   self-generated JWT (drop host minting), `CEREFOX_PROG_NAME` in the bin, simplified
+   `install-local.sh` as a Release asset, `cut_release.ts` asset upload, and the rewritten
+   `setup-local.md` (bundled). Then **cut v0.10.0** (publishes npm + ghcr) and test **both**
+   one-liners on a clean machine.
 2. **Iteration 28 — v1.0**, the stability commitment (strict SemVer becomes binding)
    + security audit. Trigger: ~2–3 months of v0.9 in the wild + an outside user
    installing unaided.

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -3378,17 +3378,33 @@ self-refreshing on `upgrade`), simplified `install-local.sh` (no host JWT mintin
 `--restart unless-stopped` + readiness wait), `cut_release.ts` asset upload, rewritten
 `setup-local.md` + quickstart pointer.
 
-**Pending items for THIS iteration (decided to defer, not drop):**
+**Added to v0.10.0 after the build (real gaps, not polish):**
+- [x] **`cerefox-local init`** — post-install OpenAI-key setup (the `curl | sh` installer
+  can't prompt; stdin is the piped script). Prompts or `--openai-key`/`--port`, persists to
+  `~/.cerefox/local/.env`, recreates to apply. Also key rotation / port change.
+- [x] **Gate cloud-`.env` messaging** — neutral host-config comment; only mention
+  `~/.cerefox/.env` when it exists and we borrowed its OpenAI key (a pure-local user never
+  had a Supabase install). Dropped the old "your cloud .env is untouched" line.
+- ~~Fold `install-local.sh` into `install.sh` / `cerefox init`~~ — **dropped**: contradicts
+  the two-separate-worlds framing (World B is Docker-only; there is no host `cerefox init`).
+
+**Pending → defer to v0.10.1 (polish, not blockers):**
 - [ ] `cerefox-local --help`: merge the host-verb preamble + the in-container KB `--help`
-  more cleanly (today it prints two sections). Decision pending.
+  more cleanly (today it prints two sections).
 - [ ] `configure-agent`: a first-class in-bin `--local` (docker-exec) mode so non-Claude
   clients (Cursor, Codex, Gemini) get auto-wired config, vs. today's `claude mcp add` /
   printed-snippet host path.
 - [ ] Shell completion for `cerefox-local`: `cerefox completion` hardcodes the root
   binding (`complete -F _cerefox_completion cerefox`, `#compdef cerefox`); parameterize it
-  off the prog name so `cerefox-local completion` emits a `cerefox-local` script.
-- [ ] Decide whether to fold `install-local.sh` into the shared `install.sh` / a
-  `cerefox init` local mode (deferred from the first-cut P2).
+  off the prog name.
+- [ ] Local live-test wiring: point the read/write suites at the local container (extract
+  its in-container JWT for the test) so the same suite runs against cloud **and** local.
+
+**Testing convention (local):** use the **single** default local container
+(`cerefox-local` / volume `cerefox_local_pgdata`) — the local analogue of the maintainer's
+"production" cloud install. Treat it as carefully as cloud; **do not** spin up a second
+DB; self-clean `[E2E …]`-prefixed artifacts after each run (same discipline as the cloud
+live suites).
 
 **Captured risk — transient PostgREST first-boot segfault.** PostgREST (Haskell/GHC) can
 crash with signal 11 once on a *fresh* first boot; `S6_BEHAVIOUR_IF_STAGE2_FAILS=2` makes

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -3353,10 +3353,12 @@ image (`-e OPENAI_API_KEY`, `-p PORT:8000`, named volume) — container self-gen
 (symlink into `~/.local/bin`); (3) optional `cerefox-local configure-agent`; (4) ships as
 a Release asset → `curl -fsSL …/releases/latest/download/install-local.sh | sh`.
 
-**`cut_release.ts`:** upload `install-local.sh` as a Release asset (mirrors `install.sh`).
-The ghcr image build+push **already auto-fires** via `local-image.yml` on
-`release: published` (no build step belongs in the script) — just add a post-cut note
-pointing at the Actions run.
+**`cut_release.ts`:** uploads `install-local.sh` as a Release asset (mirrors `install.sh`)
+and gates the ghcr image build+push behind **`--docker-publish`** (off by default,
+mirroring `--npm-publish`) — it dispatches `local-image.yml` (`publish_latest=true` for a
+stable version). `local-image.yml` is **dispatch-only** (no `release: published` trigger):
+a GitHub Release is a milestone; shipping npm/ghcr artifacts is a uniform opt-in. So a
+full v0.10.0 cut is `bun scripts/cut_release.ts 0.10.0 --npm-publish --docker-publish`.
 
 **Docs:** rewrite `docs/guides/setup-local.md` around World B (one-liner + `cerefox-local`
 lifecycle + MCP wiring); pointer from `quickstart.md`; include in the **bundled** guides

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -3370,6 +3370,33 @@ Validation requires cutting v0.10.0 and publishing to **both** npm + ghcr, then 
 help; whether `configure-agent` gets a first-class in-bin `--local` (docker-exec) mode or
 stays installer-written; PATH mechanism (`~/.local/bin` symlink vs. shell-rc export).
 
+**Status 2026-06-05: World-B core BUILT + validated end-to-end** (against an isolated
+test container: install → `cerefox-local` proxy KB round-trip with real embeddings → MCP
+handshake 10 tools → lifecycle verbs). Commits on `feat/local-cerefox`. Shipped:
+`CEREFOX_PROG_NAME`, the `cerefox-local` host script (bundled + `docker cp`'d out,
+self-refreshing on `upgrade`), simplified `install-local.sh` (no host JWT minting;
+`--restart unless-stopped` + readiness wait), `cut_release.ts` asset upload, rewritten
+`setup-local.md` + quickstart pointer.
+
+**Pending items for THIS iteration (decided to defer, not drop):**
+- [ ] `cerefox-local --help`: merge the host-verb preamble + the in-container KB `--help`
+  more cleanly (today it prints two sections). Decision pending.
+- [ ] `configure-agent`: a first-class in-bin `--local` (docker-exec) mode so non-Claude
+  clients (Cursor, Codex, Gemini) get auto-wired config, vs. today's `claude mcp add` /
+  printed-snippet host path.
+- [ ] Shell completion for `cerefox-local`: `cerefox completion` hardcodes the root
+  binding (`complete -F _cerefox_completion cerefox`, `#compdef cerefox`); parameterize it
+  off the prog name so `cerefox-local completion` emits a `cerefox-local` script.
+- [ ] Decide whether to fold `install-local.sh` into the shared `install.sh` / a
+  `cerefox init` local mode (deferred from the first-cut P2).
+
+**Captured risk — transient PostgREST first-boot segfault.** PostgREST (Haskell/GHC) can
+crash with signal 11 once on a *fresh* first boot; `S6_BEHAVIOUR_IF_STAGE2_FAILS=2` makes
+that fatal to the container. Mitigated by `--restart unless-stopped` (Docker re-runs it;
+the 2nd boot is clean) — intermittent, not deterministic, in local testing. If it proves
+more frequent, revisit: a postgrest run-script retry/backoff or `S6_…FAILS=1` (warn +
+in-place supervise-restart) instead of relying on the Docker restart cycle.
+
 ### Risks / build-time decisions
 - **Version coupling** (supabase-js ↔ pinned PostgREST) — CI compat suite is the
   mitigation (design §6-coupling). **Note:** World B mitigates this *by construction* —

--- a/packages/memory/src/cli/program.ts
+++ b/packages/memory/src/cli/program.ts
@@ -117,9 +117,13 @@ function registerRenameHusks(program: Command): void {
  * programs).
  */
 export function buildProgram(): Command {
-  const program = new Command("cerefox")
+  // Program name is overridable so the local (Docker) flavor can present itself
+  // as `cerefox-local` in help/usage/completion while reusing this one binary.
+  // The `cerefox-local` host script sets CEREFOX_PROG_NAME via `docker exec -e`.
+  const progName = process.env.CEREFOX_PROG_NAME || "cerefox";
+  const program = new Command(progName)
     .description("Cerefox — user-owned shared memory for AI agents.")
-    .version(PKG_VERSION, "-v, --version", "Print the cerefox version and exit.")
+    .version(PKG_VERSION, "-v, --version", `Print the ${progName} version and exit.`)
     .addOption(
       new Option(
         "--json",
@@ -127,11 +131,11 @@ export function buildProgram(): Command {
           "Available on read commands; ignored on commands without a JSON shape.",
       ).hideHelp(),
     )
-    .showHelpAfterError("(run `cerefox --help` for usage)")
+    .showHelpAfterError(`(run \`${progName} --help\` for usage)`)
     .enablePositionalOptions()
     .addHelpText(
       "after",
-      "\nResource groups (run `cerefox <group> --help`):\n" +
+      `\nResource groups (run \`${progName} <group> --help\`):\n` +
         "  document   get · list · edit · delete · restore · ingest · ingest-dir · version {list·archive·unarchive}\n" +
         "  project    list · create · edit · delete\n" +
         "  metadata   keys · search\n" +
@@ -150,8 +154,8 @@ export function buildProgram(): Command {
         "  0  success            2  system error (unreachable Supabase, RPC failure, …)\n" +
         "  1  user error         3  not found (document / version / project)\n" +
         "\nLearn more:\n" +
-        "  cerefox docs --list                     # bundled docs (offline)\n" +
-        "  cerefox doctor                          # diagnose your install\n" +
+        `  ${progName} guides list                  # bundled docs (offline)\n` +
+        `  ${progName} doctor                       # diagnose your install\n` +
         "  https://github.com/fstamatelopoulos/cerefox\n",
     );
 

--- a/scripts/cut_release.ts
+++ b/scripts/cut_release.ts
@@ -746,6 +746,22 @@ async function main(): Promise<void> {
     }
   }
 
+  // Attach install-local.sh too (the LOCAL/self-hosted world's one-liner), so its
+  // `latest/download/install-local.sh` URL stays current. The local Docker image
+  // itself is built + pushed to ghcr by `.github/workflows/local-image.yml`, which
+  // fires automatically on this published Release — NOT here.
+  const installLocalSh = join(REPO_ROOT, "docker", "local", "install-local.sh");
+  if (existsSync(installLocalSh)) {
+    info("Attaching install-local.sh to the GitHub Release…");
+    const upLocal = run("gh", ["release", "upload", tag, installLocalSh, "--clobber"]);
+    if (upLocal.status === 0) {
+      ok("install-local.sh uploaded to the release.");
+    } else {
+      warn(`Could not upload install-local.sh: ${upLocal.stderr.trim() || "unknown error"}. Upload manually with: gh release upload ${tag} docker/local/install-local.sh`);
+    }
+  }
+  info("Note: the ghcr local image publishes via the 'Publish local image' workflow on this Release — track it under Actions.");
+
   if (args.npmPublish) {
     info("Triggering release.yml workflow with publish_to_npm=true…");
     // `gh workflow run` queues the workflow; we don't block on its completion

--- a/scripts/cut_release.ts
+++ b/scripts/cut_release.ts
@@ -447,6 +447,7 @@ interface Args {
   check: boolean;
   yes: boolean;
   npmPublish: boolean;
+  dockerPublish: boolean;
 }
 
 function parseArgs(argv: string[]): Args {
@@ -456,18 +457,21 @@ function parseArgs(argv: string[]): Args {
     check: false,
     yes: false,
     npmPublish: false,
+    dockerPublish: false,
   };
   for (const a of argv) {
     if (a === "--dry-run") out.dryRun = true;
     else if (a === "--check") out.check = true;
     else if (a === "--yes" || a === "-y") out.yes = true;
     else if (a === "--npm-publish") out.npmPublish = true;
+    else if (a === "--docker-publish") out.dockerPublish = true;
     else if (a === "--help" || a === "-h") {
       console.log(
         [
           "Usage:",
           "  bun scripts/cut_release.ts <version>                       cut tag + GitHub Release",
           "  bun scripts/cut_release.ts <version> --npm-publish         + trigger npm publish workflow",
+          "  bun scripts/cut_release.ts <version> --docker-publish      + trigger ghcr image publish workflow",
           "  bun scripts/cut_release.ts <version> --dry-run             show actions only",
           "  bun scripts/cut_release.ts --check                         report current version",
           "",
@@ -478,6 +482,10 @@ function parseArgs(argv: string[]): Args {
           "                   workflow with publish_to_npm=true so it ships to npm.",
           "                   Default off — cut a tag without immediately publishing",
           "                   (lets you spot a problem in the staging window).",
+          "  --docker-publish After the tag + GitHub Release, trigger local-image.yml to",
+          "                   build + push the all-in-one image to ghcr.io (+ :latest for a",
+          "                   stable, non-prerelease version). Default off — same policy as",
+          "                   --npm-publish: a Release is a milestone, shipping is opt-in.",
           "  --check          Report the current VERSION; suggest the next obvious bump.",
         ].join("\n"),
       );
@@ -603,11 +611,17 @@ async function main(): Promise<void> {
   // tag that tripped the `checkTagDoesNotExist` preflight on the next run.)
   if (!args.dryRun && !args.yes) {
     console.log("");
-    info(
-      `About to cut ${tag}: bump VERSION/CHANGELOG/package.json + version literals, ` +
-        `commit, create an annotated tag, push to origin, and create a GitHub Release` +
-        (args.npmPublish ? ", then trigger the npm-publish workflow." : "."),
-    );
+    {
+      const extras = [
+        args.npmPublish ? "the npm-publish workflow" : null,
+        args.dockerPublish ? "the ghcr image-publish workflow" : null,
+      ].filter(Boolean);
+      info(
+        `About to cut ${tag}: bump VERSION/CHANGELOG/package.json + version literals, ` +
+          `commit, create an annotated tag, push to origin, and create a GitHub Release` +
+          (extras.length ? `, then trigger ${extras.join(" + ")}.` : "."),
+      );
+    }
     info(
       `Note: release tags are immutable here. Once this tag is pushed it never ` +
         `moves — any later fix ships as a NEW patch version, not a re-tag. ` +
@@ -699,6 +713,13 @@ async function main(): Promise<void> {
     info(`DRY-RUN: would 'git push origin main'`);
     info(`DRY-RUN: would 'git push origin ${tag}'`);
     info(`DRY-RUN: would 'gh release create ${tag} --title ${tag} --notes-file <release-notes>'`);
+    info(`DRY-RUN: would upload install.sh + docker/local/install-local.sh as Release assets`);
+    if (args.dockerPublish) {
+      const publishLatest = !newVersion.includes("-");
+      info(`DRY-RUN: would 'gh workflow run local-image.yml -f tag=${tag} -f publish_latest=${publishLatest}'`);
+    } else {
+      info("DRY-RUN: --docker-publish not set; no ghcr image would be published.");
+    }
     if (args.npmPublish) {
       info(`DRY-RUN: would 'gh workflow run release.yml -f tag=${tag} -f publish_to_npm=true'`);
     } else {
@@ -747,9 +768,9 @@ async function main(): Promise<void> {
   }
 
   // Attach install-local.sh too (the LOCAL/self-hosted world's one-liner), so its
-  // `latest/download/install-local.sh` URL stays current. The local Docker image
-  // itself is built + pushed to ghcr by `.github/workflows/local-image.yml`, which
-  // fires automatically on this published Release — NOT here.
+  // `latest/download/install-local.sh` URL stays current. The Docker image itself is
+  // published separately + opt-in via `--docker-publish` (handled below) — NOT on the
+  // Release event.
   const installLocalSh = join(REPO_ROOT, "docker", "local", "install-local.sh");
   if (existsSync(installLocalSh)) {
     info("Attaching install-local.sh to the GitHub Release…");
@@ -760,7 +781,31 @@ async function main(): Promise<void> {
       warn(`Could not upload install-local.sh: ${upLocal.stderr.trim() || "unknown error"}. Upload manually with: gh release upload ${tag} docker/local/install-local.sh`);
     }
   }
-  info("Note: the ghcr local image publishes via the 'Publish local image' workflow on this Release — track it under Actions.");
+
+  // Docker (ghcr) publish — opt-in via --docker-publish, mirroring --npm-publish. The
+  // local-image.yml workflow no longer fires on `release: published`. Tag :latest only
+  // for a stable (non-prerelease) version.
+  if (args.dockerPublish) {
+    const publishLatest = !newVersion.includes("-");
+    info(`Triggering local-image.yml to publish the ghcr image (publish_latest=${publishLatest})…`);
+    runOrDie("gh", [
+      "workflow",
+      "run",
+      "local-image.yml",
+      "-f",
+      `tag=${tag}`,
+      "-f",
+      `publish_latest=${publishLatest}`,
+    ]);
+    ok(`Workflow triggered. Watch at: gh run list --workflow=local-image.yml`);
+  } else {
+    info(
+      "--docker-publish not set; no ghcr image published.\n" +
+        "  When ready: gh workflow run local-image.yml -f tag=" +
+        tag +
+        " -f publish_latest=true",
+    );
+  }
 
   if (args.npmPublish) {
     info("Triggering release.yml workflow with publish_to_npm=true…");


### PR DESCRIPTION
## Summary

Ships the **local / self-hosted** Cerefox backend (Iteration 30, "World B") for
**v0.10.0**: one Docker container (Postgres+pgvector + PostgREST + cerefox-server,
s6-supervised) plus a host `cerefox-local` command. Docker-only — no Node/Bun on the
host. Cloud/Supabase ("World A") is unchanged; the two are separate installers + command
names by design.

### User workflow
- **One-liner installer** (`docker/local/install-local.sh`, a Release asset): pulls the
  ghcr image, runs it with `--restart unless-stopped`, installs `cerefox-local` on PATH.
- **`cerefox-local`**: host lifecycle (`init`, `start`/`stop`/`restart`, `upgrade`,
  `uninstall [--purge]`, `status`, `logs`, `configure-agent`) + proxies KB verbs into the
  container via `docker exec` (MCP stdio passes through; token sourced in-container).
- **`cerefox-local init`**: post-install OpenAI-key setup / rotation / port change.
- Container **self-generates its JWT**; the token **never leaves the container**. Only
  host-side secret is `OPENAI_API_KEY` (`~/.cerefox/local/.env`).
- `CEREFOX_PROG_NAME` lets the one bundled binary present as `cerefox-local` (no fork).
- `--restart unless-stopped` survives reboots + a transient first-boot PostgREST segfault.

### Release wiring (both publishes are now opt-in, symmetric)
- `cut_release.ts` uploads `install-local.sh` as a Release asset.
- **npm**: `--npm-publish` → dispatches `release.yml`.
- **ghcr image**: `--docker-publish` → dispatches `local-image.yml` (`publish_latest=true`
  for a stable version). `local-image.yml` is now **dispatch-only** (dropped the
  `release: published` trigger) — a Release is a milestone; shipping artifacts is explicit.
- No `src/cerefox/db` / EF changes → no schema bump, no compat-matrix change.

### Docs
- README: cloud vs local as two first-class backend options; trimmed "Project status".
- `setup-local.md` rewritten for World B; quickstart pointer; bundled (shows in Help).

## Validation (end-to-end)
- [x] Install → `cerefox-local` KB round-trip (project/ingest/search, real embeddings)
- [x] MCP handshake over `docker exec` (10 tools)
- [x] Lifecycle + `init` migration of an old install (data + port preserved)
- [x] `cut_release.ts --dry-run` wiring (both flags dispatch; neither without)
- [x] `_shared` (177) + CLI/stdio smoke green

## Test plan (maintainer, post-merge)
- [ ] `bun scripts/cut_release.ts 0.10.0 --npm-publish --docker-publish`
- [ ] Confirm npm `@cerefox/memory@0.10.0` + ghcr `:v0.10.0`/`:latest` published (package Public)
- [ ] Clean local install on Apple-Silicon + Intel MacBooks (v0.10.1, polished)
- [ ] Cloud install still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)