### PR TITLE
v0.10.1: restore migrated-away .env overrides + local backend polish

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,6 +79,7 @@ CEREFOX_MIN_CHUNK_CHARS=100
 # ── Retrieval ────────────────────────────────────────────────────────────────
 CEREFOX_MAX_RESPONSE_BYTES=200000
 # Minimum cosine similarity for hybrid/semantic results (0.0–1.0). Not applied to FTS.
+# Single default used by the CLI (`--min-score`), MCP tools, and the web API.
 # For OpenAI text-embedding-3-small: genuine matches start ~0.45.
 # 0.50 = good default | 0.40 = wider recall | 0.70 = high precision
 CEREFOX_MIN_SEARCH_SCORE=0.50

--- a/.env.example
+++ b/.env.example
@@ -57,20 +57,22 @@ CEREFOX_SUPABASE_KEY=sb_secret_...your-supabase-secret-key...
 CEREFOX_DATABASE_URL=postgresql://postgres.your-project-ref:your-db-password@aws-N-region.pooler.supabase.com:5432/postgres?sslmode=require
 
 # ── Embeddings ────────────────────────────────────────────────────────────────
-# Embedder provider: "openai" (default) or "fireworks"
-CEREFOX_EMBEDDER=openai
-
-# OpenAI embeddings (default, recommended)
+# OpenAI embeddings (the only embedder implemented in the TS runtime today).
 # Get your key at https://platform.openai.com/api-keys
 OPENAI_API_KEY=sk-...your-openai-key...
-# CEREFOX_OPENAI_BASE_URL=https://api.openai.com/v1  # override for proxies
+# CEREFOX_OPENAI_BASE_URL=https://api.openai.com/v1   # safe to override (proxy/gateway)
+#
+# ⚠ Changing the MODEL or DIMENSIONS is a BREAKING change: query vectors must match the
+#   stored vectors and the DB column is vector(768). After changing either you MUST
+#   re-embed everything (`cerefox server reindex`); a non-768 model also needs a schema
+#   change. Leave these unless you know you're re-indexing.
 # CEREFOX_OPENAI_EMBEDDING_MODEL=text-embedding-3-small
-# CEREFOX_OPENAI_EMBEDDING_DIMENSIONS=768  # must match DB schema
+# CEREFOX_OPENAI_EMBEDDING_DIMENSIONS=768
 
-# Fireworks AI embeddings (alternative, lower cost)
-# CEREFOX_EMBEDDER=fireworks
+# Fireworks AI: documented for the Python runtime but NOT yet implemented in the TS
+# runtime — CEREFOX_EMBEDDER / CEREFOX_FIREWORKS_* are currently no-ops. (Tracked for
+# a future release.)
 # CEREFOX_FIREWORKS_API_KEY=fw_...your-fireworks-key...
-# CEREFOX_FIREWORKS_EMBEDDING_MODEL=nomic-ai/nomic-embed-text-v1.5
 
 # ── Chunking ─────────────────────────────────────────────────────────────────
 CEREFOX_MAX_CHUNK_CHARS=4000
@@ -85,12 +87,15 @@ CEREFOX_MAX_RESPONSE_BYTES=200000
 CEREFOX_MIN_SEARCH_SCORE=0.50
 
 # ── Storage ──────────────────────────────────────────────────────────────────
-CEREFOX_BACKUP_DIR=./backups
+# Default output dir for `cerefox backup` (override with -o). Default: ~/.cerefox/backups
+# CEREFOX_BACKUP_DIR=~/.cerefox/backups
 
 # ── Versioning ────────────────────────────────────────────────────────────────
 # How long to retain archived document versions (hours). The most recent version
 # is always kept regardless of this setting (accidental-deletion protection).
 # CEREFOX_VERSION_RETENTION_HOURS=48
+# Set to false to disable the retention sweep entirely (keep all archived versions).
+# CEREFOX_VERSION_CLEANUP_ENABLED=true
 
 # ── CLI caller identity (defaults for cerefox ingest / search / etc.) ────────
 # These set the default value for the CLI's --author / --author-type / --requestor
@@ -107,5 +112,9 @@ CEREFOX_BACKUP_DIR=./backups
 # CEREFOX_AUTHOR_TYPE=user           # or "agent" for AI clients
 # CEREFOX_REQUESTOR_NAME=your-name-or-agent-name
 
-# ── Logging ──────────────────────────────────────────────────────────────────
-CEREFOX_LOG_LEVEL=INFO
+# ── Local / self-hosted (World B) ─────────────────────────────────────────────
+# For the Docker backend (`install-local.sh` / `cerefox-local`), DON'T set the Supabase
+# or database vars above — the container generates + owns them. Put OPENAI_API_KEY and
+# any of the CEREFOX_* TUNING overrides above (min-search-score, chunking, version
+# retention, embedding model/base-url, author identity) into ~/.cerefox/local/.env; they
+# are forwarded into the container. Apply changes with `cerefox-local init`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,39 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
-Open roadmap.
+### Fixed — `.env` overrides dropped in the Python→TS migration
+
+Several documented `CEREFOX_*` options were silently no-ops in the TS runtime. Each now
+has a single default honored consistently by the CLI, MCP, and web — and forwarded into
+the local/World-B container:
+
+- **`CEREFOX_MIN_SEARCH_SCORE`** (default `0.5`). The web API previously passed `0.0`, so
+  the web UI surfaced irrelevant low-similarity results; it now matches CLI/MCP.
+- **`CEREFOX_MAX_RESPONSE_BYTES`** (MCP/Edge-Function ceiling; web + CLI stay unlimited).
+- **`CEREFOX_MAX_CHUNK_CHARS` / `CEREFOX_MIN_CHUNK_CHARS` / `CEREFOX_VERSION_RETENTION_HOURS`
+  / `CEREFOX_VERSION_CLEANUP_ENABLED`** (ingestion).
+- **`CEREFOX_BACKUP_DIR`** (`cerefox backup` default).
+- **OpenAI embedding overrides** `CEREFOX_OPENAI_BASE_URL` / `_EMBEDDING_MODEL` /
+  `_EMBEDDING_DIMENSIONS`. ⚠ changing model/dimensions is breaking — requires
+  `cerefox server reindex` (DB column is `vector(768)`); documented loudly.
+- A `bun test` guard now fails if any `.env.example` var isn't referenced in the TS source
+  (cheap regression guard against future migration drift). `.env.example` cleaned up:
+  removed the no-op `CEREFOX_LOG_LEVEL`; marked Fireworks as not-yet-implemented in TS.
+
+### Changed — local backend (World B) polish
+
+- `install-local.sh` **auto-selects a free host port** (steps `+10` past a busy port, and
+  past `8000` when a cloud install shares that default) instead of silently colliding.
+- Detect-and-guide when Docker is missing or its daemon is stopped (no auto-install).
+- World-B users can put the `CEREFOX_*` tuning overrides above in `~/.cerefox/local/.env`;
+  they're forwarded into the container (apply with `cerefox-local init`).
+
+### Docs
+
+- README presents cloud vs local as two backend options; trimmed "Project status".
+- Fixed stale items: `.docx` ingest **is** supported (mammoth; only PDF dropped); CLI old
+  flat verbs are husks (not "removed"); `--mode hybrid` (not `semantic`); quickstart
+  timing + `setup-local.md` mis-links; "Python CLI/web" framing.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Cerefox is **asynchronous shared memory, not a message bus**. It solves the pers
 | **Remote MCP endpoint** | `cerefox-mcp` Supabase Edge Function — MCP Streamable HTTP; connect Claude Desktop, Claude Code, or Cursor with just a URL and anon key; no Python install needed |
 | **Local MCP server** | `cerefox mcp` stdio server (TypeScript, from `@cerefox/memory`) -- local alternative with zero Edge Function usage, lower latency, and offline support; `npm install -g @cerefox/memory`. (A frozen Python MCP server also ships for repo-clone users: `uv run cerefox mcp`.) |
 | **Web UI** | React + TypeScript SPA (Mantine UI) at `/app/`; Hono (TypeScript) JSON API backend served by `cerefox web`; Markdown viewer, search with 4 modes, document editing, project management |
-| **Markdown-first ingest** | `.md` / `.txt` (Markdown is the storage format; PDF/DOCX conversion was dropped in v0.7 — convert upstream) |
+| **Markdown-first ingest** | `.md` / `.txt` / `.docx` (Markdown is the storage format; `.docx` is converted via `mammoth` on ingest, fidelity varies. PDF is not supported — convert upstream) |
 | **Batch ingest** | `cerefox document ingest-dir` recurses directories |
 | **Deduplication** | SHA-256 content hash; re-ingesting the same file is a no-op |
 | **Backup and restore** | JSON snapshots, optional git commit |

--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ Cerefox is **asynchronous shared memory, not a message bus**. It solves the pers
 
 ## Project status
 
-Cerefox is a single-maintainer open-source project. As of **v0.10.0** it runs
-two ways: against a hosted **Supabase** project, or **fully local / self-hosted**
-in a single Docker container (no cloud, no account). The whole runtime — CLI,
-MCP server, web UI, ingestion, and server-side deploy — ships in the
+As of **v0.10.0** Cerefox runs two ways: against a hosted **Supabase** project,
+or **fully local / self-hosted** in a single Docker container (no cloud, no
+account). The whole runtime — CLI, MCP server, web UI, ingestion, and
+server-side deploy — ships in the
 [`@cerefox/memory`](https://www.npmjs.com/package/@cerefox/memory) npm package
-(no Python, no repo clone); the local backend bundles that same runtime plus
-Postgres + pgvector into one image.
+(no repo clone); the local backend bundles that same runtime plus Postgres +
+pgvector into one image.
 
 Until **v1.0.0** the SemVer policy in [`CONTRIBUTING.md`](CONTRIBUTING.md) is
 aspirational — breaking changes can land in minor versions when there's a good

--- a/_shared/__tests__/config-overrides.test.ts
+++ b/_shared/__tests__/config-overrides.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for the `.env` config overrides restored after the Python→TS migration,
+ * plus a guard against future "phantom config" drift: every CEREFOX_/OPENAI_ var
+ * documented in `.env.example` must actually be read somewhere in the TS source.
+ * This is the cheap, non-brittle way to catch migration gaps (vs. diffing the old
+ * Python against the current TS).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { getMaxResponseBytes, getMinSearchScore } from "../mcp-tools/_utils.ts";
+import { openaiEmbeddingConfig } from "../embeddings/index.ts";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..");
+const TOUCHED = [
+  "CEREFOX_MIN_SEARCH_SCORE",
+  "CEREFOX_MAX_RESPONSE_BYTES",
+  "CEREFOX_OPENAI_BASE_URL",
+  "CEREFOX_OPENAI_EMBEDDING_MODEL",
+  "CEREFOX_OPENAI_EMBEDDING_DIMENSIONS",
+];
+
+function clear() {
+  for (const k of TOUCHED) delete process.env[k];
+}
+beforeEach(clear);
+afterEach(clear);
+
+describe("getMinSearchScore", () => {
+  it("defaults to 0.5", () => expect(getMinSearchScore()).toBe(0.5));
+  it("honors a valid override", () => {
+    process.env.CEREFOX_MIN_SEARCH_SCORE = "0.7";
+    expect(getMinSearchScore()).toBe(0.7);
+  });
+  it("falls back to 0.5 on out-of-range or non-numeric values", () => {
+    process.env.CEREFOX_MIN_SEARCH_SCORE = "2";
+    expect(getMinSearchScore()).toBe(0.5);
+    process.env.CEREFOX_MIN_SEARCH_SCORE = "-1";
+    expect(getMinSearchScore()).toBe(0.5);
+    process.env.CEREFOX_MIN_SEARCH_SCORE = "bogus";
+    expect(getMinSearchScore()).toBe(0.5);
+  });
+});
+
+describe("getMaxResponseBytes", () => {
+  it("defaults to 200000", () => expect(getMaxResponseBytes()).toBe(200_000));
+  it("honors a valid override", () => {
+    process.env.CEREFOX_MAX_RESPONSE_BYTES = "50000";
+    expect(getMaxResponseBytes()).toBe(50_000);
+  });
+  it("falls back on non-positive or non-numeric values", () => {
+    process.env.CEREFOX_MAX_RESPONSE_BYTES = "0";
+    expect(getMaxResponseBytes()).toBe(200_000);
+    process.env.CEREFOX_MAX_RESPONSE_BYTES = "x";
+    expect(getMaxResponseBytes()).toBe(200_000);
+  });
+});
+
+describe("openaiEmbeddingConfig", () => {
+  it("defaults to the built-in OpenAI model/url/dims", () => {
+    const c = openaiEmbeddingConfig();
+    expect(c.url).toBe("https://api.openai.com/v1/embeddings");
+    expect(c.model).toBe("text-embedding-3-small");
+    expect(c.dimensions).toBe(768);
+  });
+  it("honors base-url + model overrides; strips a trailing slash", () => {
+    process.env.CEREFOX_OPENAI_BASE_URL = "https://proxy.example/v1/";
+    process.env.CEREFOX_OPENAI_EMBEDDING_MODEL = "text-embedding-3-large";
+    const c = openaiEmbeddingConfig();
+    expect(c.url).toBe("https://proxy.example/v1/embeddings");
+    expect(c.model).toBe("text-embedding-3-large");
+  });
+  it("falls back to 768 dims on a bad value", () => {
+    process.env.CEREFOX_OPENAI_EMBEDDING_DIMENSIONS = "0";
+    expect(openaiEmbeddingConfig().dimensions).toBe(768);
+  });
+});
+
+describe("no phantom config (every documented var is read by the TS code)", () => {
+  // Vars documented in .env.example but deliberately not wired in the TS runtime yet.
+  const ALLOW_UNWIRED = new Set<string>([
+    "CEREFOX_EMBEDDER", // OpenAI-only in TS; provider selection not implemented
+    "CEREFOX_FIREWORKS_EMBEDDING_MODEL", // Fireworks embedder not implemented in TS
+  ]);
+
+  const example = readFileSync(join(REPO_ROOT, ".env.example"), "utf8");
+  const vars = [
+    ...new Set(
+      [...example.matchAll(/^#?\s*(CEREFOX_[A-Z_]+|OPENAI_[A-Z_]+)=/gm)].map((m) => m[1]),
+    ),
+  ];
+
+  it("finds at least a dozen documented vars (sanity)", () => {
+    expect(vars.length).toBeGreaterThan(12);
+  });
+
+  for (const v of vars) {
+    if (ALLOW_UNWIRED.has(v)) continue;
+    it(`${v} is referenced in the TS source`, () => {
+      let found = false;
+      try {
+        execSync(`grep -rqE "${v}" _shared packages/memory/src supabase`, { cwd: REPO_ROOT });
+        found = true;
+      } catch {
+        found = false;
+      }
+      expect(found).toBe(true);
+    });
+  }
+});

--- a/_shared/embeddings/index.ts
+++ b/_shared/embeddings/index.ts
@@ -17,25 +17,52 @@ export const OPENAI_EMBEDDING_URL = "https://api.openai.com/v1/embeddings";
 export const OPENAI_MODEL = "text-embedding-3-small";
 export const EMBEDDING_DIMENSIONS = 768;
 
+/**
+ * Resolve the OpenAI embedding endpoint/model/dimensions, applying `.env`
+ * overrides over the built-in defaults. These were configurable in the Python
+ * runtime; the TS migration hardcoded them.
+ *
+ * ⚠ Overriding the MODEL or DIMENSIONS is a BREAKING change: query vectors must
+ * match the stored vectors and the DB column is `vector(768)`. Changing either
+ * requires re-embedding the whole corpus (`cerefox server reindex`) and, for a
+ * non-768 model, a schema change. `CEREFOX_OPENAI_BASE_URL` (proxy/gateway) is
+ * the only safe one to flip on an existing KB.
+ *
+ * Runtime-agnostic env read; the Deno Edge Function (no host env) keeps the
+ * constants — matching the EF's "model config is a constant" design.
+ */
+export function openaiEmbeddingConfig(): { url: string; model: string; dimensions: number } {
+  const env =
+    (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env ?? {};
+  const base = env.CEREFOX_OPENAI_BASE_URL?.replace(/\/+$/, "");
+  const dims = Number.parseInt(env.CEREFOX_OPENAI_EMBEDDING_DIMENSIONS ?? "", 10);
+  return {
+    url: base ? `${base}/embeddings` : OPENAI_EMBEDDING_URL,
+    model: env.CEREFOX_OPENAI_EMBEDDING_MODEL || OPENAI_MODEL,
+    dimensions: Number.isNaN(dims) || dims <= 0 ? EMBEDDING_DIMENSIONS : dims,
+  };
+}
+
 const EMBEDDING_MAX_RETRIES = 3;
 const EMBEDDING_INITIAL_BACKOFF_MS = 500; // 500ms → 1s → 2s
 
 /** Embed a single string. Used for the query vector in `cerefox_search`. */
 export async function getEmbedding(text: string, apiKey: string): Promise<number[]> {
   let lastError: Error | null = null;
+  const cfg = openaiEmbeddingConfig();
 
   for (let attempt = 0; attempt < EMBEDDING_MAX_RETRIES; attempt++) {
     try {
-      const response = await fetch(OPENAI_EMBEDDING_URL, {
+      const response = await fetch(cfg.url, {
         method: "POST",
         headers: {
           "Authorization": `Bearer ${apiKey}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          model: OPENAI_MODEL,
+          model: cfg.model,
           input: text,
-          dimensions: EMBEDDING_DIMENSIONS,
+          dimensions: cfg.dimensions,
         }),
       });
 
@@ -93,19 +120,20 @@ async function embedBatchSingleCall(
   apiKey: string,
 ): Promise<number[][]> {
   let lastError: Error | null = null;
+  const cfg = openaiEmbeddingConfig();
 
   for (let attempt = 0; attempt < EMBEDDING_MAX_RETRIES; attempt++) {
     try {
-      const response = await fetch(OPENAI_EMBEDDING_URL, {
+      const response = await fetch(cfg.url, {
         method: "POST",
         headers: {
           "Authorization": `Bearer ${apiKey}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          model: OPENAI_MODEL,
+          model: cfg.model,
           input: texts,
-          dimensions: EMBEDDING_DIMENSIONS,
+          dimensions: cfg.dimensions,
         }),
       });
 

--- a/_shared/mcp-tools/_utils.ts
+++ b/_shared/mcp-tools/_utils.ts
@@ -18,6 +18,28 @@ import type { MCPSupabaseClient } from "./types.ts";
  *  smaller budgets via `max_bytes`; values above this are capped. */
 export const MAX_RESPONSE_BYTES = 200_000;
 
+/** Built-in default cosine-similarity floor for hybrid/semantic search. */
+export const DEFAULT_MIN_SEARCH_SCORE = 0.5;
+
+/**
+ * Resolve the minimum cosine-similarity floor for hybrid/semantic search
+ * (vector-only matches below this are dropped; FTS matches always pass).
+ * Overridable via the `CEREFOX_MIN_SEARCH_SCORE` env var (0.0–1.0). The Python
+ * runtime read this; the TS migration dropped it — restored here as the single
+ * default used by the CLI, local/remote MCP, and the web API.
+ *
+ * Runtime-agnostic env read: works in Node/Bun; in the Deno Edge Function
+ * `process` may be absent, so it falls back to the built-in default (the cloud
+ * EF path doesn't use the host `.env` anyway).
+ */
+export function getMinSearchScore(): number {
+  const raw = (globalThis as { process?: { env?: Record<string, string | undefined> } })
+    .process?.env?.CEREFOX_MIN_SEARCH_SCORE;
+  if (raw === undefined || raw === "") return DEFAULT_MIN_SEARCH_SCORE;
+  const n = Number.parseFloat(raw);
+  return Number.isNaN(n) || n < 0 || n > 1 ? DEFAULT_MIN_SEARCH_SCORE : n;
+}
+
 export function applyByteBudget(
   rows: unknown[],
   maxBytes: number,

--- a/_shared/mcp-tools/_utils.ts
+++ b/_shared/mcp-tools/_utils.ts
@@ -14,9 +14,23 @@
 
 import type { MCPSupabaseClient } from "./types.ts";
 
-/** Server-enforced response-size ceiling for MCP results. Agents can request
- *  smaller budgets via `max_bytes`; values above this are capped. */
+/** Built-in default response-size ceiling for MCP/EF results. */
 export const MAX_RESPONSE_BYTES = 200_000;
+
+/**
+ * Server-enforced response-size ceiling for MCP/Edge-Function results (agents
+ * can request smaller via `max_bytes`; larger is capped). Overridable via
+ * `CEREFOX_MAX_RESPONSE_BYTES`. Read by the Python runtime; restored after the
+ * TS migration. The web UI + CLI are intentionally unlimited and do not use this.
+ * Runtime-agnostic env read (Deno EF safely falls back to the default).
+ */
+export function getMaxResponseBytes(): number {
+  const raw = (globalThis as { process?: { env?: Record<string, string | undefined> } })
+    .process?.env?.CEREFOX_MAX_RESPONSE_BYTES;
+  if (raw === undefined || raw === "") return MAX_RESPONSE_BYTES;
+  const n = Number.parseInt(raw, 10);
+  return Number.isNaN(n) || n <= 0 ? MAX_RESPONSE_BYTES : n;
+}
 
 /** Built-in default cosine-similarity floor for hybrid/semantic search. */
 export const DEFAULT_MIN_SEARCH_SCORE = 0.5;

--- a/_shared/mcp-tools/metadata-search.ts
+++ b/_shared/mcp-tools/metadata-search.ts
@@ -7,7 +7,7 @@
 
 import type { MCPSupabaseClient } from "./types.ts";
 
-import { applyByteBudget, logUsage, MAX_RESPONSE_BYTES } from "./_utils.ts";
+import { applyByteBudget, getMaxResponseBytes, logUsage } from "./_utils.ts";
 import { lookupProjectId } from "./_projects.ts";
 import { McpInvalidParams, type ToolContext, type ToolDefinition } from "./types.ts";
 
@@ -39,8 +39,9 @@ async function handler(
   }
 
   // Enforce byte ceiling for content mode
+  const ceiling = getMaxResponseBytes();
   const max_bytes = include_content
-    ? Math.min(requested_max_bytes ?? MAX_RESPONSE_BYTES, MAX_RESPONSE_BYTES)
+    ? Math.min(requested_max_bytes ?? ceiling, ceiling)
     : null;
 
   const params: Record<string, unknown> = {

--- a/_shared/mcp-tools/search.ts
+++ b/_shared/mcp-tools/search.ts
@@ -18,7 +18,7 @@
 import type { MCPSupabaseClient } from "./types.ts";
 
 import { getEmbedding } from "../embeddings/index.ts";
-import { applyByteBudget, logUsage, MAX_RESPONSE_BYTES } from "./_utils.ts";
+import { applyByteBudget, getMinSearchScore, logUsage, MAX_RESPONSE_BYTES } from "./_utils.ts";
 import { lookupProjectId } from "./_projects.ts";
 import { McpInvalidParams, type ToolContext, type ToolDefinition } from "./types.ts";
 
@@ -32,7 +32,7 @@ async function handler(
   const match_count = (args.match_count as number | undefined) ?? 5;
   const mode = (args.mode as string | undefined) ?? "docs";
   const alpha = (args.alpha as number | undefined) ?? 0.7;
-  const min_score = (args.min_score as number | undefined) ?? 0.5;
+  const min_score = (args.min_score as number | undefined) ?? getMinSearchScore();
   const metadata_filter =
     (args.metadata_filter as Record<string, string> | null | undefined) ?? null;
   const requested_max_bytes = args.max_bytes as number | undefined;

--- a/_shared/mcp-tools/search.ts
+++ b/_shared/mcp-tools/search.ts
@@ -18,7 +18,7 @@
 import type { MCPSupabaseClient } from "./types.ts";
 
 import { getEmbedding } from "../embeddings/index.ts";
-import { applyByteBudget, getMinSearchScore, logUsage, MAX_RESPONSE_BYTES } from "./_utils.ts";
+import { applyByteBudget, getMaxResponseBytes, getMinSearchScore, logUsage } from "./_utils.ts";
 import { lookupProjectId } from "./_projects.ts";
 import { McpInvalidParams, type ToolContext, type ToolDefinition } from "./types.ts";
 
@@ -37,7 +37,8 @@ async function handler(
     (args.metadata_filter as Record<string, string> | null | undefined) ?? null;
   const requested_max_bytes = args.max_bytes as number | undefined;
 
-  const max_bytes = Math.min(requested_max_bytes ?? MAX_RESPONSE_BYTES, MAX_RESPONSE_BYTES);
+  const ceiling = getMaxResponseBytes();
+  const max_bytes = Math.min(requested_max_bytes ?? ceiling, ceiling);
 
   if (
     metadata_filter !== null &&

--- a/docker/local/cerefox-local
+++ b/docker/local/cerefox-local
@@ -29,8 +29,23 @@ host_port() {
   docker inspect -f '{{range $p, $c := .NetworkSettings.Ports}}{{if eq $p "8000/tcp"}}{{(index $c 0).HostPort}}{{end}}{{end}}' "$CONTAINER" 2>/dev/null || true
 }
 
-# Recreate the container from the persisted config (used by `upgrade`). Reads the
-# host port + OPENAI key from $ENV_FILE so an upgrade preserves them.
+# Config overrides forwarded from the host .env into the container. Deliberately
+# EXCLUDES container-managed vars (SUPABASE_URL/KEY, DATABASE_URL, POSTGREST_UPSTREAM,
+# the JWT secret) — those are generated/owned inside the container. The single codebase
+# reads these the same way in-container as it does for the cloud CLI.
+PASSTHROUGH_VARS="CEREFOX_MIN_SEARCH_SCORE CEREFOX_MAX_RESPONSE_BYTES CEREFOX_MAX_CHUNK_CHARS CEREFOX_MIN_CHUNK_CHARS CEREFOX_VERSION_RETENTION_HOURS CEREFOX_VERSION_CLEANUP_ENABLED CEREFOX_OPENAI_BASE_URL CEREFOX_OPENAI_EMBEDDING_MODEL CEREFOX_OPENAI_EMBEDDING_DIMENSIONS CEREFOX_AUTHOR_NAME CEREFOX_AUTHOR_TYPE CEREFOX_REQUESTOR_NAME"
+
+# Emit `-e VAR=value` for each passthrough var present in $ENV_FILE.
+config_env_args() {
+  [ -f "$ENV_FILE" ] || return 0
+  for v in $PASSTHROUGH_VARS; do
+    val=$(grep -E "^${v}=" "$ENV_FILE" | head -1 | sed -E "s/^${v}=//")
+    [ -n "$val" ] && printf ' -e %s=%s' "$v" "$val"
+  done
+}
+
+# Recreate the container from the persisted config (used by `upgrade`/`init`). Reads the
+# host port + OPENAI key + any config overrides from $ENV_FILE so they survive a recreate.
 recreate() {
   need_docker
   [ -f "$ENV_FILE" ] || die "no config at $ENV_FILE — run install-local.sh first"
@@ -47,6 +62,7 @@ recreate() {
     --restart unless-stopped \
     -v "$VOLUME:/var/lib/postgresql/data" \
     ${OPENAI_API_KEY:+-e OPENAI_API_KEY=$OPENAI_API_KEY} \
+    $(config_env_args) \
     "$IMAGE" >/dev/null
   echo "✓ container (re)started → http://localhost:$PORT/app/"
 }
@@ -123,12 +139,22 @@ case "$cmd" in
     fi
     [ -z "$key" ] && key="$cur_key"     # keep current when left blank
     [ -z "$port" ] && port="$cur_port"
+    # Preserve any CEREFOX_* tuning overrides already in the file (we only manage key+port).
+    preserved=""
+    if [ -f "$ENV_FILE" ]; then
+      for v in $PASSTHROUGH_VARS; do
+        line=$(grep -E "^${v}=" "$ENV_FILE" | head -1)
+        [ -n "$line" ] && preserved="${preserved}${line}
+"
+      done
+    fi
     umask 077
     {
       echo "# Cerefox LOCAL host config. The access token lives in the container, not here;"
-      echo "# only the OpenAI key + port are stored. Manage with: cerefox-local init"
+      echo "# only the OpenAI key + port + optional CEREFOX_* tuning overrides are stored."
       echo "CEREFOX_LOCAL_PORT=$port"
       [ -n "$key" ] && echo "OPENAI_API_KEY=$key"
+      [ -n "$preserved" ] && printf '%s' "$preserved"
     } > "$ENV_FILE"
     echo "✓ saved config to $ENV_FILE"
     [ -n "$key" ] || echo "  (no OpenAI key set — ingest + semantic search stay disabled; re-run 'cerefox-local init' to add one)"

--- a/docker/local/install-local.sh
+++ b/docker/local/install-local.sh
@@ -97,6 +97,23 @@ if [ -z "${OPENAI_API_KEY:-}" ] && [ -f "$HOME/.cerefox/.env" ]; then
   [ -n "${OPENAI_API_KEY:-}" ] && OPENAI_FROM_CLOUD_ENV=true
 fi
 
+# Preserve any config overrides the user added to a prior local .env (we only manage
+# OPENAI + port), and forward them into the container. Same whitelist cerefox-local uses;
+# never the container-managed SUPABASE/DB/JWT vars.
+PASSTHROUGH_VARS="CEREFOX_MIN_SEARCH_SCORE CEREFOX_MAX_RESPONSE_BYTES CEREFOX_MAX_CHUNK_CHARS CEREFOX_MIN_CHUNK_CHARS CEREFOX_VERSION_RETENTION_HOURS CEREFOX_VERSION_CLEANUP_ENABLED CEREFOX_OPENAI_BASE_URL CEREFOX_OPENAI_EMBEDDING_MODEL CEREFOX_OPENAI_EMBEDDING_DIMENSIONS CEREFOX_AUTHOR_NAME CEREFOX_AUTHOR_TYPE CEREFOX_REQUESTOR_NAME"
+PRESERVED_OVERRIDES=""
+ENV_ARGS=""
+if [ -f "$CONFIG_DIR/.env" ]; then
+  for v in $PASSTHROUGH_VARS; do
+    line=$(grep -E "^${v}=" "$CONFIG_DIR/.env" | head -1)
+    if [ -n "$line" ]; then
+      PRESERVED_OVERRIDES="${PRESERVED_OVERRIDES}${line}
+"
+      ENV_ARGS="$ENV_ARGS -e $line"
+    fi
+  done
+fi
+
 # 1. Pull + (re)start the container. It self-generates PGRST_JWT_SECRET on first boot
 #    (persisted in the volume) and mints the service_role JWT internally — no host minting.
 echo "Pulling $IMAGE …"
@@ -110,16 +127,19 @@ docker run -d --name "$CONTAINER" -p "$PORT:8000" \
   --restart unless-stopped \
   -v "$VOLUME:/var/lib/postgresql/data" \
   ${OPENAI_API_KEY:+-e OPENAI_API_KEY=$OPENAI_API_KEY} \
+  $ENV_ARGS \
   "$IMAGE" >/dev/null
 
-# 2. Write the host config (OPENAI key + the port, for `cerefox-local upgrade`).
-#    NO JWT/URL here — those live in the container. Cloud ~/.cerefox/.env is untouched.
+# 2. Write the host config (OPENAI key + port + any preserved overrides). NO JWT/URL here
+#    — those live in the container. Cloud ~/.cerefox/.env is untouched.
 umask 077
 {
   echo "# Cerefox LOCAL host config. The access token lives in the container, not here;"
-  echo "# only the OpenAI key + port are stored. Manage with: cerefox-local init"
+  echo "# only the OpenAI key + port + optional CEREFOX_* tuning overrides are stored."
+  echo "# Add overrides (see docs/guides/configuration.md), then: cerefox-local init"
   echo "CEREFOX_LOCAL_PORT=$PORT"
   [ -n "${OPENAI_API_KEY:-}" ] && echo "OPENAI_API_KEY=$OPENAI_API_KEY"
+  [ -n "$PRESERVED_OVERRIDES" ] && printf '%s' "$PRESERVED_OVERRIDES"
 } > "$CONFIG_DIR/.env"
 
 # 3. Extract the host `cerefox-local` script from the image (single source of truth) and

--- a/docker/local/install-local.sh
+++ b/docker/local/install-local.sh
@@ -52,6 +52,21 @@ fi
 
 mkdir -p "$CONFIG_DIR"; chmod 700 "$CONFIG_DIR"
 
+# Port sanity. The cloud `cerefox web` ALSO defaults to 8000, so a machine running both
+# worlds will collide. Warn on the shared default when a cloud install is present, and
+# fail fast (with guidance) if the chosen port is already bound — better than the
+# container silently grabbing it (or `docker run` erroring opaquely later).
+if [ "$PORT" = "8000" ] && [ -f "$HOME/.cerefox/.env" ]; then
+  echo "⚠ A cloud Cerefox install (~/.cerefox/.env) is present and BOTH default to port 8000."
+  echo "  Running 'cerefox web' (cloud) and this local server at once will collide on 8000."
+  echo "  If you use both, pick a distinct local port: PORT=8787 sh install-local.sh"
+fi
+if command -v lsof >/dev/null 2>&1 && lsof -nP -iTCP:"$PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+  echo "✗ Port $PORT is already in use on this host. Re-run with a free port, e.g.:"
+  echo "    PORT=8787 sh install-local.sh"
+  exit 1
+fi
+
 # Embedder key: prefer the env; else, ONLY if a cloud ~/.cerefox/.env happens to exist,
 # borrow its OPENAI_API_KEY line as a convenience (we never read its Supabase creds).
 OPENAI_FROM_CLOUD_ENV=false

--- a/docker/local/install-local.sh
+++ b/docker/local/install-local.sh
@@ -26,7 +26,29 @@ CONTAINER="${CEREFOX_LOCAL_CONTAINER:-cerefox-local}"
 VOLUME="${CEREFOX_LOCAL_VOLUME:-cerefox_local_pgdata}"
 BIN_DIR="${CEREFOX_LOCAL_BIN_DIR:-$HOME/.local/bin}"
 
-command -v docker >/dev/null 2>&1 || { echo "✗ docker not found — install Docker (or Colima) first"; exit 1; }
+# Docker is a hard prerequisite. Unlike the cloud installer (which can drop Bun into
+# user space), Docker is system infrastructure (daemon + admin install), so we detect +
+# guide rather than auto-install.
+if ! command -v docker >/dev/null 2>&1; then
+  echo "✗ Docker is required but not found. Install it, then re-run this installer:"
+  case "$(uname -s)" in
+    Darwin) echo "    • Docker Desktop:  https://www.docker.com/products/docker-desktop/"
+            echo "    • or Colima (CLI): brew install colima docker && colima start" ;;
+    Linux)  echo "    • Your distro's package, or: curl -fsSL https://get.docker.com | sh"
+            echo "      (then add yourself to the 'docker' group + start the service)" ;;
+    *)      echo "    • https://docs.docker.com/get-docker/" ;;
+  esac
+  exit 1
+fi
+# Installed but the daemon may be stopped (Docker Desktop quit / Colima not started).
+if ! docker info >/dev/null 2>&1; then
+  echo "✗ Docker is installed but the daemon isn't running. Start it, then re-run:"
+  case "$(uname -s)" in
+    Darwin) echo "    • Start Docker Desktop, or run: colima start" ;;
+    *)      echo "    • Start the Docker service (e.g. sudo systemctl start docker)" ;;
+  esac
+  exit 1
+fi
 
 mkdir -p "$CONFIG_DIR"; chmod 700 "$CONFIG_DIR"
 

--- a/docker/local/install-local.sh
+++ b/docker/local/install-local.sh
@@ -20,7 +20,11 @@
 set -eu
 
 IMAGE="${CEREFOX_LOCAL_IMAGE:-ghcr.io/fstamatelopoulos/cerefox-local:latest}"
-PORT="${PORT:-8000}"
+DEFAULT_PORT=8000
+# Track whether the user set PORT explicitly (we respect it) vs. took the default
+# (we may auto-select a free one). Must check before applying the default.
+if [ -n "${PORT:-}" ]; then PORT_EXPLICIT=true; else PORT_EXPLICIT=false; fi
+PORT="${PORT:-$DEFAULT_PORT}"
 CONFIG_DIR="${CEREFOX_LOCAL_CONFIG_DIR:-$HOME/.cerefox/local}"
 CONTAINER="${CEREFOX_LOCAL_CONTAINER:-cerefox-local}"
 VOLUME="${CEREFOX_LOCAL_VOLUME:-cerefox_local_pgdata}"
@@ -52,19 +56,37 @@ fi
 
 mkdir -p "$CONFIG_DIR"; chmod 700 "$CONFIG_DIR"
 
-# Port sanity. The cloud `cerefox web` ALSO defaults to 8000, so a machine running both
-# worlds will collide. Warn on the shared default when a cloud install is present, and
-# fail fast (with guidance) if the chosen port is already bound — better than the
-# container silently grabbing it (or `docker run` erroring opaquely later).
-if [ "$PORT" = "8000" ] && [ -f "$HOME/.cerefox/.env" ]; then
-  echo "⚠ A cloud Cerefox install (~/.cerefox/.env) is present and BOTH default to port 8000."
-  echo "  Running 'cerefox web' (cloud) and this local server at once will collide on 8000."
-  echo "  If you use both, pick a distinct local port: PORT=8787 sh install-local.sh"
-fi
-if command -v lsof >/dev/null 2>&1 && lsof -nP -iTCP:"$PORT" -sTCP:LISTEN >/dev/null 2>&1; then
-  echo "✗ Port $PORT is already in use on this host. Re-run with a free port, e.g.:"
-  echo "    PORT=8787 sh install-local.sh"
-  exit 1
+# Port selection. The cloud `cerefox web` ALSO defaults to 8000, so a machine running
+# both worlds collides. `port_busy` is best-effort (needs lsof; if absent we can't probe
+# and let `docker run` fail loudly). An explicit PORT= is respected (error if busy); the
+# default auto-steps by +10 past busy ports — and past 8000 itself when a cloud install
+# (same default) is present, to avoid a latent `cerefox web` collision.
+port_busy() {
+  command -v lsof >/dev/null 2>&1 || return 1   # no lsof → can't probe; treat as free
+  lsof -nP -iTCP:"$1" -sTCP:LISTEN >/dev/null 2>&1
+}
+if [ "$PORT_EXPLICIT" = true ]; then
+  if port_busy "$PORT"; then
+    echo "✗ Port $PORT is already in use (you set PORT=$PORT). Choose a free port and re-run."
+    exit 1
+  fi
+else
+  cloud_present=false; [ -f "$HOME/.cerefox/.env" ] && cloud_present=true
+  attempts=0
+  while port_busy "$PORT" || { [ "$cloud_present" = true ] && [ "$PORT" = "$DEFAULT_PORT" ]; }; do
+    PORT=$((PORT + 10)); attempts=$((attempts + 1))
+    if [ "$attempts" -gt 50 ]; then
+      echo "✗ Couldn't find a free port near $DEFAULT_PORT. Re-run with an explicit PORT=."
+      exit 1
+    fi
+  done
+  if [ "$PORT" != "$DEFAULT_PORT" ]; then
+    if [ "$cloud_present" = true ]; then
+      echo "ℹ Port $DEFAULT_PORT is the cloud Cerefox default (and/or busy) — using $PORT for local."
+    else
+      echo "ℹ Port $DEFAULT_PORT was busy — using $PORT for local."
+    fi
+  fi
 fi
 
 # Embedder key: prefer the env; else, ONLY if a cloud ~/.cerefox/.env happens to exist,

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -14,7 +14,7 @@ Every command reads configuration from `.env` in the working directory (or envir
 
 The CLI is the TypeScript `@cerefox/memory` package. Invoke any command as plain `cerefox <subcommand>` (installed via the installer or `npm install -g @cerefox/memory` — see [`quickstart.md`](quickstart.md#1-install)).
 
-> **v0.9 verb rename**: commands now follow a `resource verb` shape (e.g. `cerefox document get`, `cerefox project list`). The old flat verbs (`get-doc`, `list-docs`, `ingest`, `list-versions`, `config-get`, `deploy-server`, `docs`, …) are husks and have been removed — use the new forms below.
+> **v0.9 verb rename**: commands now follow a `resource verb` shape (e.g. `cerefox document get`, `cerefox project list`). The old flat verbs (`get-doc`, `list-docs`, `ingest`, `list-versions`, `config-get`, `deploy-server`, `docs`, …) survive as hidden husks — they still run but print a pointer to the new form and exit non-zero (removed only at v1.0). Use the new forms below.
 
 ## Commands
 
@@ -141,7 +141,7 @@ cerefox search [OPTIONS] QUERY
 ```bash
 cerefox search "OAuth design"
 cerefox search "decisions" --metadata-filter '{"type":"decision-log"}' --match-count 5
-cerefox search "what we tried" --mode semantic --requestor "claude-code"
+cerefox search "what we tried" --mode hybrid --requestor "claude-code"
 cerefox search "design docs" --only-metadata
 ```
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -24,6 +24,13 @@ CEREFOX_CONFIG_DIR=~/.cerefox-personal cerefox search "…"
 
 Full rule documented in [`docs/specs/polish-and-distribution-design.md` §7](../specs/polish-and-distribution-design.md).
 
+> **Local / self-hosted (World B).** For the Docker backend (`cerefox-local`), do **not**
+> set the Supabase or `CEREFOX_DATABASE_URL` vars below — the container generates and owns
+> them. Put `OPENAI_API_KEY` plus any of the `CEREFOX_*` **tuning** options on this page
+> (search, chunking, retrieval, versioning, embedding base-url/model, caller identity) in
+> `~/.cerefox/local/.env`; the installer + `cerefox-local` forward them into the container.
+> Apply changes with `cerefox-local init`. See [`setup-local.md`](setup-local.md).
+
 ---
 
 ## Supabase / Database
@@ -45,34 +52,27 @@ Full rule documented in [`docs/specs/polish-and-distribution-design.md` §7](../
 
 Cerefox uses cloud-based embedding APIs. Local models (mpnet, Ollama) are not supported — they require large downloads, fail on some hardware, and add installation complexity.
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `CEREFOX_EMBEDDER` | `openai` | Embedding provider. Valid values: `openai`, `fireworks` |
+> **TS runtime: OpenAI only (today).** The current TypeScript runtime implements the
+> OpenAI embedder. `CEREFOX_EMBEDDER` and the `CEREFOX_FIREWORKS_*` variables are
+> documented (they worked in the retired Python runtime) but are **not yet wired in TS** —
+> they're currently no-ops, tracked for a future release.
 
 ### OpenAI (default, recommended)
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `OPENAI_API_KEY` | `""` | OpenAI API key. Also accepted as `CEREFOX_OPENAI_API_KEY`. Get one at [platform.openai.com/api-keys](https://platform.openai.com/api-keys). |
-| `CEREFOX_OPENAI_BASE_URL` | `https://api.openai.com/v1` | API base URL. Override for proxies or OpenAI-compatible providers. |
-| `CEREFOX_OPENAI_EMBEDDING_MODEL` | `text-embedding-3-small` | OpenAI embedding model. |
-| `CEREFOX_OPENAI_EMBEDDING_DIMENSIONS` | `768` | Output dimensions. Must match the database schema (VECTOR(768)). |
+| `CEREFOX_OPENAI_BASE_URL` | `https://api.openai.com/v1` | API base URL. Safe to override for proxies or OpenAI-compatible gateways. |
+| `CEREFOX_OPENAI_EMBEDDING_MODEL` | `text-embedding-3-small` | OpenAI embedding model. ⚠ see warning below. |
+| `CEREFOX_OPENAI_EMBEDDING_DIMENSIONS` | `768` | Output dimensions. Must match the DB schema (`VECTOR(768)`). ⚠ see warning below. |
+
+> **⚠ Changing the model or dimensions is breaking.** Query vectors must match the stored
+> vectors. After changing `CEREFOX_OPENAI_EMBEDDING_MODEL` you MUST re-embed the whole
+> corpus (`cerefox server reindex`); changing `CEREFOX_OPENAI_EMBEDDING_DIMENSIONS` away
+> from 768 also requires a schema change. `CEREFOX_OPENAI_BASE_URL` is the only one safe to
+> flip on an existing knowledge base.
 
 For cost estimates see `docs/guides/operational-cost.md`.
-
-### Fireworks AI (alternative, lower cost)
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `CEREFOX_FIREWORKS_API_KEY` | `""` | Fireworks AI API key. |
-| `CEREFOX_FIREWORKS_BASE_URL` | `https://api.fireworks.ai/inference/v1` | Fireworks API base URL. |
-| `CEREFOX_FIREWORKS_EMBEDDING_MODEL` | `nomic-ai/nomic-embed-text-v1.5` | Fireworks model. Must natively output 768-dim vectors. |
-
-To use Fireworks:
-```env
-CEREFOX_EMBEDDER=fireworks
-CEREFOX_FIREWORKS_API_KEY=fw_...
-```
 
 ### Edge Functions (for agents)
 

--- a/docs/guides/ops-scripts.md
+++ b/docs/guides/ops-scripts.md
@@ -37,7 +37,7 @@ jobs / CI / make targets that invoke them.
 
 ### TS scripts and `.env` resolution
 
-`bun scripts/<name>.ts` reads the same `.env` the Python CLI does. Precedence:
+`bun scripts/<name>.ts` reads the same `.env` the `cerefox` CLI does. Precedence:
 
 1. `CEREFOX_CONFIG_DIR` env var (explicit override; supports `~`).
 2. `./.env` in the current working directory (dev mode).

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -1,9 +1,9 @@
 # Quickstart -- Zero to First Document
 
-Get Cerefox running on your machine via the npm install path. **No source
-clone, no Python required.** Once you have a Supabase project (the one
-prerequisite — provisioning a free one takes a few minutes), the Cerefox
-install and setup below is about 5 minutes.
+Get Cerefox running on your machine via the npm install path (the **cloud /
+Supabase** backend). **No source clone required.** Once you have a Supabase
+project (the one prerequisite — provisioning a free one takes a few minutes),
+the Cerefox install and setup below takes ~15 minutes.
 
 > **Upgrading from an earlier version?** See [`upgrading.md`](upgrading.md)
 > for migration steps instead.
@@ -114,8 +114,9 @@ You should see results from the bundled self-docs.
 The path above is for **end users** (no clone). If you want to hack on Cerefox,
 clone the repo, run `bun install`, and use the contributor scripts
 (`bun scripts/db_deploy.ts`, `bun scripts/db_migrate.ts`). `uv` is only needed
-for the legacy Python MCP fallback. See [`setup-local.md`](setup-local.md) and
-`CONTRIBUTING.md`.
+for the legacy Python MCP fallback. See [`CONTRIBUTING.md`](../../CONTRIBUTING.md).
+(Want a no-cloud install instead? That's the self-hosted Docker backend —
+[`setup-local.md`](setup-local.md).)
 
 ---
 
@@ -125,7 +126,7 @@ for the legacy Python MCP fallback. See [`setup-local.md`](setup-local.md) and
   `cerefox document ingest-dir ./notes/` (recurses into sub-directories automatically)
 - **Search from the CLI**: `cerefox search "your query"`
 - **Discover all commands**: `cerefox --help`
-- **Run the web UI**: `cerefox web` (TypeScript — Hono backend + React SPA); see [`setup-local.md`](setup-local.md)
+- **Run the web UI**: `cerefox web` (TypeScript — Hono backend + React SPA); see [`cli.md`](cli.md)
 - **Connect more AI clients** (Cursor, Codex, ChatGPT GPT Actions, etc.):
   [`connect-agents.md`](connect-agents.md)
 - **Configuration reference**: [`configuration.md`](configuration.md)

--- a/docs/guides/setup-supabase.md
+++ b/docs/guides/setup-supabase.md
@@ -47,7 +47,7 @@ You need three values from Supabase: a URL, an API key, and a direct Postgres co
 
 See the **[Supabase API keys (2026)](#supabase-api-keys-2026)** section near the end of this guide for the full picture. The short version:
 
-- For `CEREFOX_SUPABASE_KEY` (this guide, Python web app, CLI): use the new **secret key** (`sb_secret_…`) from **Project Settings → API Keys → Secret key**. The legacy `service_role` JWT also still works during the transition.
+- For `CEREFOX_SUPABASE_KEY` (this guide, the web UI, and the CLI): use the new **secret key** (`sb_secret_…`) from **Project Settings → API Keys → Secret key**. The legacy `service_role` JWT also still works during the transition.
 - For `CEREFOX_SUPABASE_ANON_KEY` (only if you'll use Edge Functions / MCP / GPT Actions; not needed for this guide's deployment step): you must use the **legacy anon JWT** (`eyJ…`). The new `sb_publishable_…` key fails at the Edge Function gateway. See the reference section for why.
 
 Either way: keep this key secret — it bypasses Row Level Security and grants full database access.

--- a/packages/memory/src/cli/commands/backup.ts
+++ b/packages/memory/src/cli/commands/backup.ts
@@ -51,7 +51,9 @@ function utcStamp(): string {
 }
 
 async function action(options: BackupOptions): Promise<void> {
-  const outDir = resolve(expandHome(options.outputDir ?? "~/.cerefox/backups"));
+  const outDir = resolve(
+    expandHome(options.outputDir ?? process.env.CEREFOX_BACKUP_DIR ?? "~/.cerefox/backups"),
+  );
   if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true });
 
   const stamp = utcStamp();
@@ -123,8 +125,7 @@ export function registerBackup(program: Command): void {
     .description("Write a JSON snapshot of the knowledge base.")
     .option(
       "-o, --output-dir <dir>",
-      "Snapshot output directory.",
-      "~/.cerefox/backups",
+      "Snapshot output directory (default: CEREFOX_BACKUP_DIR or ~/.cerefox/backups).",
     )
     .option("-l, --label <label>", "Optional suffix added to the filename.")
     .option("--include-versions", "Include archived versions in the snapshot. (v0.5: ignored — current chunks only.)")

--- a/packages/memory/src/cli/commands/search.ts
+++ b/packages/memory/src/cli/commands/search.ts
@@ -26,6 +26,7 @@ import {
   systemError,
   userError,
 } from "../../../../../_shared/cli-core/index.ts";
+import { getMinSearchScore } from "../../../../../_shared/mcp-tools/_utils.ts";
 import { getClient } from "../util/client.ts";
 import { embedQuery } from "../util/embed.ts";
 
@@ -75,7 +76,7 @@ async function action(
 
   const matchCount = parsePositiveInt(options.matchCount, "--match-count", 5);
   const alpha = parseFloat01(options.alpha, "--alpha", 0.7);
-  const minScore = parseFloat01(options.minScore, "--min-score", 0.5);
+  const minScore = parseFloat01(options.minScore, "--min-score", getMinSearchScore());
   const maxBytes = parseNonNegativeInt(options.maxBytes, "--max-bytes", 200_000);
   const mode = options.mode ?? "docs";
   if (!["docs", "hybrid", "fts"].includes(mode)) {
@@ -277,7 +278,7 @@ export function registerSearch(program: Command): void {
     )
     .option("--mode <mode>", "Search mode: docs (default), hybrid, fts.", "docs")
     .option("--alpha <float>", "Semantic weight 0..1 (default: 0.7).", "0.7")
-    .option("--min-score <float>", "Minimum cosine similarity threshold.", "0.5")
+    .option("--min-score <float>", "Minimum cosine similarity threshold (default: CEREFOX_MIN_SEARCH_SCORE or 0.5).")
     .option("--max-bytes <n>", "Response size budget in bytes.", "200000")
     .option("-r, --requestor <name>", "Agent / user name (recorded in usage log).")
     .option("--json", "Emit machine-readable JSON instead of the default text.")

--- a/packages/memory/src/ingestion/pipeline.ts
+++ b/packages/memory/src/ingestion/pipeline.ts
@@ -36,7 +36,7 @@ import {
 } from "./client-bridge.ts";
 import { fileToMarkdown } from "./file-to-markdown.ts";
 import {
-  DEFAULT_PIPELINE_SETTINGS,
+  loadPipelineSettings,
   type IngestResult,
   type IngestTextOptions,
   type PipelineSettings,
@@ -64,7 +64,7 @@ export class IngestionPipeline {
     this.db = new IngestionDbBridge(deps.supabase);
     this.apiKey = deps.openAiApiKey;
     this.embedderModel = deps.embedderModel ?? "text-embedding-3-small";
-    this.settings = { ...DEFAULT_PIPELINE_SETTINGS, ...(deps.settings ?? {}) };
+    this.settings = { ...loadPipelineSettings(), ...(deps.settings ?? {}) };
   }
 
   // ── Public API ─────────────────────────────────────────────────────────────

--- a/packages/memory/src/ingestion/types.ts
+++ b/packages/memory/src/ingestion/types.ts
@@ -91,3 +91,34 @@ export const DEFAULT_PIPELINE_SETTINGS: PipelineSettings = {
   versionRetentionHours: 48,
   versionCleanupEnabled: true,
 };
+
+/**
+ * Pipeline settings with `.env` overrides applied over the defaults. The Python
+ * runtime read these; the TS migration dropped them. Honors
+ * CEREFOX_MAX_CHUNK_CHARS, CEREFOX_MIN_CHUNK_CHARS, CEREFOX_VERSION_RETENTION_HOURS,
+ * and CEREFOX_VERSION_CLEANUP_ENABLED. Used as the pipeline's default settings.
+ */
+export function loadPipelineSettings(): PipelineSettings {
+  const env =
+    (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env ?? {};
+  const intMin = (raw: string | undefined, def: number, min: number): number => {
+    if (raw === undefined || raw === "") return def;
+    const n = Number.parseInt(raw, 10);
+    return Number.isNaN(n) || n < min ? def : n;
+  };
+  const bool = (raw: string | undefined, def: boolean): boolean =>
+    raw === undefined || raw === "" ? def : !/^(false|0|no|off)$/i.test(raw.trim());
+  return {
+    maxChunkChars: intMin(env.CEREFOX_MAX_CHUNK_CHARS, DEFAULT_PIPELINE_SETTINGS.maxChunkChars, 1),
+    minChunkChars: intMin(env.CEREFOX_MIN_CHUNK_CHARS, DEFAULT_PIPELINE_SETTINGS.minChunkChars, 0),
+    versionRetentionHours: intMin(
+      env.CEREFOX_VERSION_RETENTION_HOURS,
+      DEFAULT_PIPELINE_SETTINGS.versionRetentionHours,
+      0,
+    ),
+    versionCleanupEnabled: bool(
+      env.CEREFOX_VERSION_CLEANUP_ENABLED,
+      DEFAULT_PIPELINE_SETTINGS.versionCleanupEnabled,
+    ),
+  };
+}

--- a/packages/memory/src/web/routes/discovery.ts
+++ b/packages/memory/src/web/routes/discovery.ts
@@ -14,6 +14,7 @@
 import { Hono } from "hono";
 
 import { getEmbedding } from "../../../../../_shared/embeddings/index.js";
+import { getMinSearchScore } from "../../../../../_shared/mcp-tools/_utils.js";
 import type { WebContext } from "../context.ts";
 import { logWebUsage } from "../usage.ts";
 
@@ -350,7 +351,7 @@ async function runSearch(
       p_alpha: 0.7,
       p_use_upgrade: false,
       p_project_id: projectId,
-      p_min_score: 0.0,
+      p_min_score: getMinSearchScore(),
     };
     if (metadataFilter) params.p_metadata_filter = metadataFilter;
     const { data, error } = await ctx.supabase.rpc(

--- a/packages/memory/test/pipeline-settings.test.ts
+++ b/packages/memory/test/pipeline-settings.test.ts
@@ -1,0 +1,56 @@
+/**
+ * loadPipelineSettings() applies the .env chunking/version overrides (restored
+ * after the Python→TS migration) over the built-in defaults.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+import {
+  DEFAULT_PIPELINE_SETTINGS,
+  loadPipelineSettings,
+} from "../src/ingestion/types.ts";
+
+const TOUCHED = [
+  "CEREFOX_MAX_CHUNK_CHARS",
+  "CEREFOX_MIN_CHUNK_CHARS",
+  "CEREFOX_VERSION_RETENTION_HOURS",
+  "CEREFOX_VERSION_CLEANUP_ENABLED",
+];
+function clear() {
+  for (const k of TOUCHED) delete process.env[k];
+}
+beforeEach(clear);
+afterEach(clear);
+
+describe("loadPipelineSettings", () => {
+  it("returns the defaults when nothing is set", () => {
+    expect(loadPipelineSettings()).toEqual(DEFAULT_PIPELINE_SETTINGS);
+  });
+
+  it("applies valid env overrides", () => {
+    process.env.CEREFOX_MAX_CHUNK_CHARS = "2500";
+    process.env.CEREFOX_VERSION_RETENTION_HOURS = "72";
+    process.env.CEREFOX_VERSION_CLEANUP_ENABLED = "false";
+    const s = loadPipelineSettings();
+    expect(s.maxChunkChars).toBe(2500);
+    expect(s.versionRetentionHours).toBe(72);
+    expect(s.versionCleanupEnabled).toBe(false);
+    expect(s.minChunkChars).toBe(DEFAULT_PIPELINE_SETTINGS.minChunkChars);
+  });
+
+  it("ignores invalid numeric values, keeping defaults", () => {
+    process.env.CEREFOX_MAX_CHUNK_CHARS = "0";
+    process.env.CEREFOX_VERSION_RETENTION_HOURS = "nope";
+    const s = loadPipelineSettings();
+    expect(s.maxChunkChars).toBe(DEFAULT_PIPELINE_SETTINGS.maxChunkChars);
+    expect(s.versionRetentionHours).toBe(DEFAULT_PIPELINE_SETTINGS.versionRetentionHours);
+  });
+
+  it("accepts 0 for retention hours (valid) but not for chunk size", () => {
+    process.env.CEREFOX_VERSION_RETENTION_HOURS = "0";
+    process.env.CEREFOX_MIN_CHUNK_CHARS = "0";
+    const s = loadPipelineSettings();
+    expect(s.versionRetentionHours).toBe(0);
+    expect(s.minChunkChars).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to v0.10.0. Two themes: **restore `.env` config overrides that the Python→TS
migration silently dropped**, and **polish the local (World-B) backend**.

### Config overrides (regressions fixed)
Several documented `CEREFOX_*` options were no-ops in the TS runtime. Each now has a
single default, honored consistently by **CLI + MCP + web**, and forwarded into the
local container:
- **`CEREFOX_MIN_SEARCH_SCORE`** (0.5) — the web API passed `0.0`, so the web UI returned
  irrelevant low-similarity hits; now matches CLI/MCP.
- **`CEREFOX_MAX_RESPONSE_BYTES`** (MCP/EF ceiling; web + CLI stay unlimited).
- **chunking** (`MAX/MIN_CHUNK_CHARS`) + **versioning** (`VERSION_RETENTION_HOURS`,
  `VERSION_CLEANUP_ENABLED`) + **`BACKUP_DIR`**.
- **OpenAI embedding** `OPENAI_BASE_URL` / `_EMBEDDING_MODEL` / `_EMBEDDING_DIMENSIONS`
  (⚠ model/dims changes are breaking — documented; require `cerefox server reindex`).

### Migration-drift guard
A `bun test` now fails if any `.env.example` var isn't referenced in the TS source — the
cheap, non-brittle way to catch future Python→TS gaps (vs. diffing old Python). `.env.example`
cleaned up (dropped the no-op `CEREFOX_LOG_LEVEL`; marked Fireworks not-yet-in-TS).

### Local backend (World B) polish
- `install-local.sh` **auto-selects a free port** (`+10` past a busy port, and past 8000
  when a cloud install shares that default) instead of silently colliding.
- Detect-and-guide when Docker is missing / daemon stopped (no auto-install).
- `CEREFOX_*` tuning overrides in `~/.cerefox/local/.env` are forwarded into the container
  (apply with `cerefox-local init`).

### Docs
README cloud-vs-local framing + trimmed Project status; fixed stale items (`.docx` IS
supported via mammoth — only PDF dropped; CLI verbs are husks not "removed"; `--mode
hybrid`; quickstart timing + `setup-local.md` mis-links).

## Test plan
- [x] `_shared` 206 pass (incl. new config-overrides + phantom-config guard)
- [x] `pipeline-settings` 4 pass · CLI smoke 21 pass · package build clean
- [ ] (maintainer) cut **v0.10.1** with `--npm-publish --docker-publish`
- [ ] (maintainer) start cloud (8000) then local → verify port auto-select lands on 8010

## Deferred to v0.10.2
Polish trio (`cerefox-local --help` merge, in-bin `configure-agent --local`, completion);
larger World-B doc sections (access-paths, connect-agents, upgrading, operational-cost);
`127.0.0.1` container bind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)