### PR TITLE
fix(deploy): deploy Edge Functions via --use-api (no Docker bundler)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,17 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
-Open roadmap.
+### Fixed
+
+- **`cerefox server deploy` Edge Functions now deploy via the Supabase Management API
+  (`--use-api`)** instead of the local Docker bundler. The Docker bundler bind-mounts the
+  function source dir, which fails (`entrypoint path does not exist`) when the npm package
+  is installed under a path Docker Desktop won't file-share — notably **`/usr/local`** (the
+  classic Homebrew/`npm config set prefix /usr/local` location) — *and* Docker Desktop is
+  running. The API path is Docker-independent, so the deploy works regardless of where npm
+  placed the package or whether Docker is up. (Thanks @tdebasis — [#84].)
+
+[#84]: https://github.com/fstamatelopoulos/cerefox/issues/84
 
 ---
 

--- a/packages/memory/src/cli/commands/deploy-server.ts
+++ b/packages/memory/src/cli/commands/deploy-server.ts
@@ -297,7 +297,15 @@ async function action(options: DeployServerOptions): Promise<void> {
       // (link state lives in whatever dir the user ran `supabase link`), so a
       // bare deploy here couldn't resolve the target project.
       const workdir = assets.functionsDir.replace(/\/functions$/, "").replace(/\/supabase$/, "");
-      const args = ["--yes", "supabase", "functions", "deploy", ef];
+      // `--use-api`: bundle + deploy via the Supabase Management API instead of the local
+      // Docker bundler. The Docker bundler bind-mounts the function source dir into a
+      // container; when the npm package is installed under a path Docker Desktop won't share
+      // (e.g. /usr/local — not on its default file-sharing allowlist), the mount is empty and
+      // every function fails with "entrypoint path does not exist" (issue #84). The API path
+      // is Docker-independent (it's the same fallback the CLI uses when Docker is off) and is
+      // the right path for an end-user deploying to their cloud Supabase — no local Docker
+      // bundler needed. Requires a reasonably current Supabase CLI (we resolve latest via npx).
+      const args = ["--yes", "supabase", "functions", "deploy", ef, "--use-api"];
       if (projectRef) args.push("--project-ref", projectRef);
       const r = spawnSync("npx", args, {
         encoding: "utf8",


### PR DESCRIPTION
## Summary
- `cerefox server deploy` shelled out to `supabase functions deploy`, which silently switches to the **local Docker bundler** when Docker Desktop is running. That bundler bind-mounts the function source directory — and when the npm package is installed under a path Docker Desktop won't file-share (e.g. `/usr/local`), the mount is empty and every function fails with `entrypoint path does not exist`.
- Fix: pass `--use-api`, which bundles server-side via the Supabase Management API. Docker-independent, works regardless of npm prefix, and is the correct path for an end user deploying to **cloud** Supabase.
- Reported by @tdebasis (#84) — npm prefix `/usr/local` + Docker Desktop running.

## Test plan
- [x] `cerefox server deploy --functions-only` deploys all 9 EFs via the API bundler (verified live: "Uploading asset…" path, "✓ Deployed 9 Edge Function(s).")
- [x] `cerefox doctor` confirms the deployed functions respond — `✓ edge functions Deployed EF v0.10.1` (drift warning cleared)

Fixes #84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)