### PR TITLE
OAuth MCP + security hardening + chunker fix (iter 28A/B/D); 28E/28F design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
+### Added
+- **Cloud & mobile Claude over OAuth (optional).** `cerefox-mcp` is now an OAuth 2.1
+  protected resource, so **claude.ai web and the Claude mobile app** can connect with the
+  full 10-tool hybrid-search surface (previously unsupported / FTS-only). Opt-in: it needs
+  the Supabase OAuth 2.1 Server enabled, an owner-user pin (`CEREFOX_OAUTH_OWNER_ID`), a
+  pre-registered OAuth App (**`client_secret_post`**), and a hosted consent page shipped as
+  a one-command free **Cloudflare Worker** (`cloudflare/cerefox-consent/`). Existing
+  clients (Claude Code, Cursor, Codex, Gemini, Claude Desktop, local MCP) are unchanged and
+  need none of it. In-function auth lives in the new dependency-free `_shared/mcp-auth/`
+  (OAuth JWT via Web Crypto + legacy static-Bearer back-compat). Setup:
+  `docs/guides/setup-supabase.md` Step 7. Design: `docs/specs/oauth-mcp-server-design.md`.
+
 Open roadmap.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,19 +10,17 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 ## [Unreleased]
 
 ### Security
-- **Closed a Data API RPC bypass (schema 0.7.0 — redeploy required).** All `cerefox_*`
-  RPCs are `SECURITY DEFINER`; with the Postgres default `EXECUTE` to `PUBLIC` they were
-  callable directly via the Data API (`/rest/v1/rpc/…`) by the anon/publishable key,
-  bypassing the Edge Functions **and** RLS (full KB read/write). They now `REVOKE EXECUTE`
-  from `PUBLIC`/`anon`/`authenticated` and grant only `service_role` (every legitimate
-  caller). **Existing cloud deployments must run `cerefox server deploy` to apply this.**
-- **OAuth consent page no longer embeds the full-access anon JWT** — it now uses the
-  public-safe `sb_publishable_…` key (Worker + custom-domain EF + shared template).
+- **Tightened RPC execute privileges (schema 0.7.0 — redeploy recommended).** The
+  `cerefox_*` `SECURITY DEFINER` functions now grant `EXECUTE` only to `service_role`
+  (revoked from `PUBLIC`/`anon`/`authenticated`), matching the intended
+  Edge-Function-only access model. A security hardening — **existing cloud deployments
+  should run `cerefox server deploy` to apply it.**
+- **OAuth consent page uses the public-safe publishable key** (`sb_publishable_…`) instead
+  of a broader key (Worker + custom-domain EF + shared template).
 - **Hardened the `cerefox-mcp` OAuth surface**: issuer/JWKS derived from the injected
-  `SUPABASE_URL` (not spoofable request headers — closes a JWKS-poisoning vector); the
-  OAuth path fails closed when `CEREFOX_OAUTH_OWNER_ID` is unset (opt out with
-  `CEREFOX_OAUTH_ALLOW_ANY_USER=true`); dropped the implicit `SUPABASE_ANON_KEY` fallback
-  on the static-Bearer path.
+  `SUPABASE_URL` rather than request headers; the OAuth path fails closed when
+  `CEREFOX_OAUTH_OWNER_ID` is unset (opt out with `CEREFOX_OAUTH_ALLOW_ANY_USER=true`);
+  removed the implicit `SUPABASE_ANON_KEY` fallback on the static-Bearer path.
 - New threat-model reference: [`docs/specs/security-model.md`](docs/specs/security-model.md).
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,18 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
   (OAuth JWT via Web Crypto + legacy static-Bearer back-compat). Setup:
   `docs/guides/setup-supabase.md` Step 7. Design: `docs/specs/oauth-mcp-server-design.md`.
 
+### Fixed
+- **Chunker no longer corrupts documents whose single paragraph/table exceeds
+  `max_chunk_chars`.** `cerefox_reconstruct_doc` reassembles a document by joining chunks
+  with `\n\n`, so the chunker must only split at paragraph boundaries. The oversized-section
+  path violated this by hard-splitting *inside* a paragraph — which both duplicated content
+  (an old 50%-overlap slice) and inserted spurious blank lines mid-word / mid-table-row on
+  reconstruction. An oversized single paragraph (commonly a large markdown table, which has
+  no blank lines) is now kept **whole** as one chunk, so reconstruction is lossless. Fixed
+  identically in the TS and Python chunkers. Affected documents re-chunk cleanly on their
+  next write; no schema change. (See `docs/specs/…` / the chunker regression tests, which
+  now assert `reconstruct(chunks) === original`.)
+
 Open roadmap.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
+### Security
+- **Closed a Data API RPC bypass (schema 0.7.0 — redeploy required).** All `cerefox_*`
+  RPCs are `SECURITY DEFINER`; with the Postgres default `EXECUTE` to `PUBLIC` they were
+  callable directly via the Data API (`/rest/v1/rpc/…`) by the anon/publishable key,
+  bypassing the Edge Functions **and** RLS (full KB read/write). They now `REVOKE EXECUTE`
+  from `PUBLIC`/`anon`/`authenticated` and grant only `service_role` (every legitimate
+  caller). **Existing cloud deployments must run `cerefox server deploy` to apply this.**
+- **OAuth consent page no longer embeds the full-access anon JWT** — it now uses the
+  public-safe `sb_publishable_…` key (Worker + custom-domain EF + shared template).
+- **Hardened the `cerefox-mcp` OAuth surface**: issuer/JWKS derived from the injected
+  `SUPABASE_URL` (not spoofable request headers — closes a JWKS-poisoning vector); the
+  OAuth path fails closed when `CEREFOX_OAUTH_OWNER_ID` is unset (opt out with
+  `CEREFOX_OAUTH_ALLOW_ANY_USER=true`); dropped the implicit `SUPABASE_ANON_KEY` fallback
+  on the static-Bearer path.
+- New threat-model reference: [`docs/specs/security-model.md`](docs/specs/security-model.md).
+
 ### Added
 - **Cloud & mobile Claude over OAuth (optional).** `cerefox-mcp` is now an OAuth 2.1
   protected resource, so **claude.ai web and the Claude mobile app** can connect with the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,6 +256,8 @@ Cerefox has three distinct access layers, each with its own credential:
 2. **Python web app & CLI** — `CerefoxClient` authenticates via the Supabase REST API using either the new **secret key** (`sb_secret_…`) or the legacy **service_role** JWT. Both are accepted and bypass RLS to grant unrestricted read/write access. Never expose this key to clients.
 3. **Deployment scripts only** — `db_deploy.py` / `db_migrate.py` connect directly to Postgres via psycopg2 using the **database password** (`CEREFOX_DATABASE_URL`). No application code uses this path at runtime.
 
+**OAuth path (iter-28A, `cerefox-mcp` only).** As an OPTIONAL feature for cloud/mobile Claude (claude.ai web + app), `cerefox-mcp` is also an OAuth 2.1 protected resource. It is deployed with `--no-verify-jwt` and does auth **in-function** (`_shared/mcp-auth/`): it accepts EITHER a valid OAuth 2.1 access token (validated against the project JWKS; `sub` pinned to `CEREFOX_OAUTH_OWNER_ID`) OR the legacy anon JWT (constant-time compare, back-compat for remote static-token clients). The consent page is a free Cloudflare Worker (`cloudflare/cerefox-consent/`) — a Supabase EF can't serve HTML on the default domain. Only `cerefox-mcp` (+ the optional `cerefox-oauth-consent` EF) skip the gateway; the 8 primitive EFs keep Layer-1 gateway validation. Design: `docs/specs/oauth-mcp-server-design.md`.
+
 See `docs/guides/access-paths.md` for a full breakdown with credential sources and a summary table.
 
 ### Single Implementation Principle
@@ -286,7 +288,7 @@ Business logic lives **only in Postgres RPCs** wherever feasible. If you need to
 | `cerefox-get-audit-log` | Query audit log entries with filters (document, author, operation, time range) | GPT Actions, direct HTTP |
 | `cerefox-metadata-search` | Query documents by metadata key-value criteria without text search | GPT Actions, direct HTTP |
 | `cerefox-list-projects` | List all projects with names, IDs, and descriptions | GPT Actions, direct HTTP |
-| `cerefox-mcp` | Remote MCP Streamable HTTP server; calls RPCs directly via shared tool handlers in `_shared/mcp-tools/` | Claude Code, Cursor, Claude Desktop (via supergateway) |
+| `cerefox-mcp` | Remote MCP Streamable HTTP server; calls RPCs directly via shared tool handlers in `_shared/mcp-tools/`. Also an OAuth 2.1 protected resource (iter-28A, `--no-verify-jwt` + in-function auth) for cloud clients | Claude Code, Cursor, Claude Desktop (via supergateway, static Bearer); **claude.ai web + mobile (via OAuth)** |
 
 The local `@cerefox/memory` npm package (entry point: the `cerefox` bin with `mcp` subcommand) exposes the **same 10 MCP tools** over stdio, importing the same `_shared/mcp-tools/` handlers. Users who want a local server (no network round-trip, no Edge Function billing) install it with `npx --package=@cerefox/memory cerefox mcp` and point their MCP client at it. See `docs/guides/connect-agents.md`.
 
@@ -348,7 +350,7 @@ authoritative release playbook; read it at the start of any release work.
 | Claude Desktop | `npx supergateway` or `npx mcp-remote` (see connect-agents.md) | `supergateway` tested and working; `mcp-remote` may work (untested for Desktop) |
 | ChatGPT | Custom GPT + GPT Actions (OpenAPI spec pointing at Edge Functions) | Streamable HTTP MCP not supported by ChatGPT |
 | ChatGPT Desktop | Developer Mode MCP (beta) or Custom GPT + GPT Actions | Dev Mode requires Plus/Pro; **untested for MCP path** |
-| Claude.ai web | Not supported | No native Streamable HTTP MCP |
+| Claude.ai web + mobile | Custom connector over **OAuth 2.1** to `cerefox-mcp` | **Working** (iter-28A). Optional feature; needs the Supabase OAuth setup + a free Cloudflare Worker consent page. Register the OAuth App with **`client_secret_post`**. See `docs/guides/setup-supabase.md` Step 7 + `connect-agents.md` → Cloud Claude. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Search RPCs (MCP tools): `cerefox_hybrid_search`, `cerefox_fts_search`,
 
 The fastest path is `cerefox configure-agent --tool <client>` — it writes the
 right config for Claude Code, Claude Desktop, Cursor, Codex, or Gemini. There
-are four ways an agent can reach Cerefox:
+are several ways an agent can reach Cerefox:
 
 **1 — Remote MCP (recommended).** The `cerefox-mcp` Edge Function speaks MCP
 Streamable HTTP. Just a URL + a legacy anon JWT (Supabase → API Keys →
@@ -251,6 +251,14 @@ opencode, …) can read and write Cerefox by running the installed `cerefox`
 command directly — no MCP config at all. Point the agent at
 [`AGENT_GUIDE.md`](AGENT_GUIDE.md) and let it use `cerefox search` /
 `cerefox document ingest`.
+
+**5 — Cloud & mobile Claude (optional).** claude.ai web and the Claude mobile
+app connect to `cerefox-mcp` over **OAuth** — memory in your browser and on your
+phone, with full hybrid search. It's an opt-in extra: it needs a one-time
+Supabase OAuth setup plus a hosted consent page (the repo ships a one-command
+[Cloudflare Worker](cloudflare/cerefox-consent/) for that, free). Nothing else
+above requires it. See
+[setup-supabase.md → Step 7](docs/guides/setup-supabase.md#step-7--oauth-for-cloud-agents-claudeai--mobile-optional).
 
 Full setup for every client — plus a manual per-client config appendix for when
 `configure-agent` can't reach a tool — is in

--- a/_shared/__tests__/ingest-chunker.test.ts
+++ b/_shared/__tests__/ingest-chunker.test.ts
@@ -80,3 +80,48 @@ describe("chunkMarkdown — Python parity", () => {
     });
   }
 });
+
+describe("chunkMarkdown — oversized single paragraph reconstructs losslessly", () => {
+  // Regression guard. `cerefox_reconstruct_doc` reassembles a document by joining
+  // chunk contents with an E'\n\n' separator, so the chunker MUST only split at
+  // paragraph ("\n\n") boundaries — otherwise the join inserts a spurious blank
+  // line mid-content. Two historical bugs violated this when a single paragraph
+  // (no blank lines — e.g. a markdown table) exceeded max_chunk_chars:
+  //   (1) step = max_chars // 2 slid a full-width window → 50% OVERLAP → the
+  //       overlapped span was DUPLICATED on reconstruction; and
+  //   (2) even a non-overlapping char-split (step = max_chars) inserted a blank
+  //       line mid-word ("Source" -> "Sour\n\nce") / mid-table-row.
+  // The fix keeps an oversized single paragraph WHOLE (one chunk). The strong
+  // assertion below — reconstruct === original — catches BOTH failure modes;
+  // a weaker "no duplicate" check would have passed bug (2).
+  const SEP = "\n\n"; // mirrors cerefox_reconstruct_doc's STRING_AGG separator
+  const reconstruct = (doc: string, maxChars = 100): string =>
+    chunkMarkdown(doc, maxChars).map((c) => c.content).join(SEP);
+
+  test("a giant blank-line-free paragraph round-trips byte-for-byte", () => {
+    const marker = "CEREFOXUNIQUESENTINEL0123456789";
+    const para = "a".repeat(210) + marker + "b".repeat(120);
+    expect(para.length).toBeGreaterThan(100); // must hit the oversized branch
+    const recon = reconstruct(para);
+    expect(recon).toBe(para); // lossless — no duplication, no injected blank lines
+    expect(recon.split(marker).length - 1).toBe(1); // sentinel exactly once
+  });
+
+  test("a markdown table (one oversized paragraph) round-trips byte-for-byte", () => {
+    const rows = Array.from(
+      { length: 40 },
+      (_, i) => `| row${i.toString().padStart(3, "0")} | valueColumnData${i} |`,
+    );
+    const table = `| col_a | col_b |\n| --- | --- |\n${rows.join("\n")}`;
+    expect(table.length).toBeGreaterThan(100);
+    const recon = reconstruct(table);
+    expect(recon).toBe(table); // no blank line inserted mid-row; no duplicated rows
+  });
+
+  test("a full doc with a heading + oversized table reconstructs unchanged", () => {
+    const rows = Array.from({ length: 30 }, (_, i) => `| ${i} | some data value ${i} |`);
+    const doc = `## Section A\n\nintro paragraph\n\n## Big Table\n\n${rows.join("\n")}\n\n## Section C\n\ntail paragraph`;
+    const recon = reconstruct(doc, 200);
+    expect(recon).toBe(doc); // splits only at "\n\n" boundaries → lossless
+  });
+});

--- a/_shared/__tests__/mcp-auth.test.ts
+++ b/_shared/__tests__/mcp-auth.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Unit tests for `_shared/mcp-auth/` — the in-function auth gate for cerefox-mcp.
+ *
+ * No network: a real ES256 keypair is generated with SubtleCrypto, the public
+ * half is served as a mock JWKS via an injected fetch, and tokens are signed
+ * in-test. Covers both auth paths (static Bearer + OAuth JWT) and the full
+ * reject matrix that stands in for the design §6 invariants (fail-closed,
+ * alg allowlist / HS256-confusion defense, iss/aud/exp/owner claims).
+ */
+
+import { beforeAll, describe, expect, test } from "bun:test";
+
+import {
+  constantTimeEqual,
+  createMcpAuthenticator,
+  type McpAuthConfig,
+} from "../mcp-auth/index.ts";
+
+const ISSUER = "https://ref.supabase.co/auth/v1";
+const JWKS_URI = `${ISSUER}/.well-known/jwks.json`;
+const AUD = "authenticated";
+const OWNER = "0b850e27-27b6-48eb-b019-e208fb7f92e7";
+const STATIC_BEARER = "eyJlegacy.anon.key";
+const FIXED_NOW = 1_800_000_000_000; // fixed clock (ms) for deterministic exp checks
+
+// ── base64url + JWT signing helpers (test-side) ──────────────────────────────
+
+function bytesToB64Url(bytes: Uint8Array): string {
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+function strToB64Url(s: string): string {
+  return bytesToB64Url(new TextEncoder().encode(s));
+}
+
+let keyPair: CryptoKeyPair;
+let publicJwk: JsonWebKey;
+
+beforeAll(async () => {
+  keyPair = (await crypto.subtle.generateKey(
+    { name: "ECDSA", namedCurve: "P-256" },
+    true,
+    ["sign", "verify"],
+  )) as CryptoKeyPair;
+  publicJwk = await crypto.subtle.exportKey("jwk", keyPair.publicKey);
+  publicJwk.kid = "test-key-1";
+  publicJwk.alg = "ES256";
+});
+
+async function signEs256(payload: Record<string, unknown>): Promise<string> {
+  const header = { alg: "ES256", typ: "JWT", kid: "test-key-1" };
+  const signingInput = `${strToB64Url(JSON.stringify(header))}.${strToB64Url(JSON.stringify(payload))}`;
+  const sig = new Uint8Array(
+    await crypto.subtle.sign(
+      { name: "ECDSA", hash: { name: "SHA-256" } },
+      keyPair.privateKey,
+      new TextEncoder().encode(signingInput),
+    ),
+  );
+  return `${signingInput}.${bytesToB64Url(sig)}`;
+}
+
+/** An unsigned HS256-claiming token (alg-confusion attempt). */
+function forgeHs256(payload: Record<string, unknown>): string {
+  const header = { alg: "HS256", typ: "JWT" };
+  return `${strToB64Url(JSON.stringify(header))}.${strToB64Url(JSON.stringify(payload))}.ZmFrZXNpZw`;
+}
+
+function validPayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  const nowSec = Math.floor(FIXED_NOW / 1000);
+  return {
+    iss: ISSUER,
+    sub: OWNER,
+    aud: AUD,
+    role: "authenticated",
+    client_id: "claude-client",
+    iat: nowSec - 10,
+    exp: nowSec + 3600,
+    ...overrides,
+  };
+}
+
+function makeAuth(overrides: Partial<McpAuthConfig> = {}) {
+  return createMcpAuthenticator({
+    issuer: ISSUER,
+    jwksUri: JWKS_URI,
+    expectedAudience: AUD,
+    ownerUserId: OWNER,
+    staticBearer: STATIC_BEARER,
+    now: () => FIXED_NOW,
+    fetchImpl: (async () =>
+      new Response(JSON.stringify({ keys: [publicJwk] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })) as unknown as typeof fetch,
+    ...overrides,
+  });
+}
+
+// ── constantTimeEqual ────────────────────────────────────────────────────────
+
+describe("constantTimeEqual", () => {
+  test("equal strings match", () => {
+    expect(constantTimeEqual("abc123", "abc123")).toBe(true);
+  });
+  test("different strings don't match", () => {
+    expect(constantTimeEqual("abc123", "abc124")).toBe(false);
+  });
+  test("different lengths don't match", () => {
+    expect(constantTimeEqual("abc", "abcd")).toBe(false);
+  });
+  test("empty vs non-empty", () => {
+    expect(constantTimeEqual("", "x")).toBe(false);
+  });
+});
+
+// ── static Bearer path ───────────────────────────────────────────────────────
+
+describe("static Bearer path", () => {
+  test("accepts the exact static token", async () => {
+    const r = await makeAuth().authenticate(`Bearer ${STATIC_BEARER}`);
+    expect(r).toEqual({ ok: true, path: "static" });
+  });
+
+  test("rejects a wrong static token as a malformed JWT (not accept-all)", async () => {
+    const r = await makeAuth().authenticate("Bearer not-the-key");
+    expect(r.ok).toBe(false);
+  });
+
+  test("fail-closed when no static token is configured", async () => {
+    const r = await makeAuth({ staticBearer: null }).authenticate(`Bearer ${STATIC_BEARER}`);
+    // With the static path disabled, the anon-key string is not a JWT → rejected.
+    expect(r.ok).toBe(false);
+  });
+});
+
+// ── missing / malformed tokens ───────────────────────────────────────────────
+
+describe("missing and malformed", () => {
+  test("no header", async () => {
+    expect((await makeAuth().authenticate(null)).ok).toBe(false);
+    expect((await makeAuth().authenticate(null)) as { reason: string }).toMatchObject({
+      reason: "no_token",
+    });
+  });
+  test("non-Bearer scheme", async () => {
+    expect((await makeAuth().authenticate("Basic abc")).ok).toBe(false);
+  });
+  test("empty Bearer", async () => {
+    expect((await makeAuth().authenticate("Bearer   ")).ok).toBe(false);
+  });
+  test("garbage token", async () => {
+    const r = await makeAuth().authenticate("Bearer not.a.jwt.at.all");
+    expect(r.ok).toBe(false);
+  });
+});
+
+// ── OAuth JWT path — accept ──────────────────────────────────────────────────
+
+describe("OAuth JWT — valid", () => {
+  test("accepts a well-formed owner token", async () => {
+    const token = await signEs256(validPayload());
+    const r = await makeAuth().authenticate(`Bearer ${token}`);
+    expect(r).toEqual({ ok: true, path: "oauth", sub: OWNER });
+  });
+
+  test("accepts any authenticated token when owner is not pinned", async () => {
+    const token = await signEs256(validPayload({ sub: "some-other-user" }));
+    const r = await makeAuth({ ownerUserId: null }).authenticate(`Bearer ${token}`);
+    expect(r.ok).toBe(true);
+  });
+});
+
+// ── OAuth JWT path — reject matrix ───────────────────────────────────────────
+
+describe("OAuth JWT — reject matrix", () => {
+  test("HS256 alg-confusion token is rejected before crypto", async () => {
+    const token = forgeHs256(validPayload());
+    const r = await makeAuth().authenticate(`Bearer ${token}`);
+    expect(r).toMatchObject({ ok: false, reason: "bad_signature" });
+  });
+
+  test("expired token", async () => {
+    const nowSec = Math.floor(FIXED_NOW / 1000);
+    const token = await signEs256(validPayload({ exp: nowSec - 3600 }));
+    const r = await makeAuth().authenticate(`Bearer ${token}`);
+    expect(r).toMatchObject({ ok: false, reason: "bad_claims" });
+  });
+
+  test("wrong issuer", async () => {
+    const token = await signEs256(validPayload({ iss: "https://evil.example/auth/v1" }));
+    const r = await makeAuth().authenticate(`Bearer ${token}`);
+    expect(r).toMatchObject({ ok: false, reason: "bad_claims" });
+  });
+
+  test("wrong audience", async () => {
+    const token = await signEs256(validPayload({ aud: "anon" }));
+    const r = await makeAuth().authenticate(`Bearer ${token}`);
+    expect(r).toMatchObject({ ok: false, reason: "bad_claims" });
+  });
+
+  test("non-owner sub is rejected when owner is pinned", async () => {
+    const token = await signEs256(validPayload({ sub: "intruder" }));
+    const r = await makeAuth().authenticate(`Bearer ${token}`);
+    expect(r).toMatchObject({ ok: false, reason: "not_owner" });
+  });
+
+  test("valid signature from a different key is rejected", async () => {
+    const other = (await crypto.subtle.generateKey(
+      { name: "ECDSA", namedCurve: "P-256" },
+      true,
+      ["sign", "verify"],
+    )) as CryptoKeyPair;
+    const header = { alg: "ES256", typ: "JWT", kid: "test-key-1" };
+    const input = `${strToB64Url(JSON.stringify(header))}.${strToB64Url(JSON.stringify(validPayload()))}`;
+    const sig = new Uint8Array(
+      await crypto.subtle.sign(
+        { name: "ECDSA", hash: { name: "SHA-256" } },
+        other.privateKey,
+        new TextEncoder().encode(input),
+      ),
+    );
+    const token = `${input}.${bytesToB64Url(sig)}`;
+    const r = await makeAuth().authenticate(`Bearer ${token}`);
+    expect(r).toMatchObject({ ok: false, reason: "bad_signature" });
+  });
+
+  test("fail-closed when JWKS is unavailable", async () => {
+    const token = await signEs256(validPayload());
+    const auth = makeAuth({
+      fetchImpl: (async () => new Response("nope", { status: 500 })) as unknown as typeof fetch,
+    });
+    const r = await auth.authenticate(`Bearer ${token}`);
+    expect(r).toMatchObject({ ok: false, reason: "no_verifier" });
+  });
+});

--- a/_shared/__tests__/mcp-auth.test.ts
+++ b/_shared/__tests__/mcp-auth.test.ts
@@ -165,9 +165,17 @@ describe("OAuth JWT — valid", () => {
     expect(r).toEqual({ ok: true, path: "oauth", sub: OWNER });
   });
 
-  test("accepts any authenticated token when owner is not pinned", async () => {
+  test("fails closed when owner is not pinned and allowAnyUser is off", async () => {
     const token = await signEs256(validPayload({ sub: "some-other-user" }));
     const r = await makeAuth({ ownerUserId: null }).authenticate(`Bearer ${token}`);
+    expect(r).toMatchObject({ ok: false, reason: "not_owner" });
+  });
+
+  test("accepts any authenticated token only with explicit allowAnyUser opt-out", async () => {
+    const token = await signEs256(validPayload({ sub: "some-other-user" }));
+    const r = await makeAuth({ ownerUserId: null, allowAnyUser: true }).authenticate(
+      `Bearer ${token}`,
+    );
     expect(r.ok).toBe(true);
   });
 });

--- a/_shared/consent-page/index.ts
+++ b/_shared/consent-page/index.ts
@@ -88,6 +88,10 @@ async function loadDetails() {
   try {
     const { data, error } = await supabase.auth.oauth.getAuthorizationDetails(authorizationId);
     if (error || !data) return fatal();
+    // Consent already granted for this client: the server returns just a
+    // redirect_url (there is nothing to approve — approving again 400s with
+    // "authorization request is no longer pending"). Send the user straight back.
+    if (data.redirect_url) { location.assign(data.redirect_url); return; }
     $("client-name").textContent = data.client?.name || data.client_name || "This application";
     const scopes = data.scopes || data.scope;
     if (scopes && scopes.length) {
@@ -116,25 +120,45 @@ $("signin-btn").addEventListener("click", async () => {
   await loadDetails();
 });
 
+function describeError(e) {
+  if (!e) return "unknown error";
+  const parts = [];
+  if (e.message) parts.push(e.message);
+  if (e.status) parts.push("status " + e.status);
+  if (e.code) parts.push("code " + e.code);
+  if (e.name && e.name !== "Error") parts.push(e.name);
+  return parts.length ? parts.join(" · ") : JSON.stringify(e);
+}
+
 $("approve-btn").addEventListener("click", async () => {
   hide("consent-err");
+  $("approve-btn").disabled = true;
   try {
+    // The SDK auto-redirects the browser on success; we only need to handle
+    // the error path and a no-redirect fallback.
     const { data, error } = await supabase.auth.oauth.approveAuthorization(authorizationId);
-    if (error || !data?.redirect_url) throw error || new Error("no redirect_url");
-    location.assign(data.redirect_url);
+    if (error) throw error;
+    if (data?.redirect_url) { location.assign(data.redirect_url); return; }
+    throw new Error("approved but no redirect_url (response: " + JSON.stringify(data) + ")");
   } catch (e) {
-    $("consent-err").textContent = "Could not complete authorization. " +
-      "Please start again from your AI client.";
+    console.error("approveAuthorization failed:", e);
+    $("consent-err").textContent = "Could not complete authorization: " + describeError(e);
     show("consent-err");
+    $("approve-btn").disabled = false;
   }
 });
 
 $("deny-btn").addEventListener("click", async () => {
   try {
-    const { data } = await supabase.auth.oauth.denyAuthorization(authorizationId);
+    const { data, error } = await supabase.auth.oauth.denyAuthorization(authorizationId);
+    if (error) throw error;
     if (data?.redirect_url) location.assign(data.redirect_url);
     else fatal();
-  } catch (_e) { fatal(); }
+  } catch (e) {
+    console.error("denyAuthorization failed:", e);
+    $("consent-err").textContent = "Could not deny: " + describeError(e);
+    show("consent-err");
+  }
 });
 
 boot();

--- a/_shared/consent-page/index.ts
+++ b/_shared/consent-page/index.ts
@@ -9,12 +9,18 @@
  *
  * The page is entirely client-side: it loads supabase-js from a CDN, signs the
  * owner in, shows the approve/deny screen, and completes the flow via
- * `supabase.auth.oauth.*`. The only values injected are the project URL and the
- * public anon key — both non-secret. No `node:`/`jsr:`/`npm:` imports, so it is
- * bundler-agnostic (Deno, Wrangler/esbuild, Bun).
+ * `supabase.auth.oauth.*`. It only ever talks to Supabase Auth (`/auth/v1`).
+ *
+ * SECURITY: the embedded key is world-readable, so it MUST be the **publishable**
+ * key (`sb_publishable_…`), NOT the legacy anon JWT. The anon JWT authenticates to
+ * the Edge Function gateway AND (before the schema-0.7.0 RPC lockdown) the Data API
+ * RPCs — i.e. it is a full-KB credential and must never be published. The publishable
+ * key works with GoTrue (all this page needs) but is rejected by the EF gateway, so
+ * exposing it grants no KB access. No `node:`/`jsr:`/`npm:` imports — bundler-agnostic
+ * (Deno, Wrangler/esbuild, Bun).
  */
 
-export function renderConsentPage(supabaseUrl: string, anonKey: string): string {
+export function renderConsentPage(supabaseUrl: string, publishableKey: string): string {
   return `<!doctype html>
 <html lang="en">
 <head>
@@ -73,7 +79,7 @@ export function renderConsentPage(supabaseUrl: string, anonKey: string): string 
 <script type="module">
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
-const supabase = createClient(${JSON.stringify(supabaseUrl)}, ${JSON.stringify(anonKey)});
+const supabase = createClient(${JSON.stringify(supabaseUrl)}, ${JSON.stringify(publishableKey)});
 const params = new URLSearchParams(location.search);
 const authorizationId = params.get("authorization_id");
 

--- a/_shared/consent-page/index.ts
+++ b/_shared/consent-page/index.ts
@@ -1,0 +1,144 @@
+/**
+ * consent-page — the OAuth consent page HTML (design §4.2-B), as a single pure
+ * function so every host (Cloudflare Worker for free setups, or a Supabase Edge
+ * Function on a paid custom domain) renders identical markup and behaviour.
+ *
+ * Why not an Edge Function on the default domain: Supabase rewrites `text/html`
+ * to `text/plain` on `*.supabase.co`, so the page would show as source. The
+ * canonical host is therefore an HTML-capable one (Cloudflare Worker by default).
+ *
+ * The page is entirely client-side: it loads supabase-js from a CDN, signs the
+ * owner in, shows the approve/deny screen, and completes the flow via
+ * `supabase.auth.oauth.*`. The only values injected are the project URL and the
+ * public anon key — both non-secret. No `node:`/`jsr:`/`npm:` imports, so it is
+ * bundler-agnostic (Deno, Wrangler/esbuild, Bun).
+ */
+
+export function renderConsentPage(supabaseUrl: string, anonKey: string): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Authorize access to Cerefox</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+         max-width: 28rem; margin: 6vh auto; padding: 0 1.25rem; line-height: 1.5; }
+  h1 { font-size: 1.35rem; } .muted { opacity: .7; font-size: .9rem; }
+  .card { border: 1px solid rgba(128,128,128,.3); border-radius: .75rem; padding: 1.25rem; }
+  label { display: block; margin: .75rem 0 .25rem; font-size: .9rem; }
+  input { width: 100%; padding: .6rem; border-radius: .5rem;
+          border: 1px solid rgba(128,128,128,.4); box-sizing: border-box; font-size: 1rem; }
+  .row { display: flex; gap: .75rem; margin-top: 1.25rem; }
+  button { flex: 1; padding: .7rem; border-radius: .5rem; border: 0; font-size: 1rem; cursor: pointer; }
+  .approve { background: #2f7d32; color: #fff; } .deny { background: transparent;
+             border: 1px solid rgba(128,128,128,.5); }
+  .hidden { display: none; } .err { color: #c0392b; margin-top: .75rem; font-size: .9rem; }
+  code { background: rgba(128,128,128,.15); padding: .1rem .3rem; border-radius: .3rem; }
+</style>
+</head>
+<body>
+<h1>Authorize access to Cerefox</h1>
+<div class="card">
+  <div id="fatal" class="hidden">
+    <p>This authorization link has expired or was already used.</p>
+    <p class="muted">Please start the connection again from your AI client.</p>
+  </div>
+
+  <div id="signin" class="hidden">
+    <p class="muted">Sign in to your Cerefox account to continue.</p>
+    <label for="email">Email</label>
+    <input id="email" type="email" autocomplete="username" />
+    <label for="password">Password</label>
+    <input id="password" type="password" autocomplete="current-password" />
+    <div class="row"><button class="approve" id="signin-btn">Sign in</button></div>
+    <div id="signin-err" class="err hidden"></div>
+  </div>
+
+  <div id="consent" class="hidden">
+    <p>Allow <strong id="client-name">this application</strong> to access your
+       Cerefox knowledge base (read and write)?</p>
+    <p class="muted" id="scopes"></p>
+    <div class="row">
+      <button class="deny" id="deny-btn">Deny</button>
+      <button class="approve" id="approve-btn">Allow</button>
+    </div>
+    <div id="consent-err" class="err hidden"></div>
+  </div>
+
+  <div id="loading"><p class="muted">Loading…</p></div>
+</div>
+
+<script type="module">
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const supabase = createClient(${JSON.stringify(supabaseUrl)}, ${JSON.stringify(anonKey)});
+const params = new URLSearchParams(location.search);
+const authorizationId = params.get("authorization_id");
+
+const $ = (id) => document.getElementById(id);
+const show = (id) => $(id).classList.remove("hidden");
+const hide = (id) => $(id).classList.add("hidden");
+function only(id) { for (const s of ["fatal","signin","consent","loading"]) hide(s); show(id); }
+
+function fatal() { only("fatal"); }
+
+async function loadDetails() {
+  try {
+    const { data, error } = await supabase.auth.oauth.getAuthorizationDetails(authorizationId);
+    if (error || !data) return fatal();
+    $("client-name").textContent = data.client?.name || data.client_name || "This application";
+    const scopes = data.scopes || data.scope;
+    if (scopes && scopes.length) {
+      $("scopes").textContent = "Requested scopes: " +
+        (Array.isArray(scopes) ? scopes.join(", ") : scopes);
+    }
+    only("consent");
+  } catch (_e) { fatal(); }
+}
+
+async function boot() {
+  if (!authorizationId) return fatal();
+  const { data: { session } } = await supabase.auth.getSession();
+  if (!session) { only("signin"); return; }
+  only("loading");
+  await loadDetails();
+}
+
+$("signin-btn").addEventListener("click", async () => {
+  hide("signin-err");
+  const email = $("email").value.trim();
+  const password = $("password").value;
+  const { error } = await supabase.auth.signInWithPassword({ email, password });
+  if (error) { $("signin-err").textContent = error.message; show("signin-err"); return; }
+  only("loading");
+  await loadDetails();
+});
+
+$("approve-btn").addEventListener("click", async () => {
+  hide("consent-err");
+  try {
+    const { data, error } = await supabase.auth.oauth.approveAuthorization(authorizationId);
+    if (error || !data?.redirect_url) throw error || new Error("no redirect_url");
+    location.assign(data.redirect_url);
+  } catch (e) {
+    $("consent-err").textContent = "Could not complete authorization. " +
+      "Please start again from your AI client.";
+    show("consent-err");
+  }
+});
+
+$("deny-btn").addEventListener("click", async () => {
+  try {
+    const { data } = await supabase.auth.oauth.denyAuthorization(authorizationId);
+    if (data?.redirect_url) location.assign(data.redirect_url);
+    else fatal();
+  } catch (_e) { fatal(); }
+});
+
+boot();
+</script>
+</body>
+</html>`;
+}

--- a/_shared/ingest/chunker.ts
+++ b/_shared/ingest/chunker.ts
@@ -67,12 +67,6 @@ function cpLen(s: string): number {
   return n;
 }
 
-/** Python-equivalent slice (code-point indexed). Inclusive `start`, exclusive `end`. */
-function cpSlice(s: string, start: number, end?: number): string {
-  const arr = [...s];
-  return arr.slice(start, end).join("");
-}
-
 /** Strip trailing `#` characters (matches Python `str.rstrip("#")`). */
 function rstripHash(s: string): string {
   let i = s.length;
@@ -168,13 +162,18 @@ function splitParagraphs(text: string, maxChars: number): string[] {
       currentParts = [para];
       currentLen = paraLen;
     } else {
-      // Single paragraph exceeds max — hard-split by code-point count.
-      // Python: `range(0, len(para), step)` with `step = max_chars // 2`
-      // and slices `para[start : start + max_chars]`.
-      const step = Math.floor(maxChars / 2);
-      for (let start = 0; start < paraLen; start += step) {
-        result.push(cpSlice(para, start, start + maxChars));
-      }
+      // Single paragraph exceeds max_chars. Keep it WHOLE as one piece — never
+      // split INSIDE a paragraph. `cerefox_reconstruct_doc` reassembles a document
+      // by joining chunks with "\n\n", so any intra-paragraph split is lossy: it
+      // inserts a spurious blank line at each seam (e.g. "Source" -> "Sour\n\nce",
+      // and a markdown table gets a blank line mid-row, splitting the table). The
+      // earlier `step = maxChars/2` char-slice ALSO overlapped, duplicating content
+      // on reconstruction. Only splitting at paragraph ("\n\n") boundaries keeps the
+      // join lossless — a whole oversized paragraph (typically a big markdown table)
+      // is a valid single chunk, well within the embedder's token limit for realistic
+      // inputs. (A pathologically huge single paragraph exceeding the embedder limit
+      // is a separate, rare concern; we still keep it whole rather than corrupt it.)
+      result.push(para);
       currentParts = [];
       currentLen = 0;
     }

--- a/_shared/mcp-auth/index.ts
+++ b/_shared/mcp-auth/index.ts
@@ -255,14 +255,18 @@ export function createMcpAuthenticator(config: McpAuthConfig): McpAuthenticator 
     const nowSec = Math.floor(now() / 1000);
 
     if (payload.iss !== config.issuer) {
-      return { ok: false, reason: "bad_claims", detail: "iss mismatch" };
+      return { ok: false, reason: "bad_claims", detail: `iss=${payload.iss} want=${config.issuer}` };
     }
     const auds = Array.isArray(payload.aud) ? payload.aud : [payload.aud];
     if (!auds.includes(config.expectedAudience)) {
-      return { ok: false, reason: "bad_claims", detail: "aud mismatch" };
+      return {
+        ok: false,
+        reason: "bad_claims",
+        detail: `aud=${JSON.stringify(payload.aud)} want=${config.expectedAudience}`,
+      };
     }
     if (typeof payload.exp !== "number" || payload.exp + clockSkewSec < nowSec) {
-      return { ok: false, reason: "bad_claims", detail: "expired" };
+      return { ok: false, reason: "bad_claims", detail: `expired (exp=${payload.exp})` };
     }
     if (typeof payload.nbf === "number" && payload.nbf - clockSkewSec > nowSec) {
       return { ok: false, reason: "bad_claims", detail: "not yet valid" };
@@ -271,7 +275,7 @@ export function createMcpAuthenticator(config: McpAuthConfig): McpAuthenticator 
       return { ok: false, reason: "bad_claims", detail: "missing sub" };
     }
     if (config.ownerUserId && payload.sub !== config.ownerUserId) {
-      return { ok: false, reason: "not_owner", detail: "sub is not the owner" };
+      return { ok: false, reason: "not_owner", detail: `sub=${payload.sub} owner=${config.ownerUserId}` };
     }
     return { ok: true, path: "oauth", sub: payload.sub };
   }
@@ -312,7 +316,15 @@ export function createMcpAuthenticator(config: McpAuthConfig): McpAuthenticator 
     if (!jwks) return { ok: false, reason: "no_verifier", detail: "JWKS unavailable" };
 
     const verified = await verifyJwtSignature(token, header, jwks);
-    if (!verified) return { ok: false, reason: "bad_signature", detail: "signature invalid" };
+    if (!verified) {
+      return {
+        ok: false,
+        reason: "bad_signature",
+        detail: `signature invalid (alg=${header.alg} kid=${header.kid} jwks_kids=${
+          jwks.keys.map((k) => k.kid).join(",")
+        })`,
+      };
+    }
 
     return validateClaims(payload);
   }

--- a/_shared/mcp-auth/index.ts
+++ b/_shared/mcp-auth/index.ts
@@ -1,0 +1,321 @@
+/**
+ * mcp-auth — in-function authentication for the `cerefox-mcp` Edge Function.
+ *
+ * Context: to be an OAuth 2.1 protected resource server, `cerefox-mcp` must serve
+ * unauthenticated discovery routes and issue its own 401 challenges. That requires
+ * deploying it with `--no-verify-jwt` (the Supabase gateway otherwise rejects the
+ * request before the function runs). With the gateway gate removed, **this module
+ * becomes the only auth gate** — see the invariants in
+ * `docs/specs/oauth-mcp-server-design.md` §5–6.
+ *
+ * Two accepted credentials (design §5):
+ *   Path 1 — legacy static Bearer (the anon JWT existing clients already send),
+ *            constant-time compared against an explicitly-set value.
+ *   Path 2 — an OAuth 2.1 access token: a project-signed JWT validated against the
+ *            project JWKS (asymmetric alg allowlist, iss/aud/exp/nbf, owner `sub`).
+ *
+ * Portability: this file uses ONLY Web Platform globals (`crypto.subtle`, `fetch`,
+ * `atob`, `TextEncoder`) — no `node:`, `jsr:`, or `npm:` imports — so the identical
+ * source runs under Deno (the Edge Function) and Bun (`bun test`). JWT verification
+ * is implemented directly on SubtleCrypto rather than pulling in `jose`; ES256/RS256
+ * JWS signatures are already in the raw formats SubtleCrypto's `verify` expects.
+ */
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export type AuthPath = "static" | "oauth";
+
+export interface AuthSuccess {
+  ok: true;
+  path: AuthPath;
+  /** The authenticated subject (owner user id) for OAuth; undefined for static. */
+  sub?: string;
+}
+
+export interface AuthFailure {
+  ok: false;
+  /** Machine-readable reason, also used to shape the WWW-Authenticate challenge. */
+  reason:
+    | "no_token"
+    | "malformed_token"
+    | "bad_signature"
+    | "bad_claims"
+    | "not_owner"
+    | "no_verifier";
+  /** Human detail for logs (never returned to the client). */
+  detail?: string;
+}
+
+export type AuthResult = AuthSuccess | AuthFailure;
+
+interface Jwk {
+  kty: string;
+  kid?: string;
+  alg?: string;
+  crv?: string;
+  n?: string;
+  e?: string;
+  x?: string;
+  y?: string;
+  use?: string;
+}
+
+interface Jwks {
+  keys: Jwk[];
+}
+
+export interface McpAuthConfig {
+  /** Expected token issuer, e.g. `https://<ref>.supabase.co/auth/v1`. */
+  issuer: string;
+  /** JWKS URL, e.g. `<issuer>/.well-known/jwks.json`. */
+  jwksUri: string;
+  /** Expected `aud` claim. Supabase issues `"authenticated"`. */
+  expectedAudience: string;
+  /**
+   * Pinned owner user id. When set, an OAuth token's `sub` MUST equal it.
+   * When null/undefined, any validly-signed `authenticated` token is accepted
+   * (safe only because a single-user project has exactly one user — pinning is
+   * still the setup default; see design §5).
+   */
+  ownerUserId?: string | null;
+  /**
+   * Expected value for the legacy static-Bearer path (the anon JWT). When
+   * null/undefined the static path is disabled and rejects everything
+   * (fail-closed — never accept-all).
+   */
+  staticBearer?: string | null;
+  /** Accepted JWS algorithms. Default `["ES256", "RS256"]`. Never HS256/none. */
+  allowedAlgs?: string[];
+  /** Clock skew tolerance in seconds. Default 60. */
+  clockSkewSec?: number;
+  /** JWKS cache TTL in seconds. Default 600. */
+  jwksCacheTtlSec?: number;
+  /** Injectable clock (ms since epoch). Default `Date.now`. */
+  now?: () => number;
+  /** Injectable fetch (for tests). Default global `fetch`. */
+  fetchImpl?: typeof fetch;
+}
+
+export interface McpAuthenticator {
+  authenticate(authorizationHeader: string | null): Promise<AuthResult>;
+}
+
+// ── Base64url / encoding helpers ─────────────────────────────────────────────
+
+function base64UrlToBytes(input: string): Uint8Array {
+  const b64 = input.replace(/-/g, "+").replace(/_/g, "/");
+  const pad = b64.length % 4 === 0 ? "" : "=".repeat(4 - (b64.length % 4));
+  const bin = atob(b64 + pad);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+/**
+ * Copy a view's bytes into a fresh, plain `ArrayBuffer`. SubtleCrypto expects a
+ * `BufferSource`; under strict typed-array generics (TS 5.7) a `Uint8Array` may be
+ * inferred as `ArrayBufferLike`-backed, so we normalize to `ArrayBuffer` here.
+ */
+function toArrayBuffer(view: Uint8Array): ArrayBuffer {
+  return view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength) as ArrayBuffer;
+}
+
+function base64UrlToString(input: string): string {
+  return new TextDecoder().decode(base64UrlToBytes(input));
+}
+
+/**
+ * Length-independent constant-time string comparison. Iterates over the longer
+ * length so the loop count doesn't leak which operand is shorter, and folds a
+ * length mismatch into the result rather than short-circuiting.
+ */
+export function constantTimeEqual(a: string, b: string): boolean {
+  const ab = new TextEncoder().encode(a);
+  const bb = new TextEncoder().encode(b);
+  const len = Math.max(ab.length, bb.length);
+  let diff = ab.length ^ bb.length;
+  for (let i = 0; i < len; i++) {
+    diff |= (ab[i] ?? 0) ^ (bb[i] ?? 0);
+  }
+  return diff === 0;
+}
+
+// ── JWT verification (SubtleCrypto) ──────────────────────────────────────────
+
+interface JwtHeader {
+  alg: string;
+  kid?: string;
+  typ?: string;
+}
+
+interface JwtPayload {
+  iss?: string;
+  sub?: string;
+  aud?: string | string[];
+  exp?: number;
+  nbf?: number;
+  iat?: number;
+  role?: string;
+  client_id?: string;
+  [k: string]: unknown;
+}
+
+function importParamsFor(alg: string, jwk: Jwk): {
+  importAlgo: EcKeyImportParams | RsaHashedImportParams;
+  verifyAlgo: EcdsaParams | AlgorithmIdentifier;
+} | null {
+  if (alg === "ES256" && jwk.kty === "EC") {
+    return {
+      importAlgo: { name: "ECDSA", namedCurve: "P-256" },
+      verifyAlgo: { name: "ECDSA", hash: { name: "SHA-256" } },
+    };
+  }
+  if (alg === "RS256" && jwk.kty === "RSA") {
+    return {
+      importAlgo: { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+      verifyAlgo: { name: "RSASSA-PKCS1-v1_5" },
+    };
+  }
+  return null;
+}
+
+async function verifyJwtSignature(
+  token: string,
+  header: JwtHeader,
+  jwks: Jwks,
+): Promise<boolean> {
+  const parts = token.split(".");
+  if (parts.length !== 3) return false;
+  const [headerB64, payloadB64, sigB64] = parts;
+
+  // Select the key by kid; if the token has no kid, accept a lone matching key.
+  const candidates = jwks.keys.filter((k) => {
+    if (header.kid) return k.kid === header.kid;
+    return true;
+  });
+  if (candidates.length === 0) return false;
+
+  const signature = toArrayBuffer(base64UrlToBytes(sigB64));
+  const signed = toArrayBuffer(new TextEncoder().encode(`${headerB64}.${payloadB64}`));
+
+  for (const jwk of candidates) {
+    const params = importParamsFor(header.alg, jwk);
+    if (!params) continue;
+    try {
+      const key = await crypto.subtle.importKey(
+        "jwk",
+        jwk as JsonWebKey,
+        params.importAlgo,
+        false,
+        ["verify"],
+      );
+      const ok = await crypto.subtle.verify(params.verifyAlgo, key, signature, signed);
+      if (ok) return true;
+    } catch {
+      // try the next candidate key
+    }
+  }
+  return false;
+}
+
+// ── Authenticator factory ────────────────────────────────────────────────────
+
+const BEARER_PREFIX = "Bearer ";
+
+export function createMcpAuthenticator(config: McpAuthConfig): McpAuthenticator {
+  const allowedAlgs = config.allowedAlgs ?? ["ES256", "RS256"];
+  const clockSkewSec = config.clockSkewSec ?? 60;
+  const jwksCacheTtlSec = config.jwksCacheTtlSec ?? 600;
+  const now = config.now ?? (() => Date.now());
+  const fetchImpl = config.fetchImpl ?? fetch;
+
+  // Isolate-lifetime JWKS cache (closure state). Key rotation is picked up on
+  // TTL expiry or isolate recycle.
+  let cache: { jwks: Jwks; fetchedAt: number } | null = null;
+
+  async function getJwks(): Promise<Jwks | null> {
+    if (cache && now() - cache.fetchedAt < jwksCacheTtlSec * 1000) {
+      return cache.jwks;
+    }
+    try {
+      const resp = await fetchImpl(config.jwksUri);
+      if (!resp.ok) return cache?.jwks ?? null;
+      const jwks = (await resp.json()) as Jwks;
+      if (!jwks || !Array.isArray(jwks.keys)) return cache?.jwks ?? null;
+      cache = { jwks, fetchedAt: now() };
+      return jwks;
+    } catch {
+      // On a transient fetch failure, fall back to a still-cached set if any;
+      // otherwise fail closed (caller rejects).
+      return cache?.jwks ?? null;
+    }
+  }
+
+  function validateClaims(payload: JwtPayload): AuthResult {
+    const nowSec = Math.floor(now() / 1000);
+
+    if (payload.iss !== config.issuer) {
+      return { ok: false, reason: "bad_claims", detail: "iss mismatch" };
+    }
+    const auds = Array.isArray(payload.aud) ? payload.aud : [payload.aud];
+    if (!auds.includes(config.expectedAudience)) {
+      return { ok: false, reason: "bad_claims", detail: "aud mismatch" };
+    }
+    if (typeof payload.exp !== "number" || payload.exp + clockSkewSec < nowSec) {
+      return { ok: false, reason: "bad_claims", detail: "expired" };
+    }
+    if (typeof payload.nbf === "number" && payload.nbf - clockSkewSec > nowSec) {
+      return { ok: false, reason: "bad_claims", detail: "not yet valid" };
+    }
+    if (!payload.sub) {
+      return { ok: false, reason: "bad_claims", detail: "missing sub" };
+    }
+    if (config.ownerUserId && payload.sub !== config.ownerUserId) {
+      return { ok: false, reason: "not_owner", detail: "sub is not the owner" };
+    }
+    return { ok: true, path: "oauth", sub: payload.sub };
+  }
+
+  async function authenticate(authorizationHeader: string | null): Promise<AuthResult> {
+    if (!authorizationHeader || !authorizationHeader.startsWith(BEARER_PREFIX)) {
+      return { ok: false, reason: "no_token" };
+    }
+    const token = authorizationHeader.slice(BEARER_PREFIX.length).trim();
+    if (!token) return { ok: false, reason: "no_token" };
+
+    // Path 1 — legacy static Bearer (constant-time). Fail-closed when unset.
+    if (config.staticBearer && constantTimeEqual(token, config.staticBearer)) {
+      return { ok: true, path: "static" };
+    }
+
+    // Path 2 — OAuth access token (JWT against JWKS).
+    const parts = token.split(".");
+    if (parts.length !== 3) {
+      return { ok: false, reason: "malformed_token", detail: "not a JWT" };
+    }
+    let header: JwtHeader;
+    let payload: JwtPayload;
+    try {
+      header = JSON.parse(base64UrlToString(parts[0])) as JwtHeader;
+      payload = JSON.parse(base64UrlToString(parts[1])) as JwtPayload;
+    } catch {
+      return { ok: false, reason: "malformed_token", detail: "bad JSON" };
+    }
+
+    // Algorithm allowlist BEFORE any crypto — reject none/HS256 outright, which
+    // is what defends against alg-confusion with the HS256 legacy anon JWT.
+    if (!allowedAlgs.includes(header.alg)) {
+      return { ok: false, reason: "bad_signature", detail: `alg ${header.alg} not allowed` };
+    }
+
+    const jwks = await getJwks();
+    if (!jwks) return { ok: false, reason: "no_verifier", detail: "JWKS unavailable" };
+
+    const verified = await verifyJwtSignature(token, header, jwks);
+    if (!verified) return { ok: false, reason: "bad_signature", detail: "signature invalid" };
+
+    return validateClaims(payload);
+  }
+
+  return { authenticate };
+}

--- a/_shared/mcp-auth/index.ts
+++ b/_shared/mcp-auth/index.ts
@@ -72,12 +72,18 @@ export interface McpAuthConfig {
   /** Expected `aud` claim. Supabase issues `"authenticated"`. */
   expectedAudience: string;
   /**
-   * Pinned owner user id. When set, an OAuth token's `sub` MUST equal it.
-   * When null/undefined, any validly-signed `authenticated` token is accepted
-   * (safe only because a single-user project has exactly one user — pinning is
-   * still the setup default; see design §5).
+   * Pinned owner user id. When set, an OAuth token's `sub` MUST equal it. When
+   * null/undefined the OAuth path FAILS CLOSED (rejects) unless `allowAnyUser` is
+   * true — because with Supabase's default email sign-ups on, an unpinned server
+   * would accept any self-registered user's token (design §6 / Finding 3).
    */
   ownerUserId?: string | null;
+  /**
+   * Explicit opt-out of the owner pin: accept any validly-signed `authenticated`
+   * token when `ownerUserId` is unset. For deliberate multi-user / sign-ups-disabled
+   * setups only. Default false (fail closed when unpinned).
+   */
+  allowAnyUser?: boolean;
   /**
    * Expected value for the legacy static-Bearer path (the anon JWT). When
    * null/undefined the static path is disabled and rejects everything
@@ -274,8 +280,18 @@ export function createMcpAuthenticator(config: McpAuthConfig): McpAuthenticator 
     if (!payload.sub) {
       return { ok: false, reason: "bad_claims", detail: "missing sub" };
     }
-    if (config.ownerUserId && payload.sub !== config.ownerUserId) {
-      return { ok: false, reason: "not_owner", detail: `sub=${payload.sub} owner=${config.ownerUserId}` };
+    if (config.ownerUserId) {
+      if (payload.sub !== config.ownerUserId) {
+        return { ok: false, reason: "not_owner", detail: `sub=${payload.sub} owner=${config.ownerUserId}` };
+      }
+    } else if (!config.allowAnyUser) {
+      // Fail closed: no owner pinned and no explicit opt-out. Accepting here would
+      // let any self-registered user in (Supabase email sign-ups default on).
+      return {
+        ok: false,
+        reason: "not_owner",
+        detail: "owner not pinned; set CEREFOX_OAUTH_OWNER_ID (or CEREFOX_OAUTH_ALLOW_ANY_USER=true to opt out)",
+      };
     }
     return { ok: true, path: "oauth", sub: payload.sub };
   }

--- a/cloudflare/cerefox-consent/README.md
+++ b/cloudflare/cerefox-consent/README.md
@@ -13,14 +13,17 @@ infrastructure** — you only need it if you want claude.ai web / Claude mobile;
 local MCP, Claude Desktop, Cursor, Claude Code, etc. don't use it.
 
 It holds **no secrets**: the only values baked in are your Supabase project URL and the
-**public** anon key. Sign-in happens against your own Supabase Auth, in the browser.
+**publishable** key (`sb_publishable_…`) — a public-safe key that grants no KB access (the
+Edge Function gateway rejects it, and since schema 0.7.0 it cannot call the Data API RPCs
+either). It must **not** be the legacy anon JWT, which is a full-KB credential. Sign-in
+happens against your own Supabase Auth, in the browser.
 
 ## Deploy
 
 Prerequisite: a free [Cloudflare account](https://dash.cloudflare.com/sign-up) (no
 domain, no card). The Workers free tier includes a `*.workers.dev` subdomain.
 
-**One command** (reads your Supabase URL + anon key from `~/.cerefox/.env`):
+**One command** (reads `CEREFOX_SUPABASE_URL` + `CEREFOX_SUPABASE_PUBLISHABLE_KEY` from `~/.cerefox/.env`):
 
 ```bash
 cd cloudflare/cerefox-consent
@@ -36,7 +39,7 @@ URL, e.g. `https://cerefox-consent.<your-subdomain>.workers.dev`.
 npx wrangler login
 npx wrangler deploy \
   --var SUPABASE_URL:https://<your-project-ref>.supabase.co \
-  --var SUPABASE_ANON_KEY:<your-legacy-anon-jwt>
+  --var SUPABASE_PUBLISHABLE_KEY:sb_publishable_...
 ```
 
 Both values are public. They're injected at deploy time so the committed

--- a/cloudflare/cerefox-consent/README.md
+++ b/cloudflare/cerefox-consent/README.md
@@ -1,0 +1,68 @@
+# Cerefox OAuth consent page — Cloudflare Worker
+
+This is the **consent page** for connecting cloud/mobile Claude (and other OAuth MCP
+clients) to your Cerefox knowledge base. It's the screen where you approve the
+connection during the OAuth flow.
+
+**Why a Cloudflare Worker and not a Supabase Edge Function?** Supabase rewrites
+`text/html` responses to `text/plain` on the default `*.supabase.co` domain (an
+anti-phishing measure), so an Edge Function can't render a real page there without a
+paid custom domain. The page is a single static file (all logic runs client-side via
+`supabase-js`), so a free Cloudflare Worker serves it perfectly. This is **optional
+infrastructure** — you only need it if you want claude.ai web / Claude mobile; the
+local MCP, Claude Desktop, Cursor, Claude Code, etc. don't use it.
+
+It holds **no secrets**: the only values baked in are your Supabase project URL and the
+**public** anon key. Sign-in happens against your own Supabase Auth, in the browser.
+
+## Deploy
+
+Prerequisite: a free [Cloudflare account](https://dash.cloudflare.com/sign-up) (no
+domain, no card). The Workers free tier includes a `*.workers.dev` subdomain.
+
+**One command** (reads your Supabase URL + anon key from `~/.cerefox/.env`):
+
+```bash
+cd cloudflare/cerefox-consent
+./deploy.sh
+```
+
+The first run opens a browser for `wrangler login`. On success it prints your Worker
+URL, e.g. `https://cerefox-consent.<your-subdomain>.workers.dev`.
+
+**Manual equivalent** (if you don't use `~/.cerefox/.env`, or want to see what it does):
+
+```bash
+npx wrangler login
+npx wrangler deploy \
+  --var SUPABASE_URL:https://<your-project-ref>.supabase.co \
+  --var SUPABASE_ANON_KEY:<your-legacy-anon-jwt>
+```
+
+Both values are public. They're injected at deploy time so the committed
+`wrangler.toml` stays generic (its `[vars]` are placeholders).
+
+## After deploying
+
+1. Copy the printed `…workers.dev` URL.
+2. Supabase Dashboard → **Authentication → URL Configuration → Site URL** = that URL.
+   (Keep the OAuth Server **Authorization Path** at `/consent`, so the consent page is
+   served at `…workers.dev/consent`.)
+3. Finish the rest of the OAuth setup in
+   [`docs/guides/setup-supabase.md` Step 7](../../docs/guides/setup-supabase.md).
+
+## Files
+
+- `src/index.ts` — the Worker: serves the shared consent markup
+  (`_shared/consent-page/renderConsentPage()`) as real `text/html`.
+- `wrangler.toml` — Worker config; `[vars]` are generic placeholders (overridden by
+  `deploy.sh` / `--var`).
+- `deploy.sh` — reads `~/.cerefox/.env` and deploys.
+
+The markup + client-side OAuth logic live once in `_shared/consent-page/` and are shared
+with the (retained, custom-domain-only) `cerefox-oauth-consent` Edge Function, so the two
+can't drift.
+
+## Updating
+
+Re-run `./deploy.sh` after any change to `_shared/consent-page/` or `src/index.ts`.

--- a/cloudflare/cerefox-consent/deploy.sh
+++ b/cloudflare/cerefox-consent/deploy.sh
@@ -2,11 +2,13 @@
 #
 # Deploy the Cerefox OAuth consent page to a free Cloudflare Worker.
 #
-# Reads your Supabase project URL + anon key from ~/.cerefox/.env (both are PUBLIC
-# values) and injects them at deploy time, so the committed wrangler.toml stays
-# generic (no project-specific values in the repo). First run opens a browser for
-# `wrangler login`; the free Workers plan gives you a `*.workers.dev` URL — no owned
-# domain or credit card needed.
+# Reads your Supabase project URL + PUBLISHABLE key from ~/.cerefox/.env and injects
+# them at deploy time, so the committed wrangler.toml stays generic (no project values
+# in the repo). First run opens a browser for `wrangler login`; the free Workers plan
+# gives you a `*.workers.dev` URL — no owned domain or credit card needed.
+#
+# SECURITY: this deploys the sb_publishable_… key (public-safe), NOT the legacy anon
+# JWT. The anon JWT is a full-KB credential and must never be world-readable.
 #
 # Usage:
 #   cd cloudflare/cerefox-consent && ./deploy.sh
@@ -19,22 +21,23 @@ ENV_FILE="${CEREFOX_ENV:-$HOME/.cerefox/.env}"
 if [ ! -f "$ENV_FILE" ]; then
   echo "✗ No env file at $ENV_FILE" >&2
   echo "  Set CEREFOX_ENV, or deploy manually:" >&2
-  echo "    npx wrangler deploy --var SUPABASE_URL:https://<ref>.supabase.co --var SUPABASE_ANON_KEY:<anon-jwt>" >&2
+  echo "    npx wrangler deploy --var SUPABASE_URL:https://<ref>.supabase.co --var SUPABASE_PUBLISHABLE_KEY:sb_publishable_..." >&2
   exit 1
 fi
 
 url=$(grep -m1 '^CEREFOX_SUPABASE_URL=' "$ENV_FILE" | cut -d= -f2-)
-anon=$(grep -m1 '^CEREFOX_SUPABASE_ANON_KEY=' "$ENV_FILE" | cut -d= -f2-)
+pub=$(grep -m1 '^CEREFOX_SUPABASE_PUBLISHABLE_KEY=' "$ENV_FILE" | cut -d= -f2-)
 
-if [ -z "$url" ] || [ -z "$anon" ]; then
-  echo "✗ Could not read CEREFOX_SUPABASE_URL and/or CEREFOX_SUPABASE_ANON_KEY from $ENV_FILE" >&2
-  echo "  The anon key is the legacy anon JWT (starts with eyJ). Both are public values." >&2
+if [ -z "$url" ] || [ -z "$pub" ]; then
+  echo "✗ Could not read CEREFOX_SUPABASE_URL and/or CEREFOX_SUPABASE_PUBLISHABLE_KEY from $ENV_FILE" >&2
+  echo "  Add CEREFOX_SUPABASE_PUBLISHABLE_KEY (your sb_publishable_… key from Supabase →" >&2
+  echo "  Project Settings → API Keys → Publishable) to $ENV_FILE. Do NOT use the anon JWT here." >&2
   exit 1
 fi
 
 cd "$(dirname "$0")"
-echo "▶ Deploying the Cerefox consent Worker for $url"
-npx wrangler deploy --var "SUPABASE_URL:$url" --var "SUPABASE_ANON_KEY:$anon"
+echo "▶ Deploying the Cerefox consent Worker for $url (publishable key)"
+npx wrangler deploy --var "SUPABASE_URL:$url" --var "SUPABASE_PUBLISHABLE_KEY:$pub"
 
 cat <<'EOF'
 

--- a/cloudflare/cerefox-consent/deploy.sh
+++ b/cloudflare/cerefox-consent/deploy.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Deploy the Cerefox OAuth consent page to a free Cloudflare Worker.
+#
+# Reads your Supabase project URL + anon key from ~/.cerefox/.env (both are PUBLIC
+# values) and injects them at deploy time, so the committed wrangler.toml stays
+# generic (no project-specific values in the repo). First run opens a browser for
+# `wrangler login`; the free Workers plan gives you a `*.workers.dev` URL — no owned
+# domain or credit card needed.
+#
+# Usage:
+#   cd cloudflare/cerefox-consent && ./deploy.sh
+#   CEREFOX_ENV=/path/to/.env ./deploy.sh      # non-default env file
+#
+set -euo pipefail
+
+ENV_FILE="${CEREFOX_ENV:-$HOME/.cerefox/.env}"
+
+if [ ! -f "$ENV_FILE" ]; then
+  echo "✗ No env file at $ENV_FILE" >&2
+  echo "  Set CEREFOX_ENV, or deploy manually:" >&2
+  echo "    npx wrangler deploy --var SUPABASE_URL:https://<ref>.supabase.co --var SUPABASE_ANON_KEY:<anon-jwt>" >&2
+  exit 1
+fi
+
+url=$(grep -m1 '^CEREFOX_SUPABASE_URL=' "$ENV_FILE" | cut -d= -f2-)
+anon=$(grep -m1 '^CEREFOX_SUPABASE_ANON_KEY=' "$ENV_FILE" | cut -d= -f2-)
+
+if [ -z "$url" ] || [ -z "$anon" ]; then
+  echo "✗ Could not read CEREFOX_SUPABASE_URL and/or CEREFOX_SUPABASE_ANON_KEY from $ENV_FILE" >&2
+  echo "  The anon key is the legacy anon JWT (starts with eyJ). Both are public values." >&2
+  exit 1
+fi
+
+cd "$(dirname "$0")"
+echo "▶ Deploying the Cerefox consent Worker for $url"
+npx wrangler deploy --var "SUPABASE_URL:$url" --var "SUPABASE_ANON_KEY:$anon"
+
+cat <<'EOF'
+
+Next:
+  1. Copy the printed https://cerefox-consent.<subdomain>.workers.dev URL.
+  2. Supabase → Authentication → URL Configuration → Site URL = that URL.
+     (Authorization Path stays /consent → consent page at …workers.dev/consent)
+  3. Continue the OAuth setup: docs/guides/setup-supabase.md Step 7.
+EOF

--- a/cloudflare/cerefox-consent/src/index.ts
+++ b/cloudflare/cerefox-consent/src/index.ts
@@ -1,0 +1,35 @@
+/**
+ * cerefox-consent — Cloudflare Worker
+ *
+ * Serves the Cerefox OAuth consent page as real `text/html` (which a Supabase
+ * Edge Function on the default domain cannot — it rewrites html→plain). The
+ * markup + client-side logic are the SAME as the EF version: both render the
+ * shared `renderConsentPage()`. Free on the Workers plan (a `*.workers.dev`
+ * subdomain, no custom domain needed).
+ *
+ * Config (Wrangler [vars], both public — the project URL and the anon key):
+ *   SUPABASE_URL       e.g. https://<project-ref>.supabase.co
+ *   SUPABASE_ANON_KEY  the legacy anon JWT (public by design)
+ *
+ * Point your Supabase Site URL at this Worker's origin and set Authorization
+ * Path to `/consent` (design §4.2-B).
+ */
+
+import { renderConsentPage } from "../../../_shared/consent-page/index.ts";
+
+interface Env {
+  SUPABASE_URL: string;
+  SUPABASE_ANON_KEY: string;
+}
+
+export default {
+  fetch(request: Request, env: Env): Response {
+    if (request.method !== "GET") {
+      return new Response("Method Not Allowed", { status: 405 });
+    }
+    return new Response(renderConsentPage(env.SUPABASE_URL, env.SUPABASE_ANON_KEY), {
+      status: 200,
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    });
+  },
+};

--- a/cloudflare/cerefox-consent/src/index.ts
+++ b/cloudflare/cerefox-consent/src/index.ts
@@ -7,9 +7,12 @@
  * shared `renderConsentPage()`. Free on the Workers plan (a `*.workers.dev`
  * subdomain, no custom domain needed).
  *
- * Config (Wrangler [vars], both public — the project URL and the anon key):
- *   SUPABASE_URL       e.g. https://<project-ref>.supabase.co
- *   SUPABASE_ANON_KEY  the legacy anon JWT (public by design)
+ * Config (Wrangler [vars], both public):
+ *   SUPABASE_URL              e.g. https://<project-ref>.supabase.co
+ *   SUPABASE_PUBLISHABLE_KEY  the sb_publishable_… key — NOT the legacy anon JWT.
+ *                             The page only talks to Supabase Auth; a world-readable
+ *                             publishable key grants no KB access (the EF gateway and
+ *                             the schema-0.7.0 RPC lockdown reject it).
  *
  * Point your Supabase Site URL at this Worker's origin and set Authorization
  * Path to `/consent` (design §4.2-B).
@@ -19,7 +22,7 @@ import { renderConsentPage } from "../../../_shared/consent-page/index.ts";
 
 interface Env {
   SUPABASE_URL: string;
-  SUPABASE_ANON_KEY: string;
+  SUPABASE_PUBLISHABLE_KEY: string;
 }
 
 export default {
@@ -27,7 +30,7 @@ export default {
     if (request.method !== "GET") {
       return new Response("Method Not Allowed", { status: 405 });
     }
-    return new Response(renderConsentPage(env.SUPABASE_URL, env.SUPABASE_ANON_KEY), {
+    return new Response(renderConsentPage(env.SUPABASE_URL, env.SUPABASE_PUBLISHABLE_KEY), {
       status: 200,
       headers: { "Content-Type": "text/html; charset=utf-8" },
     });

--- a/cloudflare/cerefox-consent/wrangler.toml
+++ b/cloudflare/cerefox-consent/wrangler.toml
@@ -7,8 +7,10 @@ main = "src/index.ts"
 compatibility_date = "2024-11-01"
 workers_dev = true
 
-# Both values are PUBLIC (project URL + anon JWT). Fill in your project's, or
-# override per-deploy with:  npx wrangler deploy --var SUPABASE_URL:... --var SUPABASE_ANON_KEY:...
+# Both values are PUBLIC. Use the sb_publishable_… key, NOT the legacy anon JWT
+# (the anon JWT is a full-KB credential and must never be world-readable). Fill in
+# your project's, or override per-deploy with:
+#   npx wrangler deploy --var SUPABASE_URL:... --var SUPABASE_PUBLISHABLE_KEY:...
 [vars]
 SUPABASE_URL = "https://YOUR_PROJECT_REF.supabase.co"
-SUPABASE_ANON_KEY = "REPLACE_WITH_YOUR_LEGACY_ANON_JWT"
+SUPABASE_PUBLISHABLE_KEY = "REPLACE_WITH_YOUR_sb_publishable_KEY"

--- a/cloudflare/cerefox-consent/wrangler.toml
+++ b/cloudflare/cerefox-consent/wrangler.toml
@@ -1,0 +1,14 @@
+# Cloudflare Worker: Cerefox OAuth consent page (design §4.2-B).
+# Deploy:  cd cloudflare/cerefox-consent && npx wrangler deploy
+# First run prompts `wrangler login` (browser). Free Workers plan; gives a
+# https://cerefox-consent.<your-subdomain>.workers.dev URL.
+name = "cerefox-consent"
+main = "src/index.ts"
+compatibility_date = "2024-11-01"
+workers_dev = true
+
+# Both values are PUBLIC (project URL + anon JWT). Fill in your project's, or
+# override per-deploy with:  npx wrangler deploy --var SUPABASE_URL:... --var SUPABASE_ANON_KEY:...
+[vars]
+SUPABASE_URL = "https://YOUR_PROJECT_REF.supabase.co"
+SUPABASE_ANON_KEY = "REPLACE_WITH_YOUR_LEGACY_ANON_JWT"

--- a/docker/local/roles.sql
+++ b/docker/local/roles.sql
@@ -40,11 +40,14 @@ grant all on all tables in schema public to service_role;
 grant all on all sequences in schema public to service_role;
 grant execute on all functions in schema public to service_role;
 
--- anon / authenticated: may execute the SECURITY DEFINER RPCs (matches cloud agent
--- access); direct table access stays RLS-denied (no policies).
-grant execute on all functions in schema public to anon, authenticated;
+-- anon / authenticated: NO execute on the SECURITY DEFINER RPCs. Those functions
+-- bypass RLS, so granting anon/authenticated execute would let any anon/publishable
+-- key call them via the Data API and read/write the whole KB (bypassing RLS). All
+-- Cerefox clients (CLI / MCP / web) use the service_role key, so anon/authenticated
+-- need no function access. (rpcs.sql also REVOKEs these grants defensively on every
+-- deploy — schema 0.7.0.) Direct table access stays RLS-denied (no policies).
 
 -- Objects created by later deploys (new tables/funcs) inherit the same grants.
 alter default privileges in schema public grant all on tables to service_role;
 alter default privileges in schema public grant all on sequences to service_role;
-alter default privileges in schema public grant execute on functions to service_role, anon, authenticated;
+alter default privileges in schema public grant execute on functions to service_role;

--- a/docs/guides/access-paths.md
+++ b/docs/guides/access-paths.md
@@ -226,12 +226,10 @@ gateway validates and rate-limits it. **It is not RLS-scoped** — any holder ca
 full EF tool surface (read *and* write). So treat it as a shared secret for *trusted*
 agents/clients — keep it in local configs, but do **not** publish it on a public web page.
 
-> **Schema 0.7.0 hardening:** the `cerefox_*` RPCs are `SECURITY DEFINER` (they bypass RLS),
-> so before 0.7.0 the anon/publishable key could call them **directly** via the Data API
-> (`/rest/v1/rpc/…`), sidestepping the Edge Functions entirely. Those functions now
-> `REVOKE EXECUTE` from `anon`/`authenticated`/`PUBLIC` and grant only `service_role`, so
-> the Data API RPC path is closed for anon/publishable keys — every legitimate caller uses
-> the service-role key. Run `cerefox server deploy` to apply it. See
+> **Schema 0.7.0 hardening:** the `cerefox_*` RPCs are `SECURITY DEFINER` and previously
+> had broader-than-intended `EXECUTE` grants. They now grant `EXECUTE` only to
+> `service_role` (which every legitimate caller uses) — revoked from `anon`/`authenticated`/
+> `PUBLIC`. A security hardening; run `cerefox server deploy` to apply. See
 > [`docs/specs/security-model.md`](../specs/security-model.md).
 
 The **publishable** key (`sb_publishable_…`) is genuinely public-safe: the EF gateway

--- a/docs/guides/access-paths.md
+++ b/docs/guides/access-paths.md
@@ -37,7 +37,7 @@ internally to call Postgres RPCs. Your anon key is never elevated to database-le
 | `cerefox-get-audit-log` | Query audit log entries with filters |
 | `cerefox-metadata-search` | Query documents by metadata key-value criteria without text search |
 | `cerefox-list-projects` | List all projects with names, IDs, and descriptions |
-| `cerefox-mcp` | Streamable HTTP MCP adapter — calls Postgres RPCs directly |
+| `cerefox-mcp` | Streamable HTTP MCP adapter — calls Postgres RPCs directly. **Also** an OAuth 2.1 protected resource for cloud/mobile Claude (optional — see "the OAuth variant" below) |
 
 ### How clients connect
 
@@ -68,6 +68,37 @@ same anon key as a Bearer token.
 - **Legacy anon JWT** — found in your Supabase dashboard under **Project Settings → API Keys → Legacy → anon**. (Do not use the new `sb_publishable_…` key — gateway constraint.)
 
 See `docs/guides/connect-agents.md` for step-by-step setup per client.
+
+### The OAuth variant of `cerefox-mcp` — cloud & mobile Claude (optional)
+
+claude.ai web and the Claude mobile app **cannot** send a static anon JWT — a custom
+connector there requires **OAuth**. As an optional feature (iter-28A), `cerefox-mcp` is
+therefore *also* an OAuth 2.1 protected resource, so those clients get the same full
+tool surface. Nothing else in Layer 1 changes, and you can ignore this entirely if you
+don't use cloud/mobile Claude.
+
+How it differs from the static-anon-JWT path:
+
+- **In-function auth.** `cerefox-mcp` is deployed with `--no-verify-jwt`, so the Supabase
+  gateway no longer validates it. The function authenticates each request itself
+  (`_shared/mcp-auth/`), accepting **either** a valid OAuth 2.1 access token (verified
+  against the project **JWKS**, with the token's `sub` pinned to `CEREFOX_OAUTH_OWNER_ID`)
+  **or** the legacy anon JWT (constant-time compare, so existing static-token clients keep
+  working). This is the ONLY function whose auth moves in-function; the eight primitive
+  Edge Functions keep the gateway anon-JWT validation described above.
+- **Supabase is the authorization server.** The OAuth flow uses Supabase's native OAuth 2.1
+  Server. The one piece that must serve HTML — the **consent page** — is a free **Cloudflare
+  Worker** (`cloudflare/cerefox-consent/`), because a Supabase Edge Function can't serve
+  `text/html` on the default `*.supabase.co` domain. (A `cerefox-oauth-consent` EF also
+  ships for users who have a paid Supabase custom domain.)
+- **The owner pin is the authorization boundary.** `CEREFOX_OAUTH_OWNER_ID` (the owner
+  user's UUID) is a server-side value — never entered into any client — and only tokens
+  whose `sub` matches it are accepted.
+
+Config: `CEREFOX_OAUTH_OWNER_ID` (owner pin), a pre-registered OAuth App using
+**`client_secret_post`**, and the Cloudflare Worker (public project URL + anon key baked
+in). Setup: [`setup-supabase.md` → Step 7](setup-supabase.md#step-7--oauth-for-cloud-agents-claudeai--mobile-optional).
+Design: [`docs/specs/oauth-mcp-server-design.md`](../specs/oauth-mcp-server-design.md).
 
 ---
 
@@ -179,6 +210,7 @@ single container with an internally-held token.
 |---|---|---|---|
 | Claude Code / Cursor | HTTPS → `cerefox-mcp` | Legacy anon JWT | Daily AI assistant access |
 | Claude Desktop | HTTPS → `cerefox-mcp` (via `supergateway`) | Legacy anon JWT | Daily AI assistant access |
+| **Cloud Claude (claude.ai web + mobile)** | HTTPS → `cerefox-mcp` over **OAuth 2.1** | Owner-pinned OAuth access token (JWKS-verified) | Optional; memory in the browser + on the phone |
 | ChatGPT Custom GPT | HTTPS → primitive Edge Functions | Legacy anon JWT | AI assistant via GPT Actions |
 | curl / HTTP scripts | HTTPS → primitive Edge Functions | Legacy anon JWT | Ad-hoc queries, automation |
 | Web UI (`cerefox web`) | Supabase REST API | Secret key (or legacy service_role) | Web UI backend (TS Hono) |

--- a/docs/guides/access-paths.md
+++ b/docs/guides/access-paths.md
@@ -220,11 +220,26 @@ single container with an internally-held token.
 
 ### Key security principle
 
-The (legacy) anon JWT is safe to share with AI agents and client applications — it can
-only call the operations exposed by the Edge Functions, and the Supabase gateway
-rate-limits and validates it. The secret key / `service_role` JWT and the database
-password must never be embedded in client-facing configuration or committed to the
-repository.
+The (legacy) anon JWT is the **Edge Function credential**. It authenticates to the Edge
+Functions (which run business logic with the service-role key internally); the Supabase
+gateway validates and rate-limits it. **It is not RLS-scoped** — any holder can call the
+full EF tool surface (read *and* write). So treat it as a shared secret for *trusted*
+agents/clients — keep it in local configs, but do **not** publish it on a public web page.
+
+> **Schema 0.7.0 hardening:** the `cerefox_*` RPCs are `SECURITY DEFINER` (they bypass RLS),
+> so before 0.7.0 the anon/publishable key could call them **directly** via the Data API
+> (`/rest/v1/rpc/…`), sidestepping the Edge Functions entirely. Those functions now
+> `REVOKE EXECUTE` from `anon`/`authenticated`/`PUBLIC` and grant only `service_role`, so
+> the Data API RPC path is closed for anon/publishable keys — every legitimate caller uses
+> the service-role key. Run `cerefox server deploy` to apply it. See
+> [`docs/specs/security-model.md`](../specs/security-model.md).
+
+The **publishable** key (`sb_publishable_…`) is genuinely public-safe: the EF gateway
+rejects it and (post-0.7.0) it cannot call the RPCs either, so it grants no KB access — it
+only reaches Supabase Auth. That's why the OAuth consent page embeds it, not the anon JWT.
+
+The secret key / `service_role` JWT and the database password must never be embedded in
+client-facing configuration or committed to the repository.
 
 ---
 

--- a/docs/guides/connect-agents.md
+++ b/docs/guides/connect-agents.md
@@ -37,7 +37,7 @@ Three top-level paths plus a few special cases:
 | Claude Desktop (local) | Path A-Local — `@cerefox/memory` via `npx` | Hybrid | Local alternative; Node.js; zero Edge Function invocations |
 | Claude Code (local) | Path A-Local — `@cerefox/memory` via `npx` | Hybrid | Local alternative; zero Edge Function invocations |
 | Cursor (local) | Path A-Local — `@cerefox/memory` via `npx` | Hybrid | Local alternative; zero Edge Function invocations |
-| Cloud Claude (claude.ai web) | Remote Supabase MCP | FTS only | No install; search quality limited |
+| Cloud Claude (claude.ai web + mobile) | Path A-Remote — `cerefox-mcp` over **OAuth** | Hybrid | No install; one-time Supabase OAuth setup ([setup-supabase Step 7](setup-supabase.md#step-7--oauth-for-cloud-agents-claudeai--mobile-optional)); iter-28A, verification pending |
 | Gemini CLI (remote) | Path A-Remote — `cerefox-mcp` Edge Function | Hybrid | URL + anon key only; no local install |
 | Local coding agents (Claude Code, Codex CLI, opencode, OpenClaw, Hermes, …) | Path C — Shell CLI (Bash tool) | Hybrid | `npm install -g @cerefox/memory`; agent runs `cerefox …` as a shell command. Useful when MCP setup is friction. |
 | curl / scripts | Path B — Edge Functions directly | Hybrid | Direct HTTP; no client needed |
@@ -46,8 +46,12 @@ Three top-level paths plus a few special cases:
 > **"Hybrid"** = FTS + semantic, document-level (complete reconstructed notes, not isolated chunks).
 > **"FTS only"** = keyword search only; no semantic/vector search.
 
-> **Cloud hybrid for all clients (future)**: deploying the MCP server to Cloud Run would give
-> cloud clients (claude.ai, chatgpt.com) full hybrid search. Tracked in `docs/TODO.md`.
+> **Cloud hybrid for claude.ai / mobile (iter-28A)**: `cerefox-mcp` is now an OAuth 2.1
+> protected resource, so claude.ai web and the Claude mobile app get **full hybrid search**
+> over the standard tool surface — no Cloud Run needed. Setup:
+> [setup-supabase Step 7](setup-supabase.md#step-7--oauth-for-cloud-agents-claudeai--mobile-optional)
+> + [Cloud Claude](#cloud-claude-claudeai-web--mobile-oauth) below. (An OAuth connector for
+> ChatGPT becomes possible on the same server but is not yet documented.)
 
 > **Perplexity** supports stdio-only MCP on macOS Desktop (via Helper App). Remote MCP is
 > "coming soon." Perplexity's CTO has signalled a strategic shift away from MCP (March 2026),
@@ -1101,20 +1105,44 @@ See `docs/guides/configuration.md` → "Response size limit" for full details.
 
 ---
 
-### Cloud Claude (claude.ai web)
+### Cloud Claude (claude.ai web + mobile — OAuth) <a id="cloud-claude-claudeai-web--mobile-oauth"></a>
 
-Claude.ai web can connect to the Supabase-hosted remote MCP (no local install):
+> **Status (iter-28A):** ⏳ **not yet verified end-to-end** — the server side is built and
+> deploys, but the claude.ai connection walk-through below is confirmed once we complete it
+> (Phase 4). The exact dialog labels may shift as the Supabase OAuth server and claude.ai
+> connectors are both in beta. Design: [`docs/specs/oauth-mcp-server-design.md`](../specs/oauth-mcp-server-design.md).
 
-1. In Claude.ai: **Settings → Integrations → Add integration**
-2. Enter the MCP URL:
+Claude.ai web **and the Claude mobile app** connect to your own `cerefox-mcp` Edge
+Function over **OAuth**, with the **full hybrid-search tool surface** — no local install.
+This replaces the old FTS-only `mcp.supabase.com` approach (which exposed raw keyword
+search over the tables, with no semantic search or Cerefox tool ergonomics).
+
+**Prerequisite:** complete the one-time Supabase OAuth setup in
+[`setup-supabase.md` → Step 7](setup-supabase.md#step-7--oauth-for-cloud-agents-claudeai--mobile-optional)
+(enable the OAuth 2.1 Server, owner user, secrets, and — since DCR is off — a
+pre-registered OAuth App whose Client ID/Secret you'll paste below).
+
+1. In Claude.ai (web): **Settings → Connectors → Add custom connector**.
+2. **Name**: `CerefoxMCP` (distinct from the local `cerefox` server, so both can coexist).
+3. **URL** (must be the `*.supabase.co` host — custom domains break OAuth discovery):
    ```
-   https://mcp.supabase.com/sse?project_ref=<your-project-ref>
+   https://<your-project-ref>.supabase.co/functions/v1/cerefox-mcp
    ```
-3. Authenticate with your Personal Access Token when prompted.
+4. **Advanced settings → OAuth Client ID / OAuth Client Secret**: paste the Client ID and
+   Client Secret from the pre-registered OAuth App (setup-supabase Step 7d).
+5. Save. Claude runs the OAuth flow: it redirects you to the **Cerefox consent page**
+   (sign in with the owner email/password from Step 7c, then **Allow**). On approval the
+   connector shows as connected with **10 tools**.
+6. **Mobile**: connectors are account-level, so `CerefoxMCP` appears in the Claude mobile
+   app automatically — run one search from your phone to confirm.
 
-> **Limitation**: The cloud Supabase MCP only supports **FTS keyword search** — no hybrid or
-> semantic search. For full hybrid search from the web, deploy the MCP server to Cloud Run
-> (see `docs/TODO.md` → "Remote HTTP MCP server").
+**Verify**: in a new chat with the connector enabled, ask *"Using CerefoxMCP, search for
+the Cerefox Decision Log and give the title of the latest part."* A correct answer proves
+search + document reconstruction over the OAuth path.
+
+> **Cost note**: each cloud tool call is ~1 Edge Function invocation. Fine for interactive
+> use; for heavy/automated work prefer the local stdio server (zero EF cost). Your local
+> and static-Bearer clients (Claude Code, Cursor, Codex, Gemini, Desktop) are unchanged.
 
 ---
 

--- a/docs/guides/connect-agents.md
+++ b/docs/guides/connect-agents.md
@@ -37,7 +37,7 @@ Three top-level paths plus a few special cases:
 | Claude Desktop (local) | Path A-Local — `@cerefox/memory` via `npx` | Hybrid | Local alternative; Node.js; zero Edge Function invocations |
 | Claude Code (local) | Path A-Local — `@cerefox/memory` via `npx` | Hybrid | Local alternative; zero Edge Function invocations |
 | Cursor (local) | Path A-Local — `@cerefox/memory` via `npx` | Hybrid | Local alternative; zero Edge Function invocations |
-| Cloud Claude (claude.ai web + mobile) | Path A-Remote — `cerefox-mcp` over **OAuth** | Hybrid | No install; one-time Supabase OAuth setup ([setup-supabase Step 7](setup-supabase.md#step-7--oauth-for-cloud-agents-claudeai--mobile-optional)); iter-28A, verification pending |
+| Cloud Claude (claude.ai web + mobile) | Path A-Remote — `cerefox-mcp` over **OAuth** | Hybrid | No install; **optional** one-time OAuth setup + a free Cloudflare Worker consent page ([setup-supabase Step 7](setup-supabase.md#step-7--oauth-for-cloud-agents-claudeai--mobile-optional)) |
 | Gemini CLI (remote) | Path A-Remote — `cerefox-mcp` Edge Function | Hybrid | URL + anon key only; no local install |
 | Local coding agents (Claude Code, Codex CLI, opencode, OpenClaw, Hermes, …) | Path C — Shell CLI (Bash tool) | Hybrid | `npm install -g @cerefox/memory`; agent runs `cerefox …` as a shell command. Useful when MCP setup is friction. |
 | curl / scripts | Path B — Edge Functions directly | Hybrid | Direct HTTP; no client needed |
@@ -1107,20 +1107,21 @@ See `docs/guides/configuration.md` → "Response size limit" for full details.
 
 ### Cloud Claude (claude.ai web + mobile — OAuth) <a id="cloud-claude-claudeai-web--mobile-oauth"></a>
 
-> **Status (iter-28A):** ⏳ **not yet verified end-to-end** — the server side is built and
-> deploys, but the claude.ai connection walk-through below is confirmed once we complete it
-> (Phase 4). The exact dialog labels may shift as the Supabase OAuth server and claude.ai
-> connectors are both in beta. Design: [`docs/specs/oauth-mcp-server-design.md`](../specs/oauth-mcp-server-design.md).
+> **Optional feature.** This is the only path that needs the OAuth setup + a hosted
+> consent page. If you don't use claude.ai web / mobile, skip it — every other client
+> works without it. Design + rationale:
+> [`docs/specs/oauth-mcp-server-design.md`](../specs/oauth-mcp-server-design.md).
 
 Claude.ai web **and the Claude mobile app** connect to your own `cerefox-mcp` Edge
 Function over **OAuth**, with the **full hybrid-search tool surface** — no local install.
-This replaces the old FTS-only `mcp.supabase.com` approach (which exposed raw keyword
-search over the tables, with no semantic search or Cerefox tool ergonomics).
+This replaces the old FTS-only `mcp.supabase.com` approach (raw keyword search over the
+tables, no semantic search, no Cerefox tool ergonomics).
 
 **Prerequisite:** complete the one-time Supabase OAuth setup in
 [`setup-supabase.md` → Step 7](setup-supabase.md#step-7--oauth-for-cloud-agents-claudeai--mobile-optional)
-(enable the OAuth 2.1 Server, owner user, secrets, and — since DCR is off — a
-pre-registered OAuth App whose Client ID/Secret you'll paste below).
+— enable the OAuth 2.1 Server, deploy the Cloudflare Worker consent page, create the owner
+user + `CEREFOX_OAUTH_OWNER_ID` pin, and register the Claude OAuth App
+(**`client_secret_post`**) whose Client ID/Secret you paste below.
 
 1. In Claude.ai (web): **Settings → Connectors → Add custom connector**.
 2. **Name**: `CerefoxMCP` (distinct from the local `cerefox` server, so both can coexist).
@@ -1130,15 +1131,20 @@ pre-registered OAuth App whose Client ID/Secret you'll paste below).
    ```
 4. **Advanced settings → OAuth Client ID / OAuth Client Secret**: paste the Client ID and
    Client Secret from the pre-registered OAuth App (setup-supabase Step 7d).
-5. Save. Claude runs the OAuth flow: it redirects you to the **Cerefox consent page**
-   (sign in with the owner email/password from Step 7c, then **Allow**). On approval the
-   connector shows as connected with **10 tools**.
+5. Save. Claude runs the OAuth flow → redirects you to the **Cerefox consent page** (sign
+   in with the owner email/password from Step 7c, then **Allow**) → returns to Claude. The
+   connector shows as connected with **10 tools**. (If you've approved before, Supabase
+   auto-consents and the page just flashes through — that's expected.)
 6. **Mobile**: connectors are account-level, so `CerefoxMCP` appears in the Claude mobile
    app automatically — run one search from your phone to confirm.
 
-**Verify**: in a new chat with the connector enabled, ask *"Using CerefoxMCP, search for
-the Cerefox Decision Log and give the title of the latest part."* A correct answer proves
+**Verify**: in a new chat with the connector enabled, ask *"Using CerefoxMCP, search the
+Cerefox Decision Log and give the title of the latest part."* A correct answer proves
 search + document reconstruction over the OAuth path.
+
+> **If the connect fails right after consent** with an `ofid_…` reference: the OAuth App's
+> token endpoint auth method is wrong. It must be **`request body` (`client_secret_post`)**,
+> not HTTP Basic — see setup-supabase Step 7d. This is the most common mistake.
 
 > **Cost note**: each cloud tool call is ~1 Edge Function invocation. Fine for interactive
 > use; for heavy/automated work prefer the local stdio server (zero EF cost). Your local

--- a/docs/guides/setup-supabase.md
+++ b/docs/guides/setup-supabase.md
@@ -176,105 +176,109 @@ architecture explanation, and ChatGPT GPT Actions setup.
 
 ---
 
-## Step 7 — OAuth for cloud agents (Claude.ai / mobile) (optional) <a id="step-7--oauth-for-cloud-agents-claudeai--mobile-optional"></a>
+## Step 7 — Connect cloud & mobile Claude over OAuth (optional) <a id="step-7--oauth-for-cloud-agents-claudeai--mobile-optional"></a>
 
-> **Status (iter-28A):** the server side ships in the npm package and deploys with
-> `cerefox server deploy`. This section documents the one-time Supabase configuration.
-> The client-side connection walk-through lives in
-> [`connect-agents.md` → Cloud Claude](connect-agents.md#cloud-claude-claudeai-web--mobile-oauth).
-> Full design: [`docs/specs/oauth-mcp-server-design.md`](../specs/oauth-mcp-server-design.md).
+> **This whole section is optional.** You only need it to connect **claude.ai web and
+> the Claude mobile app** (and any other OAuth-only cloud MCP client). Everything in
+> Step 6 — the local MCP, Claude Desktop, Cursor, Claude Code, Codex, Gemini — works
+> **without** any of this. Skipping Step 7 costs you nothing except cloud/mobile Claude.
+>
+> The one extra moving part OAuth adds is a **hosted consent page** — the screen where
+> you approve the connection. A Supabase Edge Function can't serve it (Supabase rewrites
+> HTML to `text/plain` on the default `*.supabase.co` domain), so this repo ships the
+> page as a **free Cloudflare Worker** with a one-command deploy. Full design + the
+> gotchas we hit: [`docs/specs/oauth-mcp-server-design.md`](../specs/oauth-mcp-server-design.md).
 
-Cloud AI agents (claude.ai web, the Claude mobile app, and other
-OAuth-discovering MCP clients) can only connect to a custom MCP server over
-**OAuth** — they cannot send a static Bearer token. Supabase's native **OAuth 2.1
-Server** (beta; free during beta on all plans) makes `cerefox-mcp` a proper
-OAuth-protected resource, so those agents get the full tool surface. Your existing
-static-Bearer clients (Claude Code, Cursor, Codex, Gemini, Claude Desktop) keep
-working unchanged.
+Cloud AI agents can only connect to a custom MCP server over **OAuth** — they cannot send
+a static token. Supabase's native **OAuth 2.1 Server** (beta; free on all plans) makes
+`cerefox-mcp` an OAuth-protected resource, so claude.ai and the mobile app get the full
+hybrid-search tool surface (not the FTS-only `mcp.supabase.com` path).
 
-**Prerequisite — asymmetric signing keys.** Token validation uses your project's
-public JWKS, so the JWT signing key must be **asymmetric (ES256 or RS256)**, not the
-HS256 default. Check under **Project Settings → JWT Keys**; if it says HS256, migrate
-to ES256 first (Supabase-managed key rotation). Legacy-anon-key clients are unaffected
-by the rotation (they treat the key as an opaque string).
+**Prerequisite — asymmetric signing keys.** Token validation uses your project's public
+JWKS, so the JWT signing key must be **asymmetric (ES256 or RS256)**, not the HS256
+default. Check **Project Settings → JWT Keys**; if it says HS256, migrate to ES256 first
+(a Supabase-managed key rotation). Existing clients are unaffected (they treat the key as
+an opaque string). New projects often already default to ES256.
 
 ### 7a. Enable the OAuth 2.1 Server
 
-Supabase Dashboard → **Authentication → Configuration → OAuth Server**:
+Supabase Dashboard → **Authentication → OAuth Server** (under Configuration):
 
 - **Enable** the OAuth 2.1 Server.
-- **Authorization Path**: set to `/consent`. (This combines with the Site URL below
-  to form your consent-page URL.)
-- **Dynamic Client Registration (DCR): leave DISABLED.** The dashboard flags open DCR
-  as a security risk (any client could self-register), a single-user setup only ever
-  needs one client, and claude.ai's DCR against Supabase is currently unreliable. You
-  register the one client by hand in Step 7d instead.
+- **Authorization Path**: set to `/consent` (combines with the Site URL in 7b to form the
+  consent-page URL).
+- **Dynamic Client Registration (DCR): leave DISABLED.** The dashboard flags open DCR as a
+  security risk (any client could self-register), a single-user setup only needs one
+  client, and claude.ai's DCR against Supabase is currently unreliable. Register the one
+  client by hand in 7d instead.
 
-### 7b. Point the Site URL at the consent page
+### 7b. Deploy the consent page (free Cloudflare Worker) and point Site URL at it
 
-Supabase Dashboard → **Authentication → URL Configuration → Site URL**:
+The consent page is a single static file. Deploy it to a free Cloudflare Worker (needs a
+free Cloudflare account — no domain, no card):
 
+```bash
+cd cloudflare/cerefox-consent
+./deploy.sh        # reads your Supabase URL + anon key from ~/.cerefox/.env; runs wrangler
 ```
-https://<your-project-ref>.supabase.co/functions/v1/cerefox-oauth-consent
-```
 
-With Authorization Path `/consent`, the consent page is served at
-`…/cerefox-oauth-consent/consent`. (If your Site URL was the default
-`http://localhost:3000`, nothing depends on it — repointing is safe.)
+See [`cloudflare/cerefox-consent/README.md`](../../cloudflare/cerefox-consent/README.md)
+for the manual `wrangler` commands and how it works. It prints your Worker URL, e.g.
+`https://cerefox-consent.<your-subdomain>.workers.dev`.
 
-### 7c. Create the owner user + secrets
+Then Dashboard → **Authentication → URL Configuration → Site URL** = that Worker origin.
+With Authorization Path `/consent`, the consent page lands at `…workers.dev/consent`. (If
+your Site URL was the default `http://localhost:3000`, repointing is safe.)
 
-1. **Owner user** — Dashboard → **Authentication → Users → Add user**: your email +
-   a strong password. This is the login you'll type on the consent page (unrelated to
-   your Supabase dashboard login). Copy the new user's **UUID** from the users list.
-2. **Function secrets** — the `cerefox-mcp` function runs with in-function auth
-   (`--no-verify-jwt`). Set the **owner pin**; the back-compat secret is **optional**:
+### 7c. Create the owner user + pin it
+
+1. **Owner user** — Dashboard → **Authentication → Users → Add user**: your email + a
+   strong password. This is the login you type on the consent page (unrelated to your
+   Supabase dashboard login). Copy the new user's **UUID**.
+2. **Owner pin** — the only Function secret this feature needs:
 
    ```bash
-   # RECOMMENDED — owner pin: only tokens for THIS user id are accepted.
    supabase secrets set CEREFOX_OAUTH_OWNER_ID='<owner-user-uuid>' --project-ref <ref>
-
-   # OPTIONAL — back-compat for existing static-Bearer clients. Skip this unless
-   # you see old clients getting 401 (see note): by default the function uses the
-   # platform-injected SUPABASE_ANON_KEY, which is what those clients already send.
-   # supabase secrets set CEREFOX_MCP_STATIC_BEARER='eyJ...your-legacy-anon-jwt...' --project-ref <ref>
    ```
 
-   **`CEREFOX_OAUTH_OWNER_ID`** is the UUID from step 1 — a **server-side** value only
-   (never entered into claude.ai). Set it: it is the authorization boundary. If unset,
-   the function accepts *any* validly-signed `authenticated` token from your project's
-   auth server — which means **if email sign-ups are enabled (the Supabase default),
-   anyone who self-registers could get an accepted token**. Pinning the owner (or
-   disabling public sign-ups under Authentication → Sign In / Providers) closes that.
+   This is the **authorization boundary**, and a server-side value only (never entered
+   into claude.ai). If unset, the function accepts *any* validly-signed `authenticated`
+   token from your project's auth server — and **with Supabase's default email sign-ups
+   enabled, anyone who self-registers could get an accepted token**. Pin the owner (or
+   disable public sign-ups under Authentication → Sign In / Providers).
 
-   **`CEREFOX_MCP_STATIC_BEARER`** is optional back-compat. The function falls back to
-   the auto-injected `SUPABASE_ANON_KEY` (what Claude Code / Cursor / etc. already send),
-   so existing clients keep working without it. Set it explicitly only if the injected
-   var proves unreliable — the symptom is old clients getting 401 with a
-   `auth rejected: bad_signature`/`malformed_token` line in
-   `supabase functions logs cerefox-mcp`. Either way the static path fails **closed**
-   (never accepts an unexpected token).
-
-### 7d. Register the Claude client (pre-registration, since DCR is off)
+### 7d. Register the Claude client — **use `client_secret_post`**
 
 Dashboard → **Authentication → OAuth Apps → New OAuth App**:
 
-- **Client type**: Confidential (or Public — Claude supports both via the connector's
-  optional Client ID / Client Secret fields).
+- **Client type**: Confidential.
 - **Redirect URI** (exact match, no wildcards): `https://claude.ai/api/mcp/auth_callback`
-- Save, then copy the generated **Client ID** and **Client Secret** — you paste these
-  into the claude.ai connector dialog in `connect-agents.md`.
+- **Token endpoint auth method: `request body` (`client_secret_post`)** — **not** HTTP
+  Basic. Claude sends its client secret in the request body; the Basic default silently
+  fails the token exchange with an opaque `ofid_…` error and no usable token. **This is
+  the single most common setup mistake — get it right here.**
+- Save, then copy the **Client ID** and **Client Secret** (the secret is shown once). You
+  paste both into the claude.ai connector — see
+  [`connect-agents.md` → Cloud Claude](connect-agents.md#cloud-claude-claudeai-web--mobile-oauth).
 
-### 7e. Deploy
+### 7e. Deploy the function
 
 ```bash
 cerefox server deploy --functions-only
 ```
 
-This deploys `cerefox-mcp` and `cerefox-oauth-consent` with `--no-verify-jwt` (the
-deploy prints a reminder to set the secrets above). Then continue with the client
-connection in
+Deploys `cerefox-mcp` with `--no-verify-jwt` (in-function auth). Then wire the claude.ai
+connector per
 [`connect-agents.md` → Cloud Claude](connect-agents.md#cloud-claude-claudeai-web--mobile-oauth).
+
+> **Note — remote static-token clients.** Deploying with `--no-verify-jwt` means the
+> Supabase gateway no longer validates the anon-JWT Bearer that *remote* static-token
+> clients would send directly to `cerefox-mcp`. **Most setups have none** — local coding
+> agents use the local MCP (Step 6), which is also cheaper (zero Edge Function calls). If
+> you do run such a client and it starts returning 401 after enabling OAuth, that is a
+> separate back-compat concern covered in the
+> [design doc §5](../specs/oauth-mcp-server-design.md); it is **not** part of the
+> OAuth/cloud setup and needs no secret here.
 
 ---
 

--- a/docs/guides/setup-supabase.md
+++ b/docs/guides/setup-supabase.md
@@ -214,21 +214,41 @@ Supabase Dashboard → **Authentication → OAuth Server** (under Configuration)
 
 ### 7b. Deploy the consent page (free Cloudflare Worker) and point Site URL at it
 
-The consent page is a single static file. Deploy it to a free Cloudflare Worker (needs a
-free Cloudflare account — no domain, no card):
+The consent page is a single static file that talks only to Supabase Auth. It embeds a
+**publishable** key (`sb_publishable_…`) — **never the legacy anon JWT**. (The anon JWT is a
+full-KB credential; the publishable key is public-safe — it's rejected by the Edge Function
+gateway and, since schema 0.7.0, cannot call the Data API RPCs either. See the
+[security model](../specs/security-model.md).)
+
+Add your publishable key to `~/.cerefox/.env` as the single source
+(`deploy.sh` reads it). Grab it from the dashboard (**Project Settings → API Keys →
+Publishable**) or the CLI:
+
+```bash
+npx supabase projects api-keys --project-ref <ref>   # find the "publishable" entry
+echo 'CEREFOX_SUPABASE_PUBLISHABLE_KEY=sb_publishable_…' >> ~/.cerefox/.env
+```
+
+Then deploy to a free Cloudflare Worker (needs a free Cloudflare account — no domain, no
+card):
 
 ```bash
 cd cloudflare/cerefox-consent
-./deploy.sh        # reads your Supabase URL + anon key from ~/.cerefox/.env; runs wrangler
+./deploy.sh        # reads CEREFOX_SUPABASE_URL + CEREFOX_SUPABASE_PUBLISHABLE_KEY from ~/.cerefox/.env
 ```
 
 See [`cloudflare/cerefox-consent/README.md`](../../cloudflare/cerefox-consent/README.md)
-for the manual `wrangler` commands and how it works. It prints your Worker URL, e.g.
+for the manual `wrangler` commands. It prints your Worker URL, e.g.
 `https://cerefox-consent.<your-subdomain>.workers.dev`.
 
 Then Dashboard → **Authentication → URL Configuration → Site URL** = that Worker origin.
 With Authorization Path `/consent`, the consent page lands at `…workers.dev/consent`. (If
 your Site URL was the default `http://localhost:3000`, repointing is safe.)
+
+> **Custom-domain alternative:** a `cerefox-oauth-consent` Edge Function also ships (renders
+> the same page from the `CEREFOX_SUPABASE_PUBLISHABLE_KEY` Function secret). It only works
+> behind a paid Supabase custom domain (EFs serve `text/plain` on `*.supabase.co`), so the
+> free Cloudflare Worker is the default.
 
 ### 7c. Create the owner user + pin it
 
@@ -242,10 +262,11 @@ your Site URL was the default `http://localhost:3000`, repointing is safe.)
    ```
 
    This is the **authorization boundary**, and a server-side value only (never entered
-   into claude.ai). If unset, the function accepts *any* validly-signed `authenticated`
-   token from your project's auth server — and **with Supabase's default email sign-ups
-   enabled, anyone who self-registers could get an accepted token**. Pin the owner (or
-   disable public sign-ups under Authentication → Sign In / Providers).
+   into claude.ai). The OAuth path **fails closed when this is unset** — the function
+   rejects every OAuth token — because otherwise, with Supabase's default email sign-ups
+   on, anyone who self-registers could get an accepted token. For a deliberate multi-user
+   setup (with sign-ups disabled), opt out explicitly:
+   `supabase secrets set CEREFOX_OAUTH_ALLOW_ANY_USER=true`.
 
 ### 7d. Register the Claude client — **use `client_secret_post`**
 

--- a/docs/guides/setup-supabase.md
+++ b/docs/guides/setup-supabase.md
@@ -228,20 +228,32 @@ With Authorization Path `/consent`, the consent page is served at
    a strong password. This is the login you'll type on the consent page (unrelated to
    your Supabase dashboard login). Copy the new user's **UUID** from the users list.
 2. **Function secrets** — the `cerefox-mcp` function runs with in-function auth
-   (`--no-verify-jwt`), so it needs:
+   (`--no-verify-jwt`). Set the **owner pin**; the back-compat secret is **optional**:
 
    ```bash
-   # Back-compat: lets existing static-Bearer clients keep working (your legacy anon JWT):
-   supabase secrets set CEREFOX_MCP_STATIC_BEARER='eyJ...your-legacy-anon-jwt...' --project-ref <ref>
-
-   # Single-user hardening: only tokens for THIS user id are accepted:
+   # RECOMMENDED — owner pin: only tokens for THIS user id are accepted.
    supabase secrets set CEREFOX_OAUTH_OWNER_ID='<owner-user-uuid>' --project-ref <ref>
+
+   # OPTIONAL — back-compat for existing static-Bearer clients. Skip this unless
+   # you see old clients getting 401 (see note): by default the function uses the
+   # platform-injected SUPABASE_ANON_KEY, which is what those clients already send.
+   # supabase secrets set CEREFOX_MCP_STATIC_BEARER='eyJ...your-legacy-anon-jwt...' --project-ref <ref>
    ```
 
-   `CEREFOX_OAUTH_OWNER_ID` is the UUID from step 1. It is a **server-side** value only —
-   you never enter it into claude.ai. If unset, any validly-signed token from your
-   project's auth server is accepted (safe only because a single-user project has one
-   user; setting it is the recommended default).
+   **`CEREFOX_OAUTH_OWNER_ID`** is the UUID from step 1 — a **server-side** value only
+   (never entered into claude.ai). Set it: it is the authorization boundary. If unset,
+   the function accepts *any* validly-signed `authenticated` token from your project's
+   auth server — which means **if email sign-ups are enabled (the Supabase default),
+   anyone who self-registers could get an accepted token**. Pinning the owner (or
+   disabling public sign-ups under Authentication → Sign In / Providers) closes that.
+
+   **`CEREFOX_MCP_STATIC_BEARER`** is optional back-compat. The function falls back to
+   the auto-injected `SUPABASE_ANON_KEY` (what Claude Code / Cursor / etc. already send),
+   so existing clients keep working without it. Set it explicitly only if the injected
+   var proves unreliable — the symptom is old clients getting 401 with a
+   `auth rejected: bad_signature`/`malformed_token` line in
+   `supabase functions logs cerefox-mcp`. Either way the static path fails **closed**
+   (never accepts an unexpected token).
 
 ### 7d. Register the Claude client (pre-registration, since DCR is off)
 

--- a/docs/guides/setup-supabase.md
+++ b/docs/guides/setup-supabase.md
@@ -164,14 +164,105 @@ This points the client at the local stdio server (`cerefox mcp`). To edit
 configs by hand or use the remote (Edge Function) HTTP transport, see
 [`connect-agents.md`](connect-agents.md).
 
-**For cloud Claude.ai** — connect to the Supabase remote MCP (FTS keyword search only):
-1. In Supabase Dashboard → Project Settings → Integrations → MCP, get your project ref
-2. In Claude.ai Settings → Integrations, add `https://mcp.supabase.com/sse?project_ref=<ref>`
+**For cloud Claude.ai / Claude mobile** — connect over OAuth to your own
+`cerefox-mcp` Edge Function with the **full hybrid-search tool surface** (not the
+FTS-only `mcp.supabase.com` path). This needs a one-time OAuth setup — see
+[Step 7](#step-7--oauth-for-cloud-agents-claudeai--mobile-optional) below.
 
 **For cloud ChatGPT** — create a Custom GPT with GPT Actions pointing at the Edge Functions.
 
 See `docs/guides/connect-agents.md` for the complete guide including system prompts,
 architecture explanation, and ChatGPT GPT Actions setup.
+
+---
+
+## Step 7 — OAuth for cloud agents (Claude.ai / mobile) (optional) <a id="step-7--oauth-for-cloud-agents-claudeai--mobile-optional"></a>
+
+> **Status (iter-28A):** the server side ships in the npm package and deploys with
+> `cerefox server deploy`. This section documents the one-time Supabase configuration.
+> The client-side connection walk-through lives in
+> [`connect-agents.md` → Cloud Claude](connect-agents.md#cloud-claude-claudeai-web--mobile-oauth).
+> Full design: [`docs/specs/oauth-mcp-server-design.md`](../specs/oauth-mcp-server-design.md).
+
+Cloud AI agents (claude.ai web, the Claude mobile app, and other
+OAuth-discovering MCP clients) can only connect to a custom MCP server over
+**OAuth** — they cannot send a static Bearer token. Supabase's native **OAuth 2.1
+Server** (beta; free during beta on all plans) makes `cerefox-mcp` a proper
+OAuth-protected resource, so those agents get the full tool surface. Your existing
+static-Bearer clients (Claude Code, Cursor, Codex, Gemini, Claude Desktop) keep
+working unchanged.
+
+**Prerequisite — asymmetric signing keys.** Token validation uses your project's
+public JWKS, so the JWT signing key must be **asymmetric (ES256 or RS256)**, not the
+HS256 default. Check under **Project Settings → JWT Keys**; if it says HS256, migrate
+to ES256 first (Supabase-managed key rotation). Legacy-anon-key clients are unaffected
+by the rotation (they treat the key as an opaque string).
+
+### 7a. Enable the OAuth 2.1 Server
+
+Supabase Dashboard → **Authentication → Configuration → OAuth Server**:
+
+- **Enable** the OAuth 2.1 Server.
+- **Authorization Path**: set to `/consent`. (This combines with the Site URL below
+  to form your consent-page URL.)
+- **Dynamic Client Registration (DCR): leave DISABLED.** The dashboard flags open DCR
+  as a security risk (any client could self-register), a single-user setup only ever
+  needs one client, and claude.ai's DCR against Supabase is currently unreliable. You
+  register the one client by hand in Step 7d instead.
+
+### 7b. Point the Site URL at the consent page
+
+Supabase Dashboard → **Authentication → URL Configuration → Site URL**:
+
+```
+https://<your-project-ref>.supabase.co/functions/v1/cerefox-oauth-consent
+```
+
+With Authorization Path `/consent`, the consent page is served at
+`…/cerefox-oauth-consent/consent`. (If your Site URL was the default
+`http://localhost:3000`, nothing depends on it — repointing is safe.)
+
+### 7c. Create the owner user + secrets
+
+1. **Owner user** — Dashboard → **Authentication → Users → Add user**: your email +
+   a strong password. This is the login you'll type on the consent page (unrelated to
+   your Supabase dashboard login). Copy the new user's **UUID** from the users list.
+2. **Function secrets** — the `cerefox-mcp` function runs with in-function auth
+   (`--no-verify-jwt`), so it needs:
+
+   ```bash
+   # Back-compat: lets existing static-Bearer clients keep working (your legacy anon JWT):
+   supabase secrets set CEREFOX_MCP_STATIC_BEARER='eyJ...your-legacy-anon-jwt...' --project-ref <ref>
+
+   # Single-user hardening: only tokens for THIS user id are accepted:
+   supabase secrets set CEREFOX_OAUTH_OWNER_ID='<owner-user-uuid>' --project-ref <ref>
+   ```
+
+   `CEREFOX_OAUTH_OWNER_ID` is the UUID from step 1. It is a **server-side** value only —
+   you never enter it into claude.ai. If unset, any validly-signed token from your
+   project's auth server is accepted (safe only because a single-user project has one
+   user; setting it is the recommended default).
+
+### 7d. Register the Claude client (pre-registration, since DCR is off)
+
+Dashboard → **Authentication → OAuth Apps → New OAuth App**:
+
+- **Client type**: Confidential (or Public — Claude supports both via the connector's
+  optional Client ID / Client Secret fields).
+- **Redirect URI** (exact match, no wildcards): `https://claude.ai/api/mcp/auth_callback`
+- Save, then copy the generated **Client ID** and **Client Secret** — you paste these
+  into the claude.ai connector dialog in `connect-agents.md`.
+
+### 7e. Deploy
+
+```bash
+cerefox server deploy --functions-only
+```
+
+This deploys `cerefox-mcp` and `cerefox-oauth-consent` with `--no-verify-jwt` (the
+deploy prints a reminder to set the secrets above). Then continue with the client
+connection in
+[`connect-agents.md` → Cloud Claude](connect-agents.md#cloud-claude-claudeai-web--mobile-oauth).
 
 ---
 

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -3218,8 +3218,11 @@ to clients), so gating the EFs on it = **no access control** (anyone who reads i
 access, since the EFs use `service_role` internally with no RLS). It only looks lower-friction
 — it isn't (you'd still paste it into every client config), and it removes all security. The
 Cerefox-managed token is the same paste-a-credential friction as today's anon key, but secret +
-rotatable; friction is minimized by automating it (`cerefox` generates + stores the Function
-secret and writes it via `configure-agent`).
+rotatable; friction is minimized by automating it (`cerefox token generate` creates + stores
+the Function secret and prints the token to paste into the two remote paths). Note the token
+touches only **GPT Actions** and the **remote HTTP MCP** — `configure-agent` writes a *local*
+stdio MCP entry (Data API via the local server's own `.env`), so it needs no token and is
+unaffected by 28E.
 
 ### 28A: OAuth 2.1 on `cerefox-mcp` — cloud/mobile Claude connectivity
 

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -3198,6 +3198,29 @@ workstreams on separate branches, merge each into `main`, then cut `v1.0.0-beta`
    Kallisti) — restore each from its last clean version after the chunker fix is installed.
 5. Retire the Python MCP fallback? — candidate for v1.0 (drops the chunker parity requirement).
 
+**Release sequencing (decided 2026-07-09) — stay in `0.x` until all breaking changes land, then freeze 1.0:**
+1. **`0.12.0-beta`** — finish **28E** (EF-auth migration, done *very carefully/defensively*) +
+   docs cleanup + secret cleanup (②) → merge `feat/oauth-mcp` → `main` → cut the beta →
+   **test extensively on the maintainer laptop** → *soft* Discord (beta testers only).
+2. **`0.12.x` betas** — the **full-codebase security audit** (③, + any mitigations) then
+   **28D Phase 1** (proper chunker: `content_format` schema + blind-stitch).
+3. **`1.0.0-rc` → `1.0.0`** once every breaking/schema change is in, audited, and soaked —
+   the stability commitment (28C).
+*Why not `1.0.0-RC` now:* RC implies "no more breaking changes," but 28E (client creds),
+28D Phase 1 (schema), and audit mitigations are still breaking/schema-affecting. Under strict
+SemVer they must land BEFORE the 1.0 freeze, or they'd force a 2.0.0. **Discord:** soft-launch
+to testers on the beta; hold the broad public announce until after the full audit (③) — it's a
+security-sensitive release, don't publicize new public surfaces before auditing them.
+
+**28E credential decision (2026-07-09): a Cerefox-managed token, NOT `sb_publishable_`.**
+The publishable key is *public by design* (it's embedded in the consent Worker HTML, shipped
+to clients), so gating the EFs on it = **no access control** (anyone who reads it gets full KB
+access, since the EFs use `service_role` internally with no RLS). It only looks lower-friction
+— it isn't (you'd still paste it into every client config), and it removes all security. The
+Cerefox-managed token is the same paste-a-credential friction as today's anon key, but secret +
+rotatable; friction is minimized by automating it (`cerefox` generates + stores the Function
+secret and writes it via `configure-agent`).
+
 ### 28A: OAuth 2.1 on `cerefox-mcp` — cloud/mobile Claude connectivity
 
 **Design of record**: [`docs/specs/oauth-mcp-server-design.md`](specs/oauth-mcp-server-design.md)

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -3174,6 +3174,30 @@ of the polish design doc becomes binding.
 **Trigger** (for 28B/28C; 28A can start immediately): ~2-3 months of v0.10/v0.11 in the
 wild without breaking changes + at least one outside user installing without help.
 
+### v1.0.0 release scope + remaining steps (updated 2026-07-09)
+
+v1.0.0 grew into a large, multi-workstream release. **Branch strategy:** keep the
+workstreams on separate branches, merge each into `main`, then cut `v1.0.0-beta` from
+`main` (each is independently reviewable/testable; squash-merge collapses history).
+
+| Workstream | Branch | Status | Remaining before merge |
+|---|---|---|---|
+| **28A — OAuth MCP** (claude.ai + mobile) | `feat/oauth-mcp` | ✅ built + live-working | Phase 5 regression matrix (static-Bearer clients) |
+| **28B — Security** | `feat/oauth-mcp` | ✅ audit + fixes deployed (OAuth surface) | ① anon-key rotation ② secret cleanup ③ **full-codebase audit** (8 primitive EFs, GPT Actions, web app, backup/restore) — may add mitigations |
+| **28D — Chunk reconstruction fix** | `fix/chunk-reconstruction` (new) | interim keep-whole shipped on `feat/oauth-mcp`; Phase 0/1 not started | Phase 0 embed cap + Phase 1 blind-stitch + doctor check + data recovery of 4 corrupted docs |
+| **28C — Stability contract** | (at cut) | pending | strict SemVer becomes binding; `security-model.md` + threat model finalized |
+
+**Held priority TODOs (do NOT lose these):**
+1. **Rotate the exposed anon key** (was briefly in the public consent Worker) — rotate the
+   legacy JWT secret; re-issue the anon key to client configs; update `CEREFOX_MCP_STATIC_BEARER`.
+2. **Supabase/CF secret cleanup** — keep `CEREFOX_OAUTH_OWNER_ID`, `CEREFOX_SUPABASE_PUBLISHABLE_KEY`;
+   drop `CEREFOX_MCP_STATIC_BEARER` if no remote static-Bearer clients; verify the old CF
+   `SUPABASE_ANON_KEY` Worker var is gone; consider deleting the redundant `cerefox-oauth-consent` EF.
+3. **Full-codebase security audit** before merge (28B extends with any new mitigations).
+4. **Data recovery** of the 4 chunker-corrupted docs (Job Hunting, Oshmabel, Saltwater,
+   Kallisti) — restore each from its last clean version after the chunker fix is installed.
+5. Retire the Python MCP fallback? — candidate for v1.0 (drops the chunker parity requirement).
+
 ### 28A: OAuth 2.1 on `cerefox-mcp` — cloud/mobile Claude connectivity
 
 **Design of record**: [`docs/specs/oauth-mcp-server-design.md`](specs/oauth-mcp-server-design.md)
@@ -3260,6 +3284,35 @@ for 28A — audit runs on the **Fable 5** model per maintainer):
 - Dependency audit (`bun audit`, `npm audit`) — clean tree at v1.0 cut.
 - Secrets scanner (`gitleaks` or similar) on the repo history — verify no credentials ever committed.
 - Document the threat model + audit findings in `docs/specs/security-model.md` (new) — part of the v1.0 deliverable.
+
+### 28B (extended 2026-07-09): deployed OAuth-surface fixes
+
+The OAuth-surface audit ran 2026-07-09 and **shipped fixes** (schema 0.7.0 + EF/Worker
+redeploys, live-verified): closed a Data-API RPC execute-privilege gap (SECURITY DEFINER
+RPCs now `service_role`-only); the OAuth consent page uses the public-safe publishable key
+(not the anon JWT); issuer/JWKS derive from `SUPABASE_URL`; the OAuth path fails closed
+when the owner isn't pinned. Full technical record: Decision Log Q3 Part 1 (KB, private —
+exploit specifics kept out of public docs). Public reference: `docs/specs/security-model.md`.
+**Still owed (see the held-TODOs table above): anon-key rotation, secret cleanup, and the
+FULL-codebase audit** of the 8 primitive EFs, GPT Actions, web app, and backup/restore.
+
+### 28D: Chunk-reconstruction fix (data-corruption bug)
+
+**Design**: [`docs/specs/chunk-reconstruction-design.md`](specs/chunk-reconstruction-design.md).
+Branch `fix/chunk-reconstruction`. A serious data-corruption bug: `cerefox_reconstruct_doc`
+re-synthesizes a `\n\n` separator it never stored, so any chunk split not on a paragraph
+boundary corrupts on read (duplication via a 50%-overlap hard-split, or a blank line
+mid-word/mid-row). 4 KB docs were corrupted.
+
+- **Interim fix (SHIPPED on `feat/oauth-mcp`)**: keep oversized single paragraphs whole →
+  lossless for realistic docs; regression test asserts `reconstruct(chunk(doc)) === doc`.
+- **Phase 0**: cap the embedding input to the model token limit (+ warn) so a huge whole
+  chunk never fails ingest.
+- **Phase 1**: exact-partition chunker + heading context moved to the embedding input +
+  a `content_format` marker on `cerefox_documents` (schema 0.7.0 → 0.8.0) + versioned
+  reconstruction (blind-stitch for new docs, `\n\n`-join for legacy) + **lazy migration**
+  (docs convert on next edit; no forced re-embed) + a `cerefox doctor` legacy-format count.
+- **Data recovery**: restore the 4 corrupted docs from their last clean version.
 
 ### 28C: The contract
 
@@ -3539,6 +3592,16 @@ in-place supervise-restart) instead of relying on the Docker restart cycle.
 ---
 
 ## Current Focus
+
+**Update (2026-07-09): v1.0.0 is a large multi-workstream release — see the "v1.0.0
+release scope + remaining steps" table under Iteration 28.** On `feat/oauth-mcp`:
+28A OAuth MCP (working) + 28B security fixes (deployed, OAuth surface) + the interim
+chunker keep-whole fix. Newly scoped as design-of-record: **28D chunk-reconstruction**
+([`docs/specs/chunk-reconstruction-design.md`](specs/chunk-reconstruction-design.md),
+branch `fix/chunk-reconstruction`). **Held priority TODOs** (in the scope table): anon-key
+rotation, secret cleanup, full-codebase security audit, recovery of the 4 chunker-corrupted
+docs, and (maybe) retiring the Python MCP fallback at v1.0. Branch strategy: separate
+branches → `main` → cut `v1.0.0-beta`.
 
 **Update (2026-07-08, `main` at v0.11.1): Iteration 28A (OAuth MCP) is BUILT and WORKING
 end-to-end on `feat/oauth-mcp`.** claude.ai web + Claude mobile now connect to

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -3200,8 +3200,9 @@ workstreams on separate branches, merge each into `main`, then cut `v1.0.0-beta`
 
 **Release sequencing (decided 2026-07-09) — stay in `0.x` until all breaking changes land, then freeze 1.0:**
 1. **`0.12.0-beta`** — finish **28E** (EF-auth migration, done *very carefully/defensively*) +
-   docs cleanup + secret cleanup (②) → merge `feat/oauth-mcp` → `main` → cut the beta →
-   **test extensively on the maintainer laptop** → *soft* Discord (beta testers only).
+   **28F** (full documentation sanity sweep) + secret cleanup (②) → merge `feat/oauth-mcp` →
+   `main` → cut the beta → **test extensively on the maintainer laptop** → *soft* Discord
+   (beta testers only).
 2. **`0.12.x` betas** — the **full-codebase security audit** (③, + any mitigations) then
    **28D Phase 1** (proper chunker: `content_format` schema + blind-stitch).
 3. **`1.0.0-rc` → `1.0.0`** once every breaking/schema change is in, audited, and soaked —
@@ -3377,6 +3378,34 @@ NOT a Supabase key:
 - **Priority: implement next** (maintainer 2026-07-09) — it's the enabler for fully retiring
   the legacy JWT + closing the maintainer's own residual anon-key risk. Overlaps 28B.
   Interim already done: `CEREFOX_MCP_STATIC_BEARER` removed on the maintainer project.
+
+### 28F: Documentation sanity sweep (v0.12.0-beta release deliverable)
+
+The access-path narrative shifted materially across 28A (OAuth), 28B (security), and 28E
+(token + legacy-JWT retirement). Before the beta cut, do **one full documentation pass** to
+make every guide tell the *same* new story. This is broader than 28E §8's targeted edits — it's
+a whole-repo consistency check. Target: v0.12.0-beta (part of step 1 in the sequencing block).
+
+**The single narrative every doc must reflect:**
+- **Local agents** (Claude Code, Cursor, Codex, Gemini, Desktop) → **local MCP** via
+  `cerefox configure-agent` (stdio, Data API, no EF token). *Preferred.*
+- **Cloud Claude** (web/mobile) → **OAuth** connector to `cerefox-mcp`.
+- **Custom GPT** → **GPT Actions** + the **Cerefox token**.
+- **Remote HTTP MCP** → token (Advanced/fallback only; not the headline).
+- **Legacy anon JWT is retired** for all EF paths (hard cutover, 28E). `CEREFOX_MCP_STATIC_BEARER`
+  is gone. New `cerefox token generate/rotate/list` + `CEREFOX_ACCESS_TOKENS` Function secret.
+
+**Docs to review (checklist):** `docs/guides/{connect-agents,access-paths,setup-supabase,
+quickstart,configuration,setup-local,setup-cloud-run}.md`, `CLAUDE.md` (Layer-1 auth note +
+Client-Compatibility table + EF inventory), `docs/solution-design.md` (auth layers),
+`docs/specs/security-model.md` (new invariant: all data EFs in-function-auth'd on a rotatable
+token), `README.md`, `AGENT_GUIDE.md`, `AGENT_QUICK_REFERENCE.md`, and the `CHANGELOG.md` beta
+entry. Sync the GPT Actions OpenAPI block (`info.version` bump) per the CLAUDE.md rule.
+
+**Grep gates (must return nothing stale after the sweep):** any lingering `CEREFOX_MCP_STATIC_BEARER`;
+any "anon JWT"/"legacy anon"/`Bearer eyJ` shown as the *current* way to connect an EF/GPT-Action
+client (historical/iteration-log mentions are fine); any doc still pointing local agents at the
+remote MCP as the default. Do the grep, fix or annotate each hit.
 
 ### 28C: The contract
 

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -3314,6 +3314,32 @@ mid-word/mid-row). 4 KB docs were corrupted.
   (docs convert on next edit; no forced re-embed) + a `cerefox doctor` legacy-format count.
 - **Data recovery**: restore the 4 corrupted docs from their last clean version.
 
+### 28E: Migrate Edge Function auth off the unrotatable legacy anon JWT
+
+**Problem (surfaced by the 2026-07-09 rotation attempt).** Supabase's Edge Function gateway
+is JWT-only — it rejects the new `sb_publishable_`/`sb_secret_` keys (Decision Log Q2 Part 1,
+2026-05-18). So the 8 primitive EFs (ChatGPT GPT Actions + direct HTTP) and `cerefox-mcp`'s
+static-Bearer path require the **legacy anon JWT**. On a project migrated to asymmetric
+(ES256) signing keys — Supabase's default direction — the legacy anon key **can only be
+revoked, not rotated** (revoking kills the whole EF path). So **any Cerefox user whose anon
+key leaks is stuck**: they can't cycle it without disabling GPT Actions / remote MCP. A real
+security gap for every user on the anon-key/EF path (not just the maintainer).
+
+**Fix — the deferred "Option B" from the Decision Log; trigger conditions (security +
+touching the client-config layer) are now met.** Deploy the 8 primitive EFs with
+`--no-verify-jwt` and validate the caller's key **in-function**, accepting a **rotatable**
+key (`sb_publishable_`/`sb_secret_`, or a Cerefox-managed token) instead of the unrotatable
+legacy anon JWT.
+- Reuse the in-function auth pattern from `_shared/mcp-auth/` (iter-28A) — a shared
+  constant-time key/token check for the primitive EFs.
+- Update the GPT Actions OpenAPI block (auth scheme + `info.version` bump) and the
+  remote-MCP client docs to the new key — a documented, client-config-breaking migration
+  with a back-compat window (still accept the legacy anon JWT during deprecation).
+- Candidate for v1.0 (security) or a fast-follow; overlaps 28B's mitigations. Interim: on
+  the maintainer's own project, remove `CEREFOX_MCP_STATIC_BEARER` (done 2026-07-09) and
+  accept residual risk on the primitive EFs (GPT Actions kept; low exposure, RPC bypass
+  already closed) until this migration ships.
+
 ### 28C: The contract
 
 Strict SemVer becomes binding. **Design**: [`docs/specs/polish-and-distribution-design.md` §13 v1.0.0](specs/polish-and-distribution-design.md).

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -3202,13 +3202,29 @@ deferral (`docs/research/oauth-mcp-auth.md`).
   path. Silver lining: the dialog confirms pre-registered-client credentials are
   supported → the DCR fallback (design §4.2-D) is a verified UI affordance. Connector
   name will be **CerefoxMCP** (design §4.4 outcome note).
-- **Phase 0 ✅ COMPLETE (2026-07-08)**: OAuth Server available on the maintainer plan
-  (disabled, ready to enable); signing keys **already ES256/P-256** (the HS256→asymmetric
-  migration prerequisite is moot for this project); Site URL is the unused
-  `localhost:3000` default → repointing at the consent EF is risk-free. Next: Phase 1
-  (enable + configure OAuth server, owner user) and Phase 2 (consent EF) — Phase 2's URL
-  is needed for Phase 1's Site URL, so build order is consent EF first or configure with
-  the known-in-advance EF URL.
+- **Phase 0 ✅ COMPLETE (2026-07-08)**: OAuth Server available on the maintainer plan;
+  signing keys **already ES256/P-256** (migration prerequisite moot); Site URL was the
+  unused `localhost:3000` default.
+- **Phases 2–3 code ✅ BUILT (2026-07-08), not yet deployed.** Commit on `feat/oauth-mcp`.
+  Shipped: `_shared/mcp-auth/` (dependency-free token validation — static constant-time
+  compare + OAuth JWT via SubtleCrypto against the project JWKS, ES256/RS256 allowlist,
+  iss/aud/exp/owner-sub, fail-closed, isolate JWKS cache; **20 unit tests green**, runs
+  under both Deno and Bun); `cerefox-mcp` auth-first dispatch + RFC 9728 metadata route +
+  401/`WWW-Authenticate` (405-for-GET and `/version` preserved); new public
+  `cerefox-oauth-consent` EF (client-side sign-in + approve/deny, `location.assign`
+  redirects so no 307 per #250, graceful consumed-`authorization_id` per #562);
+  `deploy-server` `NO_VERIFY_JWT_EFS` map (only the two EFs skip the gateway) + secret
+  reminder; `bundle_server_assets` ships `_shared/mcp-auth`. Docs updated:
+  setup-supabase Step 7 (OAuth config) + connect-agents Cloud Claude (OAuth).
+- **Phase 1 dashboard (maintainer, 2026-07-08)**: OAuth Server **enabled**, DCR left
+  **disabled** (pre-registered client instead), Site URL repointed to the consent EF,
+  owner user created (UUID `0b850e27-…`). **Remaining before Phase 4**: set the two
+  Function secrets (`CEREFOX_MCP_STATIC_BEARER`, `CEREFOX_OAUTH_OWNER_ID`), register the
+  Claude OAuth App (redirect `https://claude.ai/api/mcp/auth_callback`), then
+  `cerefox server deploy --functions-only`.
+- **Next: Phase 4** — connect claude.ai with the pre-registered Client ID/Secret, watch
+  the discovery→consent→token→tool-call handshake in EF logs, confirm mobile, then the
+  Phase 5 regression matrix for the static-Bearer clients.
 - All platform claims re-verified against live Supabase/Anthropic docs 2026-07-08
   (design §14 has the verification table; re-check before each phase).
 - **Beta caveat**: Supabase's OAuth server is beta. If Phase 4 shows instability, soak

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -3339,6 +3339,9 @@ mid-word/mid-row). 4 KB docs were corrupted.
 
 ### 28E: Migrate Edge Function auth off the unrotatable legacy anon JWT
 
+**Design-of-record**: [`docs/specs/ef-auth-migration-design.md`](specs/ef-auth-migration-design.md)
+(the full, self-contained design + defensive rollout order — start there).
+
 **Problem (surfaced by the 2026-07-09 rotation attempt).** Supabase's Edge Function gateway
 is JWT-only — it rejects the new `sb_publishable_`/`sb_secret_` keys (Decision Log Q2 Part 1,
 2026-05-18). So the 8 primitive EFs (ChatGPT GPT Actions + direct HTTP) and `cerefox-mcp`'s

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -3222,9 +3222,19 @@ deferral (`docs/research/oauth-mcp-auth.md`).
   Function secrets (`CEREFOX_MCP_STATIC_BEARER`, `CEREFOX_OAUTH_OWNER_ID`), register the
   Claude OAuth App (redirect `https://claude.ai/api/mcp/auth_callback`), then
   `cerefox server deploy --functions-only`.
-- **Next: Phase 4** — connect claude.ai with the pre-registered Client ID/Secret, watch
-  the discovery→consent→token→tool-call handshake in EF logs, confirm mobile, then the
-  Phase 5 regression matrix for the static-Bearer clients.
+- **Phase 2/3 deployed + live-verified (2026-07-08).** `cerefox-mcp` + secrets
+  (`CEREFOX_OAUTH_OWNER_ID`, `CEREFOX_MCP_STATIC_BEARER`) deployed. Live curls pass:
+  RFC 9728 metadata (https, exact `resource` match), 401+`WWW-Authenticate` on
+  unauthenticated POST, `tools/list` with the anon key → 10 tools. Two live fixes: the
+  `http→https` metadata scheme bug, and the injected `SUPABASE_ANON_KEY` not
+  authenticating (→ explicit `CEREFOX_MCP_STATIC_BEARER` required). **Consent page
+  moved to a Cloudflare Worker** (Supabase EFs rewrite html→text/plain on the default
+  domain) — deployed to `https://cerefox-consent.f-stamatelopoulos.workers.dev`,
+  verified serving real `text/html` with the project URL + anon key injected.
+- **Next: Phase 4** — set Supabase Site URL → the Worker; register the Claude OAuth App;
+  add the CerefoxMCP connector on claude.ai; watch discovery→consent→token→tool-call;
+  confirm mobile; then the Phase 5 regression matrix for static-Bearer clients. Highest
+  remaining risk: the beta supabase-js `auth.oauth.*` API in the consent page.
 - All platform claims re-verified against live Supabase/Anthropic docs 2026-07-08
   (design §14 has the verification table; re-check before each phase).
 - **Beta caveat**: Supabase's OAuth server is beta. If Phase 4 shows instability, soak

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -3156,23 +3156,69 @@ Accumulating on `fix/v0.9.1` (draft PR #68). Status as of 2026-05-30:
 
 ---
 
-## Iteration 28: v1.0.0 — "Stability Commitment" + Security Audit
+## Iteration 28: v1.0.0 — OAuth MCP (Claude.ai + mobile) + "Stability Commitment" + Security Audit
 
-**Goal**: Not a feature release. The contract release. Strict SemVer policy from §11 of the
-design doc becomes binding. Plus a one-time security audit (added per Fotis-24 / 2026-05-29).
+**Re-scoped 2026-07-08**: the OAuth-protected remote MCP server (Claude.ai / Claude
+mobile / other cloud agents) is folded INTO this iteration as 28A (maintainer decision).
+Rationale: the feature and the stability commitment travel together so the one-time
+security audit (28B) covers the new OAuth auth surface in the same pass — the audit's
+"every public endpoint requires auth" headline item must anyway be re-stated around the
+two deliberately-public routes 28A introduces. v1.0.0 is thus a feature + contract
+release. Work lands on `feat/oauth-mcp`.
 
-**Trigger**: ~2-3 months of v0.9 in the wild without breaking changes + at least one outside
-user installing without help.
+**Goal**: (28A) any OAuth-discovering MCP client — claude.ai web, the Claude mobile app,
+potentially ChatGPT connectors — can use the full 10-tool Cerefox surface; (28B) one-time
+security audit over the final surface; (28C) the contract: strict SemVer policy from §11
+of the polish design doc becomes binding.
 
-**Security audit headline items** (added 2026-05-29 per Fotis-24):
+**Trigger** (for 28B/28C; 28A can start immediately): ~2-3 months of v0.10/v0.11 in the
+wild without breaking changes + at least one outside user installing without help.
 
-- Every public-facing endpoint (Edge Functions including the new `/version` aggregator, GPT Actions OpenAPI block) requires Bearer JWT auth — verify none accidentally allow anon access. Cerefox treats every byte as personal/sensitive.
-- Threat-model review: write-access paths (`cerefox-ingest`, MCP `cerefox_ingest`/`cerefox_set_document_projects`), audit-log integrity (immutability guarantees), backup file handling, `~/.cerefox/.env` mode 0600 enforcement.
+### 28A: OAuth 2.1 on `cerefox-mcp` — cloud/mobile Claude connectivity
+
+**Design of record**: [`docs/specs/oauth-mcp-server-design.md`](specs/oauth-mcp-server-design.md)
+— read it first. Derived from the maintainer's 2026-07-07 research handoff (KB doc
+`92996524-…`). The unblock: Supabase shipped a native **OAuth 2.1 Server** (beta
+2025-11-26), dissolving the GoTrue `/.well-known` conflict that forced the 2026-03-15
+deferral (`docs/research/oauth-mcp-auth.md`).
+
+- Supabase-native OAuth 2.1 (authorization code + PKCE + DCR); no new infrastructure.
+- `cerefox-mcp` becomes an RFC 9728 protected resource: serves its own
+  `.well-known/oauth-protected-resource`, returns 401 + `WWW-Authenticate`, validates
+  OAuth JWTs against the project JWKS in-function (new unit-tested `_shared/mcp-auth/`),
+  deployed `--no-verify-jwt`.
+- **Back-compat invariant**: legacy static-Bearer (anon JWT) keeps working for Claude
+  Code / Cursor / Codex / Gemini / Desktop bridges — validated in-function by
+  constant-time compare against an explicitly-set Function secret.
+- New public consent-page EF (`cerefox-oauth-consent`); owner user in GoTrue; per-EF
+  deploy-flag map in `deploy-server.ts` (only these two EFs skip gateway JWT).
+- No schema/RPC changes (no `schema_version` bump); GPT Actions block untouched.
+- Phases 0–6 in the design doc (preflight → Supabase config → consent page → resource
+  server → connect Claude → regression → docs). Fallback if the native path fails:
+  Cloudflare Worker OAuth proxy (design §12).
+- **Quick win to test in Phase 0** (verified 2026-07-08): claude.ai now has a beta,
+  slow-rollout "Request headers" option on custom connectors (static Bearer) — if the
+  maintainer's account has it, the existing anon-JWT auth works on claude.ai/mobile
+  with zero code while OAuth is built (design §4.4).
+- All platform claims re-verified against live Supabase/Anthropic docs 2026-07-08
+  (design §14 has the verification table; re-check before each phase).
+- **Beta caveat**: Supabase's OAuth server is beta. If Phase 4 shows instability, soak
+  the feature in a v0.12.x pre-release and stamp v1.0.0 after it settles.
+
+### 28B: Security audit
+
+**Security audit headline items** (added 2026-05-29 per Fotis-24; extended 2026-07-08
+for 28A — audit runs on the **Fable 5** model per maintainer):
+
+- Every public-facing endpoint (Edge Functions including the new `/version` aggregator, GPT Actions OpenAPI block) requires Bearer JWT auth — verify none accidentally allow anon access. Cerefox treats every byte as personal/sensitive. **Re-stated for 28A**: the only deliberately-unauthenticated surfaces are `cerefox-mcp`'s RFC 9728 metadata route + 401 challenge and the `cerefox-oauth-consent` page; everything else on the two `--no-verify-jwt` functions is gated in-function (auth-first dispatch, fail-closed, constant-time compare, JWT alg allowlist — full invariant list in the design doc §6).
+- Threat-model review: write-access paths (`cerefox-ingest`, MCP `cerefox_ingest`/`cerefox_set_document_projects`), audit-log integrity (immutability guarantees), backup file handling, `~/.cerefox/.env` mode 0600 enforcement, **plus the OAuth token-validation paths and the consent flow (28A)**.
 - Dependency audit (`bun audit`, `npm audit`) — clean tree at v1.0 cut.
 - Secrets scanner (`gitleaks` or similar) on the repo history — verify no credentials ever committed.
 - Document the threat model + audit findings in `docs/specs/security-model.md` (new) — part of the v1.0 deliverable.
 
-**Design**: [`docs/specs/polish-and-distribution-design.md` §13 v1.0.0](specs/polish-and-distribution-design.md).
+### 28C: The contract
+
+Strict SemVer becomes binding. **Design**: [`docs/specs/polish-and-distribution-design.md` §13 v1.0.0](specs/polish-and-distribution-design.md).
 
 ---
 
@@ -3449,6 +3495,12 @@ in-place supervise-restart) instead of relying on the Docker restart cycle.
 
 ## Current Focus
 
+**Update (2026-07-08, `main` at v0.11.1): Iteration 28 started (28A — OAuth MCP) on
+`feat/oauth-mcp`.** Supabase's native OAuth 2.1 Server (beta 2025-11-26) unblocked the
+claude.ai / Claude-mobile connectivity that was deferred 2026-03-15; design committed at
+[`docs/specs/oauth-mcp-server-design.md`](specs/oauth-mcp-server-design.md), iteration 28
+re-scoped (see track 3 below). Implementation not yet started.
+
 **Update (2026-06-09, `main` at v0.10.3):** Iteration 30 (Local / Self-Hosted Cerefox,
 World B) shipped across v0.10.0–v0.10.2; v0.10.3 fixed the `cerefox server deploy` Edge
 Function bundler (`--use-api`, issue #84). Two active branches:
@@ -3492,8 +3544,13 @@ bundler (`--use-api`, issue #84). Design of record:
 2. **Iteration 31 — Local ONNX embedder** (fully-offline World B), target **v0.12+**
    (slid from v0.11.0 to make room for iter-32), on `feat/local-embedder`.
    Design committed; P0 implementation pending review. See iter-31 in the log above.
-3. **Iteration 28 — v1.0**, the stability commitment (strict SemVer becomes binding)
-   + security audit. Trigger: ~2–3 months of v0.10 in the wild + an outside user
+3. **Iteration 28 — v1.0**: ⏳ **ACTIVE (28A) as of 2026-07-08** on `feat/oauth-mcp`.
+   Re-scoped to fold in the **OAuth-protected remote MCP server** (28A: claude.ai +
+   Claude mobile via Supabase's native OAuth 2.1 Server — design of record:
+   [`docs/specs/oauth-mcp-server-design.md`](specs/oauth-mcp-server-design.md)),
+   then the security audit (28B, on the Fable 5 model, covering the new OAuth
+   surface) and the stability contract (28C: strict SemVer becomes binding).
+   28B/28C trigger: ~2–3 months of v0.10/v0.11 in the wild + an outside user
    installing unaided.
 4. **Iteration 29 — Document Relations & Semantic Graph** (post-v1.0, target **v1.1+**),
    pending — design only. Design of record:

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -3202,6 +3202,13 @@ deferral (`docs/research/oauth-mcp-auth.md`).
   path. Silver lining: the dialog confirms pre-registered-client credentials are
   supported → the DCR fallback (design §4.2-D) is a verified UI affordance. Connector
   name will be **CerefoxMCP** (design §4.4 outcome note).
+- **Phase 0 ✅ COMPLETE (2026-07-08)**: OAuth Server available on the maintainer plan
+  (disabled, ready to enable); signing keys **already ES256/P-256** (the HS256→asymmetric
+  migration prerequisite is moot for this project); Site URL is the unused
+  `localhost:3000` default → repointing at the consent EF is risk-free. Next: Phase 1
+  (enable + configure OAuth server, owner user) and Phase 2 (consent EF) — Phase 2's URL
+  is needed for Phase 1's Site URL, so build order is consent EF first or configure with
+  the known-in-advance EF URL.
 - All platform claims re-verified against live Supabase/Anthropic docs 2026-07-08
   (design §14 has the verification table; re-check before each phase).
 - **Beta caveat**: Supabase's OAuth server is beta. If Phase 4 shows instability, soak

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -3343,18 +3343,19 @@ mid-word/mid-row). 4 KB docs were corrupted.
 (the full, self-contained design + defensive rollout order — start there).
 
 **Problem (surfaced by the 2026-07-09 rotation attempt).** Supabase's Edge Function gateway
-is JWT-only — it rejects the new `sb_publishable_`/`sb_secret_` keys (Decision Log Q2 Part 1,
-2026-05-18). So the 8 primitive EFs (ChatGPT GPT Actions + direct HTTP) and `cerefox-mcp`'s
-static-Bearer path require the **legacy anon JWT**. On a project migrated to asymmetric
+is JWT-only — it rejects the new `sb_publishable_`/`sb_secret_` keys (verified 2026-05-18:
+the gateway returns `UNAUTHORIZED_INVALID_JWT_FORMAT` for non-JWT keys). So the 8 primitive
+EFs (ChatGPT GPT Actions + direct HTTP) and `cerefox-mcp`'s static-Bearer path require the
+**legacy anon JWT**. On a project migrated to asymmetric
 (ES256) signing keys — Supabase's default direction — the legacy anon key **can only be
 revoked, not rotated** (revoking kills the whole EF path). So **any Cerefox user whose anon
 key leaks is stuck**: they can't cycle it without disabling GPT Actions / remote MCP. A real
 security gap for every user on the anon-key/EF path (not just the maintainer).
 
-**Fix — the deferred "Option B" from the Decision Log; trigger conditions (security +
-touching the client-config layer) are now met.** Deploy the 8 primitive EFs with
-`--no-verify-jwt` and validate the caller's credential **in-function**, using a **rotatable,
-appropriately-scoped Cerefox-managed access token** — NOT a Supabase key:
+**Fix — full design in [`docs/specs/ef-auth-migration-design.md`](specs/ef-auth-migration-design.md).**
+Deploy the 8 primitive EFs with `--no-verify-jwt` and validate the caller's credential
+**in-function**, using a **rotatable, appropriately-scoped Cerefox-managed access token** —
+NOT a Supabase key:
 - **Why not the Supabase keys:** `sb_secret_` is full-DB (service_role) — handing it to a
   ChatGPT GPT Action / remote client config means a client compromise = full DB access via
   the Data API (worse than the anon key). `sb_publishable_` is public by design — accepting
@@ -3364,9 +3365,10 @@ appropriately-scoped Cerefox-managed access token** — NOT a Supabase key:
   Rotatable = regenerate the secret + re-issue to clients.
 - Reuse/extend the in-function auth pattern from `_shared/mcp-auth/` (iter-28A) — a shared
   constant-time token check for the primitive EFs AND `cerefox-mcp`'s (removed) static path.
-- **Deprecate the legacy anon JWT for all EF paths.** Back-compat window: accept the legacy
-  anon JWT during deprecation, warn, then drop. Migration docs for the two affected client
-  classes: **old remote static-Bearer MCP** and **ChatGPT GPT Actions**.
+- **Retire the legacy anon JWT for all EF paths — hard cutover, no back-compat window.**
+  Single-user project, so each deployer updates their own clients then flips to token-only (a
+  clean breaking change at the `0.12.0-beta` boundary). Migration docs for the two affected
+  client classes: **old remote static-Bearer MCP** and **ChatGPT GPT Actions**.
 - Update the GPT Actions OpenAPI block (auth scheme → the token in a header; `info.version`
   bump) + the remote-MCP client + connect-agents docs.
 - **Priority: implement next** (maintainer 2026-07-09) — it's the enabler for fully retiring

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -3231,10 +3231,20 @@ deferral (`docs/research/oauth-mcp-auth.md`).
   moved to a Cloudflare Worker** (Supabase EFs rewrite html→text/plain on the default
   domain) — deployed to `https://cerefox-consent.f-stamatelopoulos.workers.dev`,
   verified serving real `text/html` with the project URL + anon key injected.
-- **Next: Phase 4** — set Supabase Site URL → the Worker; register the Claude OAuth App;
-  add the CerefoxMCP connector on claude.ai; watch discovery→consent→token→tool-call;
-  confirm mobile; then the Phase 5 regression matrix for static-Bearer clients. Highest
-  remaining risk: the beta supabase-js `auth.oauth.*` API in the consent page.
+- **Phase 4 ✅ DONE (2026-07-08) — claude.ai web + mobile connected over OAuth, all 10
+  tools, verified live (tools/list + a hybrid search from claude.ai).** Two live-only
+  gotchas resolved: (R1) the consent page must redirect immediately when consent was
+  already granted (`getAuthorizationDetails` returns only a `redirect_url`; approving an
+  already-resolved request 400s "no longer pending"); (R2) the Supabase OAuth app must use
+  **`client_secret_post`** (request body), not `client_secret_basic` — Claude sends the
+  secret in the body, and the basic default failed the token exchange with an opaque
+  `ofid_` error. Debugging lesson: the token-exchange failure is invisible in the Edge
+  Function logs (only `no_token` discovery probes reach the function) — it lives in the
+  Supabase **Auth** logs. Full write-up: Decision Log Q3 Part 1 (KB) "Resolution".
+- **Next: Phase 5** — regression matrix for the static-Bearer clients (Claude Code /
+  Cursor / Codex / Gemini / local MCP) confirming the OAuth work didn't disturb them
+  (`tools/list` with the anon key already re-verified → 10 tools). Then **28B** (security
+  audit over the OAuth surface, Fable 5) and **28C** (v1.0 stability commitment).
 - All platform claims re-verified against live Supabase/Anthropic docs 2026-07-08
   (design §14 has the verification table; re-check before each phase).
 - **Beta caveat**: Supabase's OAuth server is beta. If Phase 4 shows instability, soak
@@ -3530,11 +3540,18 @@ in-place supervise-restart) instead of relying on the Docker restart cycle.
 
 ## Current Focus
 
-**Update (2026-07-08, `main` at v0.11.1): Iteration 28 started (28A — OAuth MCP) on
-`feat/oauth-mcp`.** Supabase's native OAuth 2.1 Server (beta 2025-11-26) unblocked the
-claude.ai / Claude-mobile connectivity that was deferred 2026-03-15; design committed at
-[`docs/specs/oauth-mcp-server-design.md`](specs/oauth-mcp-server-design.md), iteration 28
-re-scoped (see track 3 below). Implementation not yet started.
+**Update (2026-07-08, `main` at v0.11.1): Iteration 28A (OAuth MCP) is BUILT and WORKING
+end-to-end on `feat/oauth-mcp`.** claude.ai web + Claude mobile now connect to
+`cerefox-mcp` over OAuth with the full 10-tool surface (verified live). Supabase's native
+OAuth 2.1 Server (beta 2025-11-26) unblocked what was deferred 2026-03-15. Shipped: the
+`_shared/mcp-auth/` in-function validator (OAuth JWT + legacy static Bearer, Web-Crypto,
+20 tests), `cerefox-mcp` as an RFC 9728 protected resource (`--no-verify-jwt`), the
+`_shared/consent-page/` markup rendered by a free **Cloudflare Worker** (Supabase EFs
+can't serve HTML on the default domain), and the per-EF deploy-flag map. Design of record:
+[`docs/specs/oauth-mcp-server-design.md`](specs/oauth-mcp-server-design.md). Full decision
+history + the R1/R2 live gotchas: Decision Log Q3 Part 1 (KB). Remaining in iter-28:
+Phase 5 regression matrix, then 28B (security audit, Fable 5) + 28C (v1.0 contract).
+**Not yet merged to `main` or released** — still on `feat/oauth-mcp`.
 
 **Update (2026-06-09, `main` at v0.10.3):** Iteration 30 (Local / Self-Hosted Cerefox,
 World B) shipped across v0.10.0–v0.10.2; v0.10.3 fixed the `cerefox server deploy` Edge

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -3196,10 +3196,12 @@ deferral (`docs/research/oauth-mcp-auth.md`).
 - Phases 0–6 in the design doc (preflight → Supabase config → consent page → resource
   server → connect Claude → regression → docs). Fallback if the native path fails:
   Cloudflare Worker OAuth proxy (design §12).
-- **Quick win to test in Phase 0** (verified 2026-07-08): claude.ai now has a beta,
-  slow-rollout "Request headers" option on custom connectors (static Bearer) — if the
-  maintainer's account has it, the existing anon-JWT auth works on claude.ai/mobile
-  with zero code while OAuth is built (design §4.4).
+- **Quick win tested in Phase 0 — NOT available** (2026-07-08): the claude.ai beta
+  "Request headers" static-auth rollout hasn't reached the maintainer's account (dialog
+  shows only OAuth Client ID/Secret advanced fields). OAuth build confirmed as the only
+  path. Silver lining: the dialog confirms pre-registered-client credentials are
+  supported → the DCR fallback (design §4.2-D) is a verified UI affordance. Connector
+  name will be **CerefoxMCP** (design §4.4 outcome note).
 - All platform claims re-verified against live Supabase/Anthropic docs 2026-07-08
   (design §14 has the verification table; re-check before each phase).
 - **Beta caveat**: Supabase's OAuth server is beta. If Phase 4 shows instability, soak

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -3327,18 +3327,25 @@ security gap for every user on the anon-key/EF path (not just the maintainer).
 
 **Fix — the deferred "Option B" from the Decision Log; trigger conditions (security +
 touching the client-config layer) are now met.** Deploy the 8 primitive EFs with
-`--no-verify-jwt` and validate the caller's key **in-function**, accepting a **rotatable**
-key (`sb_publishable_`/`sb_secret_`, or a Cerefox-managed token) instead of the unrotatable
-legacy anon JWT.
-- Reuse the in-function auth pattern from `_shared/mcp-auth/` (iter-28A) — a shared
-  constant-time key/token check for the primitive EFs.
-- Update the GPT Actions OpenAPI block (auth scheme + `info.version` bump) and the
-  remote-MCP client docs to the new key — a documented, client-config-breaking migration
-  with a back-compat window (still accept the legacy anon JWT during deprecation).
-- Candidate for v1.0 (security) or a fast-follow; overlaps 28B's mitigations. Interim: on
-  the maintainer's own project, remove `CEREFOX_MCP_STATIC_BEARER` (done 2026-07-09) and
-  accept residual risk on the primitive EFs (GPT Actions kept; low exposure, RPC bypass
-  already closed) until this migration ships.
+`--no-verify-jwt` and validate the caller's credential **in-function**, using a **rotatable,
+appropriately-scoped Cerefox-managed access token** — NOT a Supabase key:
+- **Why not the Supabase keys:** `sb_secret_` is full-DB (service_role) — handing it to a
+  ChatGPT GPT Action / remote client config means a client compromise = full DB access via
+  the Data API (worse than the anon key). `sb_publishable_` is public by design — accepting
+  it in-function is no auth at all. So the credential is a **random Cerefox-owned token**
+  stored as a Function secret (the expected value), given to clients, constant-time-compared
+  in-function; the EF still uses its own `service_role` internally (never leaves the server).
+  Rotatable = regenerate the secret + re-issue to clients.
+- Reuse/extend the in-function auth pattern from `_shared/mcp-auth/` (iter-28A) — a shared
+  constant-time token check for the primitive EFs AND `cerefox-mcp`'s (removed) static path.
+- **Deprecate the legacy anon JWT for all EF paths.** Back-compat window: accept the legacy
+  anon JWT during deprecation, warn, then drop. Migration docs for the two affected client
+  classes: **old remote static-Bearer MCP** and **ChatGPT GPT Actions**.
+- Update the GPT Actions OpenAPI block (auth scheme → the token in a header; `info.version`
+  bump) + the remote-MCP client + connect-agents docs.
+- **Priority: implement next** (maintainer 2026-07-09) — it's the enabler for fully retiring
+  the legacy JWT + closing the maintainer's own residual anon-key risk. Overlaps 28B.
+  Interim already done: `CEREFOX_MCP_STATIC_BEARER` removed on the maintainer project.
 
 ### 28C: The contract
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -29,3 +29,8 @@ Current contents:
   `cerefox-mcp` via Supabase's native OAuth 2.1 Server, so claude.ai / Claude
   mobile / other cloud agents get the full MCP tool surface. Supersedes the
   2026-03 deferral in `docs/research/oauth-mcp-auth.md`.
+- `ef-auth-migration-design.md` — Iteration 28E design (2026-07-09): replace the
+  unrotatable legacy anon JWT across all Edge Function paths (8 primitive EFs +
+  `cerefox-mcp` static path) with a rotatable, Cerefox-managed access token
+  validated in-function; back-compat window then legacy-anon revoke. Target
+  v0.12.0-beta.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -17,3 +17,9 @@ Current contents:
 - `ui-redesign-spa-python-api.md` — the Iteration 14 web-app SPA refactor design
   (shipped). Superseded in one respect: the API backend it targeted is now Hono
   on Bun/Node, not the FastAPI named in the doc.
+- `concurrency-control-design.md` — Iteration 32 design: optimistic concurrency on
+  content updates (`expected_content_hash` / `last_write_wins`). Shipped in v0.11.0.
+- `oauth-mcp-server-design.md` — Iteration 28A design (2026-07-08): OAuth 2.1 on
+  `cerefox-mcp` via Supabase's native OAuth 2.1 Server, so claude.ai / Claude
+  mobile / other cloud agents get the full MCP tool surface. Supersedes the
+  2026-03 deferral in `docs/research/oauth-mcp-auth.md`.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -19,6 +19,9 @@ Current contents:
   on Bun/Node, not the FastAPI named in the doc.
 - `concurrency-control-design.md` — Iteration 32 design: optimistic concurrency on
   content updates (`expected_content_hash` / `last_write_wins`). Shipped in v0.11.0.
+- `security-model.md` — **living doc** (not a point-in-time snapshot): Cerefox's access
+  layers, credential scopes, the schema-0.7.0 RPC lockdown, and the OAuth surface
+  invariants. Iteration 28B deliverable.
 - `oauth-mcp-server-design.md` — Iteration 28A design (2026-07-08): OAuth 2.1 on
   `cerefox-mcp` via Supabase's native OAuth 2.1 Server, so claude.ai / Claude
   mobile / other cloud agents get the full MCP tool surface. Supersedes the

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -19,6 +19,9 @@ Current contents:
   on Bun/Node, not the FastAPI named in the doc.
 - `concurrency-control-design.md` — Iteration 32 design: optimistic concurrency on
   content updates (`expected_content_hash` / `last_write_wins`). Shipped in v0.11.0.
+- `chunk-reconstruction-design.md` — Iteration 28D design (2026-07-09): fix the
+  document-reconstruction data-corruption bug via an exact-partition chunker +
+  versioned blind-stitch reconstruction (backward-compatible, lazy migration).
 - `security-model.md` — **living doc** (not a point-in-time snapshot): Cerefox's access
   layers, credential scopes, the schema-0.7.0 RPC lockdown, and the OAuth surface
   invariants. Iteration 28B deliverable.

--- a/docs/specs/chunk-reconstruction-design.md
+++ b/docs/specs/chunk-reconstruction-design.md
@@ -1,0 +1,126 @@
+# Design: chunk storage & lossless document reconstruction
+
+> **Status**: Design-of-record (2026-07-09). Not started (Phase 1). The interim
+> correctness fix (keep oversized single paragraphs whole) already shipped on
+> `feat/oauth-mcp`; this doc specifies the *proper* fix. Work lands on a new branch
+> `fix/chunk-reconstruction`. Target: v1.0.0 (part of the release; see `docs/plan.md`).
+
+## 1. The problem
+
+Documents are stored as chunks and reassembled on read by
+`cerefox_reconstruct_doc` (and 3 sibling RPCs) via
+`STRING_AGG(content, E'\n\n' ORDER BY chunk_index)` — i.e. reconstruction
+**re-synthesizes a `\n\n` separator it never stored**. That is only correct if the
+chunker splits *exactly* at paragraph boundaries. Any other split point injects a
+`\n\n` into the middle of content on read.
+
+Two failure modes (both observed / proven):
+- **Duplication** — the oversized-single-paragraph hard-split used
+  `step = max_chars/2` with a `max_chars`-wide window → 50% overlap → the overlapped
+  span was duplicated on reconstruction. (Trigger: a markdown table, which has no
+  blank lines, so the whole table is one paragraph; once it exceeded `max_chunk_chars`
+  it hit this path. 4 documents in the maintainer KB were corrupted this way.)
+- **Mid-content blank lines** — even a *non-overlapping* char-split (`step = max_chars`)
+  inserts a blank line mid-word / mid-table-row on reconstruction (e.g. `Source` →
+  `Sour\n\nce`).
+
+Root cause: **the reconstruction separator is not part of the stored data.**
+
+## 2. Interim fix (already shipped, `feat/oauth-mcp`)
+
+Keep an oversized single paragraph **whole** (one chunk) — never split inside a
+paragraph, so the `\n\n`-join stays lossless. This fixes the corruption for all
+realistic documents (tables up to the embedder's limit). Its limitation is exactly
+what this design removes: a very large single paragraph becomes one huge chunk, and
+the embedder (no input cap today) will reject a chunk over its token limit → ingest
+failure. Regression test asserts `reconstruct(chunk(doc)) === doc`.
+
+## 3. Phase 0 — embedding-input cap (safety, no migration)
+
+Independent of the reconstruction redesign, and good regardless: **truncate the text
+sent to the embedding model to its token limit**, and `log.warn` when truncation
+happens (so a huge chunk is visible, not silent). The full chunk `content` is stored
+and reconstructed untouched; only that chunk's *embedding* is computed on a prefix
+(degraded search for that chunk, never an ingest failure).
+
+- Where: the embedding call sites in `packages/memory/src/ingestion/pipeline.ts` (and
+  the EF ingest path / `_shared/embeddings`). Cap the built input
+  (`# {title}\n{...}\n{content}`) to a conservative char/token budget for
+  `text-embedding-3-small` (8191 tokens; use a safe char proxy, configurable).
+- This makes the interim keep-whole fix production-safe on its own.
+
+## 4. Phase 1 — exact-partition chunks + versioned blind-stitch reconstruction
+
+### 4.1 The invariant
+Store chunks so that **blind concatenation reproduces the document**:
+`concat(content[0..n]) === document` (no separator injected on read). Then a chunk
+boundary may fall **anywhere** — including mid-paragraph at a size limit — with zero
+corruption, which is what lets us bound chunk size again.
+
+### 4.2 Chunker changes
+- `content` becomes an **exact slice** of the (trimmed) document; the chunker no longer
+  trims section bodies and re-joins with `\n\n`. Boundaries are chosen at headings →
+  paragraph (`\n\n`) boundaries → a hard size limit (a big single paragraph splits at
+  the size limit; losslessly, since reconstruction adds nothing).
+- **Heading context moves from stored content to the embedding input.** A mid-section
+  chunk no longer needs the `## heading` line embedded in its `content` (that would
+  break the exact partition). Instead the embedding input becomes
+  `# {doc_title}\n{heading_path breadcrumb}\n{content}`, taking the breadcrumb from the
+  already-stored `heading_path` metadata. Stored content stays a clean partition;
+  search still gets full heading context. (`heading_path`, `heading_level`, `title`
+  metadata are computed as today.)
+- Keep it byte-for-byte identical between the TS chunker (`_shared/ingest/chunker.ts`)
+  and the legacy Python chunker (`src/cerefox/chunking/markdown.py`) — OR, if the Python
+  MCP fallback is retired at v1.0 (see plan), drop the Python parity requirement then.
+
+### 4.3 Reconstruction (backward-compatible, versioned)
+- New column `cerefox_documents.content_format SMALLINT NOT NULL DEFAULT 1`
+  (`1` = legacy `\n\n`-join; `2` = blind-stitch).
+- The 4 reconstruction RPC sites branch on it:
+  `CASE WHEN d.content_format >= 2 THEN STRING_AGG(c.content, '' ORDER BY chunk_index)
+        ELSE STRING_AGG(c.content, E'\n\n' ORDER BY chunk_index) END`.
+- The ingest RPC sets `content_format = 2` on any write that stores blind-stitch chunks
+  (i.e. all writes from the new chunker).
+- Schema bump: `schema_version` 0.7.0 → 0.8.0 (both literals in lockstep).
+
+### 4.4 Migration — lazy, zero forced re-embed
+- **Existing documents stay `content_format = 1`** and reconstruct exactly as today.
+- A document **flips to `2` the next time it is written** (re-chunked by the new
+  chunker). No mass re-embed; Debasis's 1,000+ docs are untouched until edited.
+- **Eager option:** `cerefox server reindex` re-chunks + re-embeds and stamps
+  `content_format = 2` (offer, don't force).
+
+### 4.5 Doctor check
+`cerefox doctor` reports migration progress:
+*"N of M documents use the legacy reconstruction format (auto-convert on next edit;
+run `cerefox server reindex` to convert now)."* Informational, not a gate. Needs the
+`content_format` column, so it ships with Phase 1. A fresh install shows 0 legacy.
+
+## 5. Acceptance tests
+- **The invariant** (the one that would have caught this bug): for a corpus of inputs
+  — plain prose, multi-heading docs, a markdown table larger than `max_chunk_chars`, a
+  single blank-line-free paragraph larger than `max_chunk_chars`, unicode/multibyte,
+  trailing/leading whitespace — assert `blindStitch(chunk(doc)) === trim(doc)` for
+  format-2, and `join('\n\n', chunk_legacy(doc))` still equals the legacy expectation
+  for format-1.
+- **No chunk exceeds the size limit** (bounded chunks again).
+- **Reconstruction-RPC branch**: legacy-format doc reconstructs with `\n\n`; new-format
+  doc reconstructs by blind concat; a live round-trip through the ingest RPC + a read.
+- Regenerate the `python-parity` chunking fixtures for the new output (they encoded the
+  old normalize-and-rejoin format).
+
+## 6. Risks & rollout
+- Changing how *new* writes are stored right before the v1.0 stability freeze is the
+  main risk — mitigated by: versioning (old docs unaffected), the strong `reconstruct
+  === original` acceptance test, and lazy migration (no big-bang).
+- Doing this **before** 1.0 means the frozen format is the correct one; doing it after
+  would be a format migration under the stability contract. So: before 1.0.
+- The interim keep-whole fix stays until Phase 1 lands (no regression window).
+
+## 7. References
+- Root-cause forensics + the 4 affected docs: Cerefox Decision Log 2026 Q3 Part 1
+  (KB), 2026-07-09 entries.
+- Interim fix: `fix(chunker): keep oversized single paragraphs whole` on
+  `feat/oauth-mcp`; regression test in `_shared/__tests__/ingest-chunker.test.ts`.
+- Reconstruction sites: `src/cerefox/db/rpcs.sql` (`STRING_AGG(c.content, E'\n\n' …)`,
+  4 occurrences).

--- a/docs/specs/ef-auth-migration-design.md
+++ b/docs/specs/ef-auth-migration-design.md
@@ -116,10 +116,30 @@ token EFs = the Cerefox token).
 
 ## 7. CLI automation (minimize friction)
 
-- **`cerefox token generate` / `rotate` / `list`** (new command group): generates a random
-  token, sets/updates `CEREFOX_ACCESS_TOKENS` (via `supabase secrets set`, needs the Supabase
-  CLI + project), prints the token, and records it where clients need it. `rotate` adds a new
-  token and (after confirmation) drops the oldest.
+**`cerefox token generate` / `rotate` / `list`** (new command group). The command automates
+the **server** side and **guides** the client side — it deliberately does *not* claim to
+auto-install into ChatGPT (not technically possible; see below). `generate` flow:
+1. **Generate** a random `cfx_pat_…` token.
+2. **Install it on Supabase** — set/update the `CEREFOX_ACCESS_TOKENS` Function secret via
+   `supabase secrets set` (needs the Supabase CLI + linked project). This is the only place
+   the token is *installed* automatically.
+3. **Print the token once** + where to paste it: the Custom GPT's **Configure → Actions →
+   Authentication → API Key**, Auth Type **Bearer**. (Reprints are impossible — it's a secret;
+   `list` shows only masked fingerprints, not the value. Lose it → `rotate`.)
+4. **Point to the local doc** for the Action *body* — print the path/anchor to the GPT Actions
+   OpenAPI block in `docs/guides/connect-agents.md` to copy-paste **if the schema changed**
+   this release (the auth-scheme change bumps `info.version`; changing the schema in ChatGPT
+   also clears the stored auth key, so the user re-pastes the schema *and* re-enters the token
+   together). `cerefox guides open connect-agents` can surface it locally.
+
+`rotate` adds a new token to the set and (after confirmation) drops the oldest — zero-downtime
+because `CEREFOX_ACCESS_TOKENS` accepts multiple. `list` shows masked fingerprints + count.
+
+**Why the ChatGPT side is guide-only:** Custom GPTs are editable **only** through the ChatGPT
+web GPT-builder UI; OpenAI exposes no API/CLI to set a Custom GPT's Action authentication or
+schema programmatically. So the token lands in ChatGPT by a human paste — the CLI's job is to
+make that paste trivial (right value, right field, right doc), not to eliminate it.
+
 - **`cerefox server deploy`** generates a token on first deploy if none exists; warns loudly
   if the token-gated EFs would deploy with no token (fail-closed footgun).
 - **`cerefox configure-agent` is NOT in scope** — it writes a *local stdio* MCP entry

--- a/docs/specs/ef-auth-migration-design.md
+++ b/docs/specs/ef-auth-migration-design.md
@@ -79,32 +79,40 @@ Add a small **`_shared/ef-auth/`** module (Web-Platform-only, runs under Deno + 
 ```
 checkAccessToken(authorizationHeader, {
   tokens: string[],          // from CEREFOX_ACCESS_TOKENS
-  legacyBearer?: string|null // legacy anon JWT accepted during the deprecation window
-}): { ok: true, path: "token"|"legacy" } | { ok: false, reason }
+}): { ok: true } | { ok: false, reason }
 ```
 
 - Constant-time compare (reuse `constantTimeEqual` from `_shared/mcp-auth/`).
-- **Fail closed**: if `tokens` is empty and no `legacyBearer`, reject everything (never
-  accept-all). `cerefox server deploy` must warn if it deploys token-gated EFs with no token set.
-- Log the reason on rejection (never the token); `console.log` a warn when the **legacy** path
-  is used (so the maintainer sees remaining legacy usage before dropping it).
-- `cerefox-mcp` composes: OAuth JWT (existing `_shared/mcp-auth`) OR `checkAccessToken`.
+- **Fail closed**: if `tokens` is empty, reject everything (never accept-all). `cerefox server
+  deploy` must warn if it deploys token-gated EFs with no token set.
+- Log the reason on rejection (never the token).
+- `cerefox-mcp` composes: OAuth JWT (existing `_shared/mcp-auth`) OR `checkAccessToken` (the
+  static-token arm — kept mainly for the live remote-MCP e2e harness + as a non-OAuth
+  fallback; positioned as *Advanced* in the guides, not the primary story).
 - The 8 primitive EFs: `checkAccessToken` only. Refactor their shared request handling
   (they each build a Supabase client + parse the request) to call the check first — put the
   gate in one shared place they already import if possible (`supabase/functions/*/shared.ts`
   or a new `_shared/ef-auth` used by each `index.ts`).
 
-## 6. Back-compat / deprecation window (CRITICAL for defensive rollout)
+## 6. Cutover — hard, no back-compat window
 
-During migration the EFs accept **BOTH**: the new Cerefox token(s) **and** the legacy anon
-JWT (via `legacyBearer` = the known anon JWT value, set as a Function secret
-`CEREFOX_LEGACY_ANON_BEARER` during the window — same static-compare mechanism as the removed
-`CEREFOX_MCP_STATIC_BEARER`). Warn on legacy use. After all clients migrate, **unset**
-`CEREFOX_LEGACY_ANON_BEARER` → only tokens accepted → the legacy anon JWT is fully deprecated.
+No runtime dual-accept, no warn-then-drop, no `legacyBearer` machinery. The EFs accept **only**
+the Cerefox token (fail closed). Dropping the legacy anon JWT is a **clean breaking change at
+the `0.12.0-beta` boundary** (breaking changes are allowed pre-1.0), documented in CHANGELOG +
+the migration note. This is safe because Cerefox is single-user: each deployer controls all
+their own clients and cuts over on their own schedule.
 
-**This unlocks completing the 28B anon-key rotation:** once *no* EF accepts the legacy anon
-JWT, the maintainer can **revoke the legacy HS256 secret** in Supabase → the exposed anon key
-is fully neutralized (closes the 28B residual risk).
+**Per-deployer order (so nobody locks *themselves* out mid-upgrade):**
+1. `cerefox token generate` → get the token.
+2. Update your client configs (GPT Actions, remote MCP) to the token.
+3. `cerefox server deploy` → token-only EFs (`--no-verify-jwt` + `checkAccessToken`), with
+   `CEREFOX_ACCESS_TOKENS` set.
+4. **Revoke the legacy anon key** in Supabase.
+
+**This completes the 28B anon-key rotation:** after step 3 *no* EF accepts the legacy anon JWT,
+so step 4 fully neutralizes the exposed anon key (closes the 28B residual risk). Nothing at
+runtime uses the legacy HS256 secret afterward (OAuth = ES256 JWKS; local MCP = no network;
+token EFs = the Cerefox token).
 
 ## 7. CLI automation (minimize friction)
 
@@ -137,8 +145,8 @@ is fully neutralized (closes the 28B residual risk).
 ## 9. Deploy changes
 
 - `packages/memory/src/cli/commands/deploy-server.ts`: extend `NO_VERIFY_JWT_EFS` to the 8
-  primitive EFs; keep the post-deploy reminder (now: "set `CEREFOX_ACCESS_TOKENS`; optional
-  `CEREFOX_LEGACY_ANON_BEARER` during the deprecation window").
+  primitive EFs; post-deploy reminder now: "set `CEREFOX_ACCESS_TOKENS`, update your client
+  configs to the token, then revoke the legacy anon key."
 - Bundle `_shared/ef-auth` into `dist/server-assets/_shared/` (`scripts/bundle_server_assets.ts`
   — add `"ef-auth"` to the subtree list, like `mcp-auth`).
 - No schema change (this is EF/auth only) → **no `schema_version` bump**.
@@ -146,34 +154,32 @@ is fully neutralized (closes the 28B residual risk).
 ## 10. Testing (extensive — this is security)
 
 - **Unit (`bun test`, `_shared/__tests__/`):** `checkAccessToken` — accepts a valid token,
-  rejects garbage, rejects empty header, constant-time, accepts the legacy bearer only when
-  `legacyBearer` set, **fails closed** when no tokens + no legacy, multiple-token set.
+  rejects garbage, rejects empty header, constant-time, **fails closed** when no tokens set,
+  multiple-token set (rotation).
 - **Live EF e2e (opt-in `CEREFOX_LIVE_E2E=1`, narrowest file):** each primitive EF with the
-  token → 200; with the legacy anon JWT during the window → 200 + warn; with garbage → 401;
-  with the token unset server-side → 401 (fail closed). Keep EF-quota discipline (`requestor:
-  "e2e-test"`).
+  token → 200; with garbage → 401; with the token unset server-side → 401 (fail closed); with
+  the (now-revoked) legacy anon JWT → 401. Keep EF-quota discipline (`requestor: "e2e-test"`).
 - **`cerefox-mcp`:** OAuth path still works; token static path works; garbage → 401.
 - **Regression:** existing EF e2e suites migrated to the token; `cerefox doctor` still works
   (its `/version` aggregator now needs the token, not the anon key).
 
-## 11. Defensive rollout order (avoid locking yourself out)
+## 11. Rollout order (per-deployer; avoid locking yourself out)
 
+Because the cutover is hard (§6), the client update must precede the token-only deploy:
 1. Implement + unit-test the shared check.
-2. Deploy the EFs with **BOTH** accepted (set `CEREFOX_ACCESS_TOKENS` AND
-   `CEREFOX_LEGACY_ANON_BEARER`=current anon JWT). Nothing breaks — existing clients keep
-   working via legacy; new token also works. **Verify live before proceeding.**
-3. Migrate clients to the token (GPT Actions re-enter; remote MCP re-configure; `doctor`/CLI
-   to the token).
-4. Watch the "legacy path used" logs go quiet.
-5. **Unset `CEREFOX_LEGACY_ANON_BEARER`** → token-only. Verify.
-6. **Then revoke the legacy HS256 secret** in Supabase → the exposed anon key is dead (closes
+2. `cerefox token generate` → set `CEREFOX_ACCESS_TOKENS`; **update every client config**
+   (GPT Actions, remote MCP, `doctor`/CLI) to the token.
+3. `cerefox server deploy` → token-only EFs (`--no-verify-jwt` + `checkAccessToken`).
+   **Verify live** each path (primitive EFs, `cerefox-mcp` token + OAuth).
+4. **Revoke the legacy HS256 secret** in Supabase → the exposed anon key is dead (closes
    28B ①). Verify OAuth (cloud Claude) + local MCP + token EFs all still work (none use the
    legacy secret).
 
 ## 12. Risks
 
-- **Lockout** if steps are reordered — mitigated by back-compat-first (§11). Never tighten
-  before migrating clients + verifying.
+- **Self-lockout** if the token-only deploy (step 3) runs before clients are updated (step 2) —
+  brief, self-inflicted, per-deployer. The documented order avoids it; verify live before
+  revoking.
 - **Token leakage** in client configs (esp. ChatGPT) — it's a secret, but rotatable (the whole
   point). Document safe handling; never commit; gitleaks pattern.
 - **"Every public endpoint requires auth"** (28B invariant) — this *strengthens* it: after
@@ -187,7 +193,4 @@ is fully neutralized (closes the 28B residual risk).
   logging patterns). `supabase/functions/cerefox-mcp/{index,oauth}.ts` (the pattern to mirror).
 - `docs/specs/security-model.md` (§1 credentials, §4 OAuth invariants — update for 28E).
 - `docs/specs/oauth-mcp-server-design.md` (the sibling iter-28A design).
-- Decision Log Q3 Part 1 (KB, private) — the 2026-07-09 security entry (RPC bypass, anon-key
-  rotation blocked by the ES256/gateway constraint — the direct motivation for 28E).
-- Decision Log Q2 Part 1 (KB) — the original "Option B" sketch (2026-05-18) this executes.
 - GPT Actions OpenAPI block: `docs/guides/connect-agents.md` (keep in sync per CLAUDE.md rule).

--- a/docs/specs/ef-auth-migration-design.md
+++ b/docs/specs/ef-auth-migration-design.md
@@ -1,0 +1,193 @@
+# Design: migrate Edge Function auth off the unrotatable legacy anon JWT (iter-28E)
+
+> **Status**: Design-of-record (2026-07-09). Not started. Work lands on a new branch
+> `feat/ef-auth-token` (off `feat/oauth-mcp` — so the OAuth/security context is present).
+> Target: **v0.12.0-beta** (executed carefully/defensively, extensively tested), before the
+> 1.0.0 freeze. Plan entry: `docs/plan.md` Iteration 28E + the "Release sequencing" note.
+>
+> **Read-this-first context for a fresh session** (post-compaction): Cerefox is a single-user
+> KB on Supabase (Postgres + pgvector + Edge Functions). Iteration 28A made `cerefox-mcp` an
+> OAuth 2.1 protected resource with **in-function auth** (`_shared/mcp-auth/`), deployed
+> `--no-verify-jwt`. Iteration 28B's security audit (see `docs/specs/security-model.md` +
+> Decision Log Q3 Part 1 in the KB) closed a Data-API RPC bypass and found that the **legacy
+> anon JWT is a full-KB credential**. On projects migrated to ES256 signing keys, that anon
+> JWT **can only be revoked, not rotated** — so a leak can't be cycled without killing the EF
+> path. `CEREFOX_MCP_STATIC_BEARER` (the anon-JWT accepted by `cerefox-mcp`'s static path) was
+> already **removed** on the maintainer project. This iteration replaces the legacy anon JWT
+> across **all** Edge Function paths with a rotatable, Cerefox-managed access token.
+
+## 1. Problem
+
+The Supabase **Edge Function gateway is JWT-only** — it rejects the new
+`sb_publishable_`/`sb_secret_` keys (Decision Log Q2 Part 1, 2026-05-18). So today:
+- the **8 primitive EFs** (`cerefox-search`, `cerefox-ingest`, `cerefox-metadata`,
+  `cerefox-get-document`, `cerefox-list-versions`, `cerefox-get-audit-log`,
+  `cerefox-metadata-search`, `cerefox-list-projects`) are gateway-verified and authenticate
+  callers with the **legacy anon JWT** (used by ChatGPT **GPT Actions** and **direct HTTP**);
+- `cerefox-mcp`'s **static-Bearer** path (remote MCP clients that don't do OAuth) also used
+  the legacy anon JWT.
+
+On an ES256-migrated project the legacy anon JWT is **unrotatable** (revoke-only, and
+revoking kills the whole EF path). A leaked anon key therefore can't be cycled — a real
+security gap for **every** Cerefox user on the EF/GPT-Actions/remote-static-MCP path.
+
+## 2. Decision — a Cerefox-managed access token (NOT a Supabase key)
+
+The caller credential becomes a **random, Cerefox-owned access token**, validated in-function.
+
+**Rejected alternatives (record why):**
+- `sb_publishable_` — *public by design* (it's embedded in the consent Worker HTML, shipped
+  to clients). Cerefox has **no RLS** on the EF path (EFs use `service_role` internally), so
+  gating on a public key = **no access control**: anyone who reads it gets full KB access.
+- `sb_secret_` — full-DB (service_role). Placing it in a client config (GPT Action / MCP
+  client) means a client compromise = full DB access via the Data API. Too powerful client-side.
+
+The Cerefox token is: **secret** (real access control), **rotatable** (regenerate + re-issue),
+**scoped** (grants EF access only; the EF's own `service_role` never leaves the server), and
+independent of Supabase's key lifecycle. Same pattern as `cerefox-mcp`'s in-function auth and
+OB1's `MCP_ACCESS_KEY`.
+
+## 3. Architecture
+
+- **All data EFs run `--no-verify-jwt`** (the gateway stops gating; in-function auth is the
+  only gate — extends the `NO_VERIFY_JWT_EFS` set from `{cerefox-mcp, cerefox-oauth-consent}`
+  to include the 8 primitive EFs). `cerefox-oauth-consent` stays public (no auth — it's the
+  consent page). `cerefox-mcp` already `--no-verify-jwt`.
+- **In-function token check** on every data EF: read the incoming credential from
+  `Authorization: Bearer <token>`, constant-time-compare against a set of accepted tokens.
+- `cerefox-mcp` accepts **OAuth JWT (owner-pinned) OR a Cerefox token** (its static path,
+  re-added — replacing the removed anon-JWT one). The 8 primitive EFs accept **a Cerefox
+  token** (no OAuth — GPT Actions/HTTP clients don't do OAuth).
+- Internally, EFs keep using `SUPABASE_SERVICE_ROLE_KEY` to call the RPCs (unchanged).
+
+## 4. The token
+
+- **Format:** a random 256-bit secret, base64url, prefixed for identifiability, e.g.
+  `cfx_pat_<43chars>`. (Prefix helps gitleaks/humans recognize it.)
+- **Storage (server):** a Supabase **Function secret** holding the accepted set:
+  `CEREFOX_ACCESS_TOKENS` = comma-separated list (support **multiple** for zero-downtime
+  rotation — accept old + new during a cutover). Set via `supabase secrets set`.
+- **Distribution (clients):** the token goes into client configs (GPT Actions header, remote
+  MCP client header). Automated by the CLI (§7).
+- **Rotation:** add a new token to the set → migrate clients → remove the old. No downtime.
+
+## 5. In-function auth (shared helper)
+
+Add a small **`_shared/ef-auth/`** module (Web-Platform-only, runs under Deno + Bun, like
+`_shared/mcp-auth/`), or extend `_shared/mcp-auth/`:
+
+```
+checkAccessToken(authorizationHeader, {
+  tokens: string[],          // from CEREFOX_ACCESS_TOKENS
+  legacyBearer?: string|null // legacy anon JWT accepted during the deprecation window
+}): { ok: true, path: "token"|"legacy" } | { ok: false, reason }
+```
+
+- Constant-time compare (reuse `constantTimeEqual` from `_shared/mcp-auth/`).
+- **Fail closed**: if `tokens` is empty and no `legacyBearer`, reject everything (never
+  accept-all). `cerefox server deploy` must warn if it deploys token-gated EFs with no token set.
+- Log the reason on rejection (never the token); `console.log` a warn when the **legacy** path
+  is used (so the maintainer sees remaining legacy usage before dropping it).
+- `cerefox-mcp` composes: OAuth JWT (existing `_shared/mcp-auth`) OR `checkAccessToken`.
+- The 8 primitive EFs: `checkAccessToken` only. Refactor their shared request handling
+  (they each build a Supabase client + parse the request) to call the check first — put the
+  gate in one shared place they already import if possible (`supabase/functions/*/shared.ts`
+  or a new `_shared/ef-auth` used by each `index.ts`).
+
+## 6. Back-compat / deprecation window (CRITICAL for defensive rollout)
+
+During migration the EFs accept **BOTH**: the new Cerefox token(s) **and** the legacy anon
+JWT (via `legacyBearer` = the known anon JWT value, set as a Function secret
+`CEREFOX_LEGACY_ANON_BEARER` during the window — same static-compare mechanism as the removed
+`CEREFOX_MCP_STATIC_BEARER`). Warn on legacy use. After all clients migrate, **unset**
+`CEREFOX_LEGACY_ANON_BEARER` → only tokens accepted → the legacy anon JWT is fully deprecated.
+
+**This unlocks completing the 28B anon-key rotation:** once *no* EF accepts the legacy anon
+JWT, the maintainer can **revoke the legacy HS256 secret** in Supabase → the exposed anon key
+is fully neutralized (closes the 28B residual risk).
+
+## 7. CLI automation (minimize friction)
+
+- **`cerefox token generate` / `rotate` / `list`** (new command group): generates a random
+  token, sets/updates `CEREFOX_ACCESS_TOKENS` (via `supabase secrets set`, needs the Supabase
+  CLI + project), prints the token, and records it where clients need it. `rotate` adds a new
+  token and (after confirmation) drops the oldest.
+- **`cerefox server deploy`** generates a token on first deploy if none exists; warns loudly
+  if the token-gated EFs would deploy with no token (fail-closed footgun).
+- **`cerefox configure-agent`** writes the token into remote-MCP client configs (it already
+  writes MCP configs; swap the anon key for the token for the *remote* transport).
+- The token is a **secret** — never commit it; `.env` / Function secret / client config only.
+  Add it to the gitleaks allowlist patterns (recognize `cfx_pat_`), and ensure it's not
+  printed to logs.
+
+## 8. GPT Actions OpenAPI + docs
+
+- Update the **GPT Actions OpenAPI block** in `docs/guides/connect-agents.md`: security scheme
+  → the Cerefox token in `Authorization: Bearer` (or an `apiKey` header), **bump `info.version`**
+  (SemVer). Note: ChatGPT resets a Custom GPT's stored key when the schema changes (known
+  gotcha) — users re-enter the token.
+- **Migration guide** (new section in `connect-agents.md` + a pointer from the CHANGELOG) for
+  the two client classes: **ChatGPT GPT Actions** and **remote static-Bearer MCP** — "get your
+  token with `cerefox token …`, replace the anon key in your client config." Note the
+  back-compat window (old anon JWT still works, with a warning, until the token is required).
+- Update `docs/guides/access-paths.md`, `setup-supabase.md`, `CLAUDE.md` (Layer-1 auth +
+  client-compat matrix), and `docs/specs/security-model.md` (new invariant: all data EFs are
+  in-function-auth'd on a rotatable token; the legacy anon JWT is deprecated/removed).
+
+## 9. Deploy changes
+
+- `packages/memory/src/cli/commands/deploy-server.ts`: extend `NO_VERIFY_JWT_EFS` to the 8
+  primitive EFs; keep the post-deploy reminder (now: "set `CEREFOX_ACCESS_TOKENS`; optional
+  `CEREFOX_LEGACY_ANON_BEARER` during the deprecation window").
+- Bundle `_shared/ef-auth` into `dist/server-assets/_shared/` (`scripts/bundle_server_assets.ts`
+  — add `"ef-auth"` to the subtree list, like `mcp-auth`).
+- No schema change (this is EF/auth only) → **no `schema_version` bump**.
+
+## 10. Testing (extensive — this is security)
+
+- **Unit (`bun test`, `_shared/__tests__/`):** `checkAccessToken` — accepts a valid token,
+  rejects garbage, rejects empty header, constant-time, accepts the legacy bearer only when
+  `legacyBearer` set, **fails closed** when no tokens + no legacy, multiple-token set.
+- **Live EF e2e (opt-in `CEREFOX_LIVE_E2E=1`, narrowest file):** each primitive EF with the
+  token → 200; with the legacy anon JWT during the window → 200 + warn; with garbage → 401;
+  with the token unset server-side → 401 (fail closed). Keep EF-quota discipline (`requestor:
+  "e2e-test"`).
+- **`cerefox-mcp`:** OAuth path still works; token static path works; garbage → 401.
+- **Regression:** existing EF e2e suites migrated to the token; `cerefox doctor` still works
+  (its `/version` aggregator now needs the token, not the anon key).
+
+## 11. Defensive rollout order (avoid locking yourself out)
+
+1. Implement + unit-test the shared check.
+2. Deploy the EFs with **BOTH** accepted (set `CEREFOX_ACCESS_TOKENS` AND
+   `CEREFOX_LEGACY_ANON_BEARER`=current anon JWT). Nothing breaks — existing clients keep
+   working via legacy; new token also works. **Verify live before proceeding.**
+3. Migrate clients to the token (GPT Actions re-enter; remote MCP re-configure; `doctor`/CLI
+   to the token).
+4. Watch the "legacy path used" logs go quiet.
+5. **Unset `CEREFOX_LEGACY_ANON_BEARER`** → token-only. Verify.
+6. **Then revoke the legacy HS256 secret** in Supabase → the exposed anon key is dead (closes
+   28B ①). Verify OAuth (cloud Claude) + local MCP + token EFs all still work (none use the
+   legacy secret).
+
+## 12. Risks
+
+- **Lockout** if steps are reordered — mitigated by back-compat-first (§11). Never tighten
+  before migrating clients + verifying.
+- **Token leakage** in client configs (esp. ChatGPT) — it's a secret, but rotatable (the whole
+  point). Document safe handling; never commit; gitleaks pattern.
+- **"Every public endpoint requires auth"** (28B invariant) — this *strengthens* it: after
+  28E, the only unauthenticated surfaces are the consent page + `cerefox-mcp`'s RFC 9728
+  metadata/401. State that in `security-model.md`.
+- **`doctor` / internal callers** that used the anon key must switch to the token.
+
+## 13. References
+
+- `_shared/mcp-auth/` (iter-28A in-function auth; reuse `constantTimeEqual`, the fail-closed +
+  logging patterns). `supabase/functions/cerefox-mcp/{index,oauth}.ts` (the pattern to mirror).
+- `docs/specs/security-model.md` (§1 credentials, §4 OAuth invariants — update for 28E).
+- `docs/specs/oauth-mcp-server-design.md` (the sibling iter-28A design).
+- Decision Log Q3 Part 1 (KB, private) — the 2026-07-09 security entry (RPC bypass, anon-key
+  rotation blocked by the ES256/gateway constraint — the direct motivation for 28E).
+- Decision Log Q2 Part 1 (KB) — the original "Option B" sketch (2026-05-18) this executes.
+- GPT Actions OpenAPI block: `docs/guides/connect-agents.md` (keep in sync per CLAUDE.md rule).

--- a/docs/specs/ef-auth-migration-design.md
+++ b/docs/specs/ef-auth-migration-design.md
@@ -122,8 +122,12 @@ token EFs = the Cerefox token).
   token and (after confirmation) drops the oldest.
 - **`cerefox server deploy`** generates a token on first deploy if none exists; warns loudly
   if the token-gated EFs would deploy with no token (fail-closed footgun).
-- **`cerefox configure-agent`** writes the token into remote-MCP client configs (it already
-  writes MCP configs; swap the anon key for the token for the *remote* transport).
+- **`cerefox configure-agent` is NOT in scope** — it writes a *local stdio* MCP entry
+  (`npx … cerefox mcp`, or `cerefox-local mcp` with `--local`), which authenticates to Supabase
+  via the local server's own `.env` credential and the **Data API**, bypassing the Edge
+  Functions. It needs no EF token and is unaffected by 28E. The two token-bearing paths
+  (**GPT Actions**, **remote HTTP MCP**) are configured *manually* per `connect-agents.md`;
+  `cerefox token generate` just prints the token to paste there.
 - The token is a **secret** — never commit it; `.env` / Function secret / client config only.
   Add it to the gitleaks allowlist patterns (recognize `cfx_pat_`), and ensure it's not
   printed to logs.

--- a/docs/specs/oauth-mcp-server-design.md
+++ b/docs/specs/oauth-mcp-server-design.md
@@ -153,6 +153,12 @@ a **small static HTML+JS page from a dedicated Edge Function** deployed with
   scopes, then `approveAuthorization(authorization_id)` or
   `denyAuthorization(authorization_id)` — both return a `redirect_url` to send the user
   back to the OAuth client.
+- Two hard requirements from claude.ai field reports (`anthropics/claude-ai-mcp`):
+  redirects back to the client must be **302/303, never 307** (claude.ai silently
+  rejects 307 — issue #250), and an **already-consumed or unknown `authorization_id`
+  must render a graceful "start over from Claude" message** — Claude's Reconnect
+  button re-uses consumed authorization URLs and can double-submit approvals
+  (issue #562).
 - Holds **no secrets server-side**; everything runs client-side with the owner's session.
 Alternatives considered: the local web app (not publicly reachable — rejected); static
 hosting (GitHub Pages / Cloudflare Pages — works, but new infra and a second deploy
@@ -187,6 +193,11 @@ name `Claude`. If DCR proves flaky or noisy (one-off `client_id` rows per connec
 fall back to **pre-registering** a client with that exact redirect URI (exact match, no
 wildcards). CIMD is not yet supported by Supabase; Claude falls back to DCR when CIMD
 isn't advertised, so DCR is the working path today (watch item, §11).
+**Expect to need the pre-registration fallback**: `anthropics/claude-ai-mcp` issue #565
+(2026-07-07, open) reports claude.ai DCR against the Supabase OAuth server failing with
+"Couldn't register". The claude.ai connector dialog's "OAuth Client ID / Client Secret
+(optional)" fields are the UI for the pre-registered path (confirmed on the
+maintainer's account, Phase 0) — register via Authentication → OAuth Apps and paste.
 
 ### 4.3 What deliberately does NOT change
 
@@ -407,6 +418,26 @@ constantly; re-verify §14 before each phase that depends on a claim.)
 - **Signing-key migration**: moving HS256 → asymmetric is a prerequisite (§4.2-A);
   legacy-anon-key clients are unaffected (opaque string compare), but treat the
   migration as its own verified step in Phase 1, not a footnote.
+- **Known claude.ai platform failure modes** (from `anthropics/claude-ai-mcp`, the
+  official claude.ai-MCP tracker — check it before and during Phase 4, and file
+  server-developer reports there if we hit a wall):
+  - **#565** (open, 2026-07-07): DCR against Supabase OAuth server fails ("Couldn't
+    register") → go straight to the pre-registered client (§4.2-D).
+  - **#354 / #335 / #304 / #275** (recurring; #304 is Supabase-Auth-based): OAuth
+    completes, token endpoint returns 200, **claude.ai never sends an authenticated
+    MCP request**. Mostly closed "not planned". If we hit this and can't resolve it
+    (first suspects: PRS `resource` not byte-identical to the connector URL;
+    WWW-Authenticate still returned after valid auth), that is the §12 fallback
+    trigger.
+  - **#482** (closed): post-OAuth requests arrive **without** the Authorization header
+    → 401 loop. Distinguish from the above by EF logs (requests arrive, no token).
+  - **#476** (open): handshake + OAuth fine, tools never surface to the model on
+    claude.ai web (same server fine in Claude Code/ChatGPT).
+  - **#250**: 307 redirects silently rejected (consent page must 302/303 — §4.2-B).
+  - **#562**: Reconnect re-uses consumed authorization URLs (consent page must handle
+    idempotently — §4.2-B).
+  - **#561** (open): connectors occasionally removed without warning / can't re-add —
+    platform flakiness to keep in mind before blaming our own stack.
 
 ## 12. Fallback: Cloudflare Worker OAuth proxy (build only if §11 bites)
 
@@ -429,6 +460,9 @@ why it's the fallback. Trigger: the native path fails in a way we cannot resolve
 - Claude connector auth (OAuth required; callback URL; CIMD/DCR):
   `https://claude.com/docs/connectors/building/authentication`,
   `https://support.claude.com/en/articles/11503834-building-custom-connectors-via-remote-mcp-servers`
+- claude.ai MCP tracker (bug reports + announcements — watch during Phase 4):
+  `https://github.com/anthropics/claude-ai-mcp` (issues #565, #562, #482, #476, #354,
+  #335, #304, #275, #250 catalogued in §11)
 - RFC 9728 (Protected Resource Metadata); RFC 8414 (AS metadata); RFC 8707 (resource
   indicators)
 - FastMCP `SupabaseProvider` (pattern reference only — Python, not a drop-in):

--- a/docs/specs/oauth-mcp-server-design.md
+++ b/docs/specs/oauth-mcp-server-design.md
@@ -125,12 +125,13 @@ compliant clients never fall back to probing the domain root — where GoTrue's 
 - Enable **OAuth 2.1 Server** (Authentication → OAuth Server; config.toml equivalent:
   `[auth.oauth_server] enabled / authorization_url_path / allow_dynamic_registration`).
   Verified 2026-07-08: the feature is **beta, free during beta on all Supabase plans**.
-- **Migrate signing keys to asymmetric (RS256/ES256) — a prerequisite, not a
+- **Signing keys must be asymmetric (RS256/ES256) — a prerequisite, not a
   recommendation**: Supabase's default is HS256, and this design validates tokens against
   the public **JWKS** (§5 Path 2), which HS256 cannot serve; OIDC id tokens outright fail
-  on HS256. This project predates the asymmetric default — migrate during Phase 1 (a
-  Supabase-managed key-rotation flow) and verify existing clients are unaffected (they
-  compare the anon key as an opaque string, so they are).
+  on HS256. If a project is on HS256, migrate first (a Supabase-managed key-rotation
+  flow); legacy-anon-key clients are unaffected (they compare the key as an opaque
+  string). **Maintainer project: verified already on ES256 (ECC P-256), Phase 0
+  2026-07-08 — no migration needed.** Forks/other installs must still check.
 - Configure **Site URL + Authorization Path** — "the authorization path is combined with
   your Site URL … to create the full authorization endpoint URL" (component B's URL).
   Cerefox doesn't use Supabase Auth emails today, so repointing Site URL is acceptable;
@@ -360,6 +361,11 @@ explicit audit items for the v1.0 security audit (`docs/specs/security-model.md`
   baseline while OAuth is built). Confirm OAuth 2.1 Server availability in the project's
   dashboard; check current signing-key algorithm; re-verify the §14 claims that matter
   for the next phase.
+  **✅ DONE 2026-07-08**: Request-headers beta NOT on the account (§4.4 outcome note);
+  OAuth Server present on the plan (disabled, Authentication → OAuth Apps / Configuration
+  → OAuth Server); signing keys **already ES256 (P-256)** — no migration needed; Site URL
+  is the unused `http://localhost:3000` default (repointing is risk-free; Redirect URLs
+  allowlist empty).
 - **Phase 1 — Supabase config**: enable OAuth server + DCR; create owner user; set
   Site URL + Authorization Path; set `CEREFOX_MCP_STATIC_BEARER` secret; pin
   `oauth_owner_user_id` config row. No code.
@@ -487,6 +493,6 @@ docs on 2026-07-08. Re-check the relevant rows before each phase.
 | 4 | Custom domains break `.well-known` discovery | ✅ Still broken (maintainer ack 2026-02-17, no fix) — MCP URL stays on `<ref>.supabase.co` |
 | 5 | EF gateway is JWT-only; new `sb_…` keys rejected; `--no-verify-jwt` is the sanctioned escape | ✅ Confirmed (collaborator, 2026-01-10: "It is required to use --no-verify-jwt if you call them with anon (publishable) or service_role (secret) key") |
 | 6 | Consent page via Site URL + Authorization Path; supabase-js approve/deny | ✅ Confirmed; exact API: `supabase.auth.oauth.{getAuthorizationDetails,approveAuthorization,denyAuthorization}` → `redirect_url`; redirect carries `authorization_id` |
-| 7 | Asymmetric signing keys | ⚠️ **Sharpened**: HS256 is still the default; asymmetric is *required* for JWKS-based validation + OIDC id tokens → migration is a Phase 1 prerequisite. JWKS at `…/auth/v1/.well-known/jwks.json` |
+| 7 | Asymmetric signing keys | ⚠️ **Sharpened**: HS256 is still the platform default; asymmetric is *required* for JWKS-based validation + OIDC id tokens. **Maintainer project verified already on ES256 (P-256) in Phase 0** — prerequisite satisfied; forks must check. JWKS at `…/auth/v1/.well-known/jwks.json` |
 | 8 | Token claims | ✅ `sub`, `email`, `role`, `aud:"authenticated"`, `iss`, `client_id`; **no RFC 8707** resource binding |
 | 9 | claude.ai connectors require OAuth; callback `https://claude.ai/api/mcp/auth_callback`; CIMD→DCR fallback | ✅ Confirmed, **with one change**: beta slow-rollout **static "Request headers" auth** now exists (§4.4). PRS `resource` must exactly match the server URL; `authorization_servers[0]` is what Claude reads |

--- a/docs/specs/oauth-mcp-server-design.md
+++ b/docs/specs/oauth-mcp-server-design.md
@@ -212,9 +212,11 @@ maintainer's account, Phase 0) — register via Authentication → OAuth Apps an
   Actions (Developer-Mode MCP disables ChatGPT Memory — recorded lesson); an OAuth MCP
   connector for ChatGPT becomes *possible* later but is out of scope.
 - **Local MCP server (`cerefox mcp`) and CLI**: untouched.
-- **Schema / RPCs**: no `src/cerefox/db/` change → **no `schema_version` bump**. Any new
-  server-side setting (e.g. the pinned owner id, §5) is a `cerefox_config` *row*, not a
-  schema change.
+- **Schema / RPCs**: no `src/cerefox/db/` change → **no `schema_version` bump**. New
+  server-side settings (the owner pin, the optional static-Bearer value) are **Edge
+  Function secrets** (`supabase secrets set`), read via `Deno.env` — no DB round-trip on
+  the auth hot path, and no schema change. (An earlier draft considered a `cerefox_config`
+  row; secrets are cheaper per-request and equally single-user-safe.)
 - **Existing client configs**: Claude Code / Cursor / Codex / Gemini / Desktop bridges
   keep sending the legacy anon JWT in `Authorization: Bearer` — unchanged.
 
@@ -253,16 +255,20 @@ Every request to the JSON-RPC surface must present `Authorization: Bearer <token
 passes ONE of:
 
 **Path 1 — legacy static Bearer (back-compat).**
-Constant-time equality against the expected anon JWT. Because EF env vars are not
-reliably available (Decision Log 2026-03-14), the expected value is an **explicitly-set
-Function secret** (e.g. `CEREFOX_MCP_STATIC_BEARER`, set to the legacy anon JWT via
-`supabase secrets set`), with `SUPABASE_ANON_KEY` as an opportunistic fallback when
-present. Note this *tightens* auth versus today: the gateway accepted any valid project
-JWT (anon, service_role, user tokens); the in-function check accepts exactly the anon key
-on this path. `cerefox server deploy` gains a preflight that verifies the secret is set
-before deploying with `--no-verify-jwt` (never deploy an open function whose only gate is
-an unset secret — fail closed: if neither source is available at request time, Path 1
-rejects everything rather than accepting everything).
+Constant-time equality against the expected anon JWT.
+`staticBearer = CEREFOX_MCP_STATIC_BEARER ?? SUPABASE_ANON_KEY ?? null`.
+**Decision (2026-07-08, maintainer):** default to the platform-injected
+`SUPABASE_ANON_KEY` — which is exactly what existing clients send — and treat the
+explicit `CEREFOX_MCP_STATIC_BEARER` secret as an **escape hatch**, set only if the
+injected var proves unreliable (the 2026-03-14 Decision Log flagged `SUPABASE_ANON_KEY`
+as "sometimes undefined", but that was the original always-on gateway-redundant check;
+here it is a fallback, and the maintainer primarily uses the local MCP that never touches
+this path, so the blast radius of a miss is small). Whichever source is used, the check
+*tightens* auth versus the old gateway (which accepted any valid project JWT). **Fail
+closed**: if neither source is available at request time, Path 1 rejects everything
+rather than accepting everything. No blocking deploy preflight — `cerefox server deploy`
+prints a reminder; a missing static value cannot *open* the function (it only breaks old
+clients, who then show `bad_signature`/`malformed_token` in the logs).
 
 **Path 2 — OAuth access token.**
 JWT validation against the project JWKS
@@ -277,13 +283,15 @@ JWT validation against the project JWKS
   `role` (`authenticated`), `aud`, `iss`, and the OAuth-specific `client_id`.
 - Grant types issued: `authorization_code` (+PKCE) and `refresh_token` only
   (`client_credentials`/`password` explicitly unsupported — fine for this flow).
-- **Owner check** (single-user): `sub` must equal the pinned owner user id, stored as a
-  `cerefox_config` row (`oauth_owner_user_id`) set during Phase 1 setup. Until the row is
-  set, any `authenticated`-role token is accepted (only the owner exists) — but pinning is
-  part of the setup checklist, and `cerefox doctor` should warn when OAuth is live without
-  it. **Maintainer owner UUID (Phase 1, 2026-07-08):
-  `0b850e27-27b6-48eb-b019-e208fb7f92e7`** — this is a server-side value only; it is
-  never entered into claude.ai.
+- **Owner check** (single-user) — **this is the authorization boundary, not optional
+  hardening.** `sub` must equal the pinned owner user id, from the `CEREFOX_OAUTH_OWNER_ID`
+  Function secret (a server-side value only; never entered into claude.ai). If unset, the
+  function accepts *any* validly-signed `authenticated` token from the project's auth
+  server — and **because Supabase enables email sign-ups by default, an attacker could
+  self-register via `/auth/v1/signup` and obtain an accepted token**. Pinning the owner
+  (or disabling public sign-ups) closes that hole; for a "every byte is sensitive" system,
+  pin it. Maintainer owner UUID (Phase 1, 2026-07-08):
+  `0b850e27-27b6-48eb-b019-e208fb7f92e7`.
 - JWKS fetched with in-isolate caching (EF isolates are short-lived; a simple in-memory
   cache with TTL is enough — key rotation is picked up on isolate recycle or TTL expiry).
 - Use a vetted JWT library (`jose` via npm/esm specifier in Deno) — no hand-rolled JWT

--- a/docs/specs/oauth-mcp-server-design.md
+++ b/docs/specs/oauth-mcp-server-design.md
@@ -1,0 +1,448 @@
+# Design: OAuth 2.1 on `cerefox-mcp` — Cerefox for Claude.ai, Claude mobile, and other cloud agents
+
+> **Status**: Design-of-record (2026-07-08). Not started. Work lands on `feat/oauth-mcp`,
+> ships as part of **Iteration 28 (v1.0.0)** alongside the stability commitment and the
+> security audit (which explicitly covers this new auth surface).
+>
+> **Supersedes** the March 2026 deferral in
+> [`docs/research/oauth-mcp-auth.md`](../research/oauth-mcp-auth.md): Supabase has since
+> shipped a native **OAuth 2.1 Server** (public beta 2025-11-26), which turns the old
+> GoTrue blocker into the intended mechanism. This doc is the repo-side design derived
+> from the maintainer's research handoff (Cerefox KB doc `92996524-2923-4c7d-864b-7ae52f1bbb28`,
+> "Handoff: Cerefox as an OAuth-protected MCP server for Claude.ai and mobile").
+>
+> Per `docs/specs/README.md`, this is a point-in-time snapshot; `docs/plan.md` wins where
+> they diverge during execution.
+
+---
+
+## 1. Problem and goal
+
+Cerefox's remote MCP server (`cerefox-mcp` Edge Function) authenticates with a **static
+Bearer token** (the legacy anon JWT), validated by the Supabase API gateway before the
+function runs. That works for every client that can send a static header — Claude Code,
+Cursor, Codex, Gemini CLI, Claude Desktop (via `supergateway`/`mcp-remote --header`) — but
+**claude.ai web and the Claude mobile app require OAuth for custom connectors**
+(authorization code + PKCE, with standard MCP discovery). Nuance verified 2026-07-08:
+Anthropic has begun a **beta, slow-rollout "Request headers" option** on custom connectors
+(static bearer/API-key via an allowlisted header set incl. `authorization`) — see §4.4; it
+may deliver a zero-code quick win if the rollout has reached the maintainer's account, but
+OAuth remains the robust, generally-available path this design targets.
+
+**Goal**: make `cerefox-mcp` a spec-compliant OAuth 2.1 **protected resource server** so
+any OAuth-discovering MCP client — claude.ai, Claude mobile, and potentially ChatGPT
+connectors and others — can connect with the **full 10-tool surface** (hybrid search,
+document reconstruction, ingest, the works). Explicitly rejected: keyword-only access via
+Supabase's hosted MCP (`mcp.supabase.com` + PAT) — raw table access without semantic
+search or Cerefox tool ergonomics is not worth having.
+
+**Non-goals**: multi-user support (Cerefox stays single-user; OAuth authenticates the one
+owner), real-time transport changes (no SSE), any change to the primitive Edge Functions
+or the GPT Actions path.
+
+## 2. History — why this was blocked, and what changed
+
+The March 2026 research (`docs/research/oauth-mcp-auth.md`) and the Decision Log
+(2026 Q1 Part 1, entries of 2026-03-14/15/16) established:
+
+- **GoTrue owned `/.well-known/*` on `*.supabase.co`** and served nothing valid for a
+  custom Edge Function. Every OAuth-discovering client (`mcp-remote` default mode,
+  Perplexity web connector — both *tested*) crashed at discovery/DCR before reaching the
+  EF. Custom EFs could not override those routes.
+- Supabase's own docs said auth for BYO MCP on Edge Functions was "coming soon".
+- Decision then: **defer**; static Bearer covers every client we actually needed
+  ("don't build infrastructure for a problem that doesn't exist yet"), with the
+  Cloudflare Worker OAuth proxy noted as the escape hatch.
+
+**What changed (the unblock)**: Supabase shipped the **OAuth 2.1 Server** (public beta
+announced 2025-11-26). It provides:
+
+- OAuth 2.1 **authorization code + PKCE** (the only grant — exactly what Claude needs).
+- **Valid discovery metadata** at
+  `https://<project-ref>.supabase.co/.well-known/oauth-authorization-server` (plus the
+  `/auth/v1`-suffixed variant and `/.well-known/openid-configuration`). The route GoTrue
+  owns now answers correctly — the wall became the door.
+- **Dynamic Client Registration** (dashboard toggle), so Claude can self-register.
+- JWT access tokens (carrying `user_id`, `role`, `client_id`) with refresh-token rotation,
+  verifiable against the project **JWKS**.
+
+Relevant Decision Log lessons this design must respect (from the 2026 sweep):
+
+1. **405-for-GET is load-bearing** (2026-03-30): a 200 on GET once caused clients to
+   treat the server as SSE-capable and poll ~1 req/sec (~86K EF invocations/day/client).
+   The new discovery routes are GETs; everything else must keep returning 405.
+2. **EF env vars are not reliably available** (2026-03-14): the original in-function
+   Bearer check was removed partly because `Deno.env.get("SUPABASE_ANON_KEY")` was
+   sometimes undefined. Any new in-function secret must be an **explicitly-set Function
+   secret**, not an assumed platform-injected var.
+3. **The EF gateway is JWT-only** (2026-05-18): it rejects the new `sb_publishable_…`/
+   `sb_secret_…` keys with `UNAUTHORIZED_INVALID_JWT_FORMAT`. The recorded "Option B"
+   sketch — per-function `verify_jwt = false` + in-function validation — was deliberately
+   parked with trigger conditions; condition (d) ("MCP client-config layer being touched
+   anyway") is now met. This design effectively executes Option B for `cerefox-mcp`,
+   while keeping `Authorization: Bearer` semantics so no existing client config changes.
+4. The old "claude.ai would be FTS-only even with perfect OAuth" note was an explicitly
+   **untested assumption** about the `mcp.supabase.com` path; it does not apply to our
+   own MCP server and is superseded by this design.
+
+## 3. Decisions (locked 2026-07-07, maintainer session)
+
+- **(a) Full MCP access only.** No keyword-only half measure.
+- **(b) Primary path: native Supabase OAuth 2.1 Server**, with `cerefox-mcp` as the
+  protected resource. No new infrastructure except a publicly reachable consent page.
+- **(c) Cloudflare Worker OAuth proxy is the documented fallback** (§12), built only if
+  the native path hits an unresolvable wall (likely a beta bug or discovery mismatch).
+- **(d) Backward compatibility is an invariant**: the legacy static-Bearer path keeps
+  working for all existing clients throughout and after this work.
+
+## 4. Target architecture
+
+### 4.1 The flow (what happens when the connector is added on claude.ai)
+
+```
+1. claude.ai POSTs (unauthenticated) to
+   https://<ref>.supabase.co/functions/v1/cerefox-mcp
+2. cerefox-mcp returns 401 + WWW-Authenticate: Bearer resource_metadata=
+   "https://<ref>.supabase.co/functions/v1/cerefox-mcp/.well-known/oauth-protected-resource"
+3. claude.ai fetches that Protected Resource Metadata (RFC 9728); it names
+   Supabase's auth server in `authorization_servers`
+4. claude.ai fetches https://<ref>.supabase.co/.well-known/oauth-authorization-server
+   (served natively by Supabase now) → learns authorize/token/registration/JWKS endpoints
+5. claude.ai self-registers via DCR (fallback: pre-registered client)
+6. Authorization code + PKCE: Supabase authenticates the owner, redirects to OUR
+   consent page; owner approves; Supabase issues access + refresh tokens
+7. claude.ai calls cerefox-mcp with the Bearer access token; the function validates
+   the JWT against Supabase's JWKS and serves the full tool surface
+```
+
+The `resource_metadata` URL points at a **path the function itself serves** (step 2), so
+compliant clients never fall back to probing the domain root — where GoTrue's metadata
+(which is correct now anyway) would also work, but the explicit pointer removes ambiguity.
+
+### 4.2 Components
+
+**A. Supabase project configuration (dashboard / Management API — no code).**
+- Enable **OAuth 2.1 Server** (Authentication → OAuth Server; config.toml equivalent:
+  `[auth.oauth_server] enabled / authorization_url_path / allow_dynamic_registration`).
+  Verified 2026-07-08: the feature is **beta, free during beta on all Supabase plans**.
+- **Migrate signing keys to asymmetric (RS256/ES256) — a prerequisite, not a
+  recommendation**: Supabase's default is HS256, and this design validates tokens against
+  the public **JWKS** (§5 Path 2), which HS256 cannot serve; OIDC id tokens outright fail
+  on HS256. This project predates the asymmetric default — migrate during Phase 1 (a
+  Supabase-managed key-rotation flow) and verify existing clients are unaffected (they
+  compare the anon key as an opaque string, so they are).
+- Configure **Site URL + Authorization Path** — "the authorization path is combined with
+  your Site URL … to create the full authorization endpoint URL" (component B's URL).
+  Cerefox doesn't use Supabase Auth emails today, so repointing Site URL is acceptable;
+  verify no side effects during Phase 1.
+- Enable **DCR** (`allow_dynamic_registration` — defaults to disabled).
+- Create the **owner user** in Supabase Auth (email + password). Cerefox has never had
+  GoTrue users; the OAuth flow authenticates *as* this user.
+
+**B. Consent page — a new public Edge Function (`cerefox-oauth-consent`).**
+Supabase delegates the consent screen to us; it needs a stable public URL. The Cerefox
+web app is localhost-only, so it can't host this. Rather than stand up new hosting, serve
+a **small static HTML+JS page from a dedicated Edge Function** deployed with
+`verify_jwt = false`:
+- Signs the owner in via supabase-js (CDN import, publishable key — public by design).
+- Receives the redirect with an `authorization_id` query parameter; fetches the pending
+  authorization's details and renders "Allow *Claude* to access your Cerefox knowledge
+  base?" with Approve / Deny.
+- Uses the supabase-js `supabase.auth.oauth` namespace (verified against the docs
+  2026-07-08): `getAuthorizationDetails(authorization_id)` to display client info and
+  scopes, then `approveAuthorization(authorization_id)` or
+  `denyAuthorization(authorization_id)` — both return a `redirect_url` to send the user
+  back to the OAuth client.
+- Holds **no secrets server-side**; everything runs client-side with the owner's session.
+Alternatives considered: the local web app (not publicly reachable — rejected); static
+hosting (GitHub Pages / Cloudflare Pages — works, but new infra and a second deploy
+surface; keep as plan-B if EF-served HTML proves awkward).
+
+**C. `cerefox-mcp` becomes a protected resource server (the core code work).**
+Deployed with `verify_jwt = false` — the gateway no longer gates it, so **in-function
+auth becomes the only gate** (see §5 and §6). Changes:
+- Serve `GET <function-path>/.well-known/oauth-protected-resource` (RFC 9728):
+  `resource` (**must match the MCP server URL exactly** — Anthropic requirement),
+  `authorization_servers` with the project's auth-server **issuer URL
+  (`https://<ref>.supabase.co/auth/v1`) as the first entry** (Anthropic reads the first),
+  `bearer_methods_supported: ["header"]`, and supported scopes. Clients then fetch the AS
+  metadata from the documented endpoints
+  `…/auth/v1/.well-known/{oauth-authorization-server,openid-configuration}` (Supabase:
+  "both endpoints return the same metadata").
+- Return **401 + `WWW-Authenticate`** (with the explicit `resource_metadata` pointer) for
+  missing/invalid tokens on the JSON-RPC surface.
+- **Validate tokens in-function** (§5): OAuth access JWTs against JWKS, or the legacy
+  static Bearer by constant-time comparison.
+- Preserve the GET contract: `/version` (now auth-gated in-function, §6) and the new
+  `.well-known` route are the only GETs answered; everything else stays **405** (Decision
+  Log lesson — do not resurrect SSE polling).
+- The token-validation logic lives in a new **`_shared/mcp-auth/`** module so it is unit
+  testable with `bun test` (mocked JWKS) and reusable if the local server ever grows a
+  remote HTTP mode (iter-30's deferred "remote HTTP-MCP" item).
+
+**D. Client registration.**
+Prefer **DCR** (zero manual steps). Claude's callback is
+`https://claude.ai/api/mcp/auth_callback` (watch for a `claude.com` migration), client
+name `Claude`. If DCR proves flaky or noisy (one-off `client_id` rows per connect),
+fall back to **pre-registering** a client with that exact redirect URI (exact match, no
+wildcards). CIMD is not yet supported by Supabase; Claude falls back to DCR when CIMD
+isn't advertised, so DCR is the working path today (watch item, §11).
+
+### 4.3 What deliberately does NOT change
+
+- **Primitive Edge Functions + GPT Actions**: untouched. `cerefox-mcp` is not in the GPT
+  Actions OpenAPI block, so no `info.version` bump. ChatGPT stays on Custom GPT + GPT
+  Actions (Developer-Mode MCP disables ChatGPT Memory — recorded lesson); an OAuth MCP
+  connector for ChatGPT becomes *possible* later but is out of scope.
+- **Local MCP server (`cerefox mcp`) and CLI**: untouched.
+- **Schema / RPCs**: no `src/cerefox/db/` change → **no `schema_version` bump**. Any new
+  server-side setting (e.g. the pinned owner id, §5) is a `cerefox_config` *row*, not a
+  schema change.
+- **Existing client configs**: Claude Code / Cursor / Codex / Gemini / Desktop bridges
+  keep sending the legacy anon JWT in `Authorization: Bearer` — unchanged.
+
+### 4.4 Parallel quick win (test in Phase 0): claude.ai "Request headers" beta
+
+Verified 2026-07-08 against Anthropic's connector docs: custom connectors now support
+**static bearer/API-key auth in beta** — a "Request headers" section in the Add custom
+connector dialog, restricted to an allowlist of header names **including
+`authorization`** (value entered as `Bearer <token>`, stored securely, sent on every
+request). It is a **slow rollout** ("contact Anthropic for early access") and the docs
+frame it around organization admins, so availability on a personal account is unknown
+until tried.
+
+If the maintainer's account has it, pointing a connector at `cerefox-mcp` with the
+legacy anon JWT should work **today with zero code changes** (the EF gateway already
+accepts it) — full 10-tool surface on claude.ai web and mobile. Phase 0 tests this
+first. It does **not** replace the OAuth work: it's a beta under slow rollout with a
+shared-credential model, it does nothing for other OAuth-discovering clients, and the
+product story ("any MCP client can connect") still needs the standard flow. But it can
+deliver the maintainer's primary use case immediately and serves as a fallback if the
+Supabase beta misbehaves — a *second* escape hatch alongside §12.
+
+## 5. Token validation (the auth model, precisely)
+
+Every request to the JSON-RPC surface must present `Authorization: Bearer <token>` that
+passes ONE of:
+
+**Path 1 — legacy static Bearer (back-compat).**
+Constant-time equality against the expected anon JWT. Because EF env vars are not
+reliably available (Decision Log 2026-03-14), the expected value is an **explicitly-set
+Function secret** (e.g. `CEREFOX_MCP_STATIC_BEARER`, set to the legacy anon JWT via
+`supabase secrets set`), with `SUPABASE_ANON_KEY` as an opportunistic fallback when
+present. Note this *tightens* auth versus today: the gateway accepted any valid project
+JWT (anon, service_role, user tokens); the in-function check accepts exactly the anon key
+on this path. `cerefox server deploy` gains a preflight that verifies the secret is set
+before deploying with `--no-verify-jwt` (never deploy an open function whose only gate is
+an unset secret — fail closed: if neither source is available at request time, Path 1
+rejects everything rather than accepting everything).
+
+**Path 2 — OAuth access token.**
+JWT validation against the project JWKS
+(`https://<ref>.supabase.co/auth/v1/.well-known/jwks.json`):
+- **Algorithm allowlist**: RS256/ES256 only (never `none`, never HS256 — prevents
+  key-confusion between the legacy HS256 anon JWT and asymmetric user tokens).
+- `iss` = `https://<ref>.supabase.co/auth/v1`; `exp`/`nbf` with small clock skew.
+- `aud` = `"authenticated"` (the documented value; verified 2026-07-08). RFC 8707
+  resource-audience binding is **not supported** by Supabase's OAuth server — the token
+  is project-scoped, not resource-scoped, which is acceptable here because the project
+  hosts exactly one protected resource. Documented claims: `sub` (user UUID), `email`,
+  `role` (`authenticated`), `aud`, `iss`, and the OAuth-specific `client_id`.
+- Grant types issued: `authorization_code` (+PKCE) and `refresh_token` only
+  (`client_credentials`/`password` explicitly unsupported — fine for this flow).
+- **Owner check** (single-user): `sub` must equal the pinned owner user id, stored as a
+  `cerefox_config` row (`oauth_owner_user_id`) set during Phase 1 setup. Until the row is
+  set, any `authenticated`-role token is accepted (only the owner exists) — but pinning is
+  part of the setup checklist, and `cerefox doctor` should warn when OAuth is live without
+  it.
+- JWKS fetched with in-isolate caching (EF isolates are short-lived; a simple in-memory
+  cache with TTL is enough — key rotation is picked up on isolate recycle or TTL expiry).
+- Use a vetted JWT library (`jose` via npm/esm specifier in Deno) — no hand-rolled JWT
+  parsing.
+
+On success, the function proceeds exactly as today: **service-role key internally for DB
+work** (single-implementation principle unchanged; RLS-scoped user access is available if
+multi-user ever happens, not now). The usage log gains nothing new structurally — but the
+handler should record the auth path (`oauth` vs `static`) in the existing `requestor`/
+`access_path` conventions where useful for the audit trail.
+
+## 6. Security invariants (audit checklist input for Iteration 28)
+
+`verify_jwt = false` removes the platform gate; these invariants replace it and are
+explicit audit items for the v1.0 security audit (`docs/specs/security-model.md`):
+
+1. **Auth-first dispatch**: token validation runs before *any* method dispatch, tool
+   lookup, or DB touch. The only unauthenticated responses the function ever produces:
+   the RFC 9728 metadata document (public by spec), the 401 challenge, 405s, and CORS
+   preflight. Nothing else leaks — not `/version` (now requires auth in-function; EF
+   version info is low-sensitivity but stays gated as before), not error details.
+2. **Fail closed** on both paths (§5): missing secret → Path 1 rejects; JWKS unreachable
+   → Path 2 rejects (no "temporarily open" fallback).
+3. **Constant-time comparison** for the static token.
+4. **Algorithm allowlist** on JWT verification (no HS256 on Path 2, no `none` anywhere).
+5. **405-for-GET preserved** for everything except `/version` and the `.well-known` route
+   (quota-burn regression guard, not just spec hygiene).
+6. **Deploy-time flag audit**: `--no-verify-jwt` applies ONLY to `cerefox-mcp` and
+   `cerefox-oauth-consent`. The 8 primitive EFs keep gateway verification. The per-EF
+   flag map lives in code (`deploy-server.ts` + `_shared/db-deploy/`), not in operator
+   memory, and the flag must be passed on **every** deploy of those functions (the CLI
+   default re-enables verification otherwise — a silent regression that would break
+   OAuth clients; conversely, forgetting it never *opens* anything, it only breaks).
+7. **Consent page holds no secrets**; approve/deny happens under the owner's GoTrue
+   session; the page validates the `authorization_id` against the API rather than
+   trusting query-string content for display.
+8. **Redirect URIs are exact-match** (no wildcards) whether DCR-created or pre-registered.
+9. The peer `/version?peers=true` aggregator keeps forwarding the caller's auth to peer
+   EFs (they still sit behind the gateway).
+
+## 7. Repo changes (file-level map)
+
+| Area | Change |
+|---|---|
+| `supabase/functions/cerefox-mcp/index.ts` | Auth-first dispatch; `.well-known` route; 401+`WWW-Authenticate`; auth-gate `/version` in-function |
+| `_shared/mcp-auth/` (new) | Token validation: static compare + JWKS JWT verification; unit-testable, mocked in tests |
+| `supabase/functions/cerefox-oauth-consent/` (new) | Public consent page EF (static HTML+JS, supabase-js CDN) |
+| `packages/memory/src/cli/commands/deploy-server.ts` | Per-EF deploy-flag map (`--no-verify-jwt` for the two functions); secret preflight |
+| `_shared/ef-meta/` | Add `cerefox-oauth-consent`?? — **no**: it's not a peer with a `/version` surface worth aggregating; decide at build time (default: leave out) |
+| `_shared/compatibility/index.ts` | Review `minEdgeFunctions` — OAuth is additive for existing clients, so likely **no** bump (bump only if a client release depends on the new EF behavior) |
+| `packages/memory/src/cli/commands/doctor.ts` | Optional: OAuth-config checks (owner pinned, secret set) — nice-to-have, Phase 5 |
+| `docs/guides/connect-agents.md` | New "Claude.ai / Claude mobile (OAuth)" section; client matrix rows flip to supported |
+| `docs/guides/setup-supabase.md` | OAuth 2.1 Server setup section (enable, Site URL/Authorization Path, DCR, owner user, secrets) |
+| `docs/research/oauth-mcp-auth.md` | Resolution note: native OAuth path shipped; revise takeaways |
+| `CLAUDE.md` | Client-compat matrix + three-layer auth section gain the OAuth path |
+| `CHANGELOG.md` | `[Unreleased]` entries as work lands |
+
+`EF_VERSION` bumps with the release as usual (via `cut_release.ts`).
+
+## 8. Testing
+
+- **Unit (`bun test`, no network)**: `_shared/mcp-auth/` — valid/expired/wrong-iss/
+  wrong-alg/HS256-downgrade/garbage tokens against a mocked JWKS; static-path constant
+  compare incl. unset-secret fail-closed; 401 challenge shape; metadata document shape;
+  405 matrix (GET/PUT/DELETE on non-well-known paths).
+- **Live remote-MCP e2e (opt-in, `CEREFOX_LIVE_E2E=1`)**: extend
+  `packages/memory/test/mcp-remote/` with: unauthenticated → 401 + parseable
+  `WWW-Authenticate`; `.well-known` fetch → valid RFC 9728 doc naming the auth server;
+  legacy-Bearer tool call still works. (Full OAuth dance is not automatable here — it
+  needs an interactive consent; cover it manually in Phase 4.) Keep EF-quota discipline:
+  narrowest file, `requestor: "e2e-test"`.
+- **Manual acceptance (Phase 4/5)**: claude.ai connector end-to-end (discovery → DCR →
+  consent → tokens → all 10 tools); same connector on Claude mobile; regression matrix
+  for Claude Code / Cursor / Claude Desktop (supergateway) / Codex on static Bearer;
+  GPT Actions untouched-but-verified; watch EF logs for the full handshake.
+
+## 9. Phased plan
+
+- **Phase 0 — Preflight**: check whether the claude.ai "Add custom connector" dialog
+  offers the beta **Request headers** section (§4.4) — if yes, connect with the legacy
+  anon JWT and test the full tool surface on web + mobile (immediate value + a working
+  baseline while OAuth is built). Confirm OAuth 2.1 Server availability in the project's
+  dashboard; check current signing-key algorithm; re-verify the §14 claims that matter
+  for the next phase.
+- **Phase 1 — Supabase config**: enable OAuth server + DCR; create owner user; set
+  Site URL + Authorization Path; set `CEREFOX_MCP_STATIC_BEARER` secret; pin
+  `oauth_owner_user_id` config row. No code.
+- **Phase 2 — Consent page**: build + deploy `cerefox-oauth-consent`; verify the
+  approve/deny round trip with a manual OAuth test client before Claude ever connects.
+- **Phase 3 — Resource server**: `_shared/mcp-auth/` + `cerefox-mcp` changes + deploy
+  flag map; unit tests green; deploy; verify legacy clients unaffected.
+- **Phase 4 — Connect Claude**: add the claude.ai custom connector; watch the full
+  handshake in EF logs; then verify Claude mobile (same connector, synced).
+- **Phase 5 — Regression + hardening**: full client matrix; optional `doctor` checks;
+  live e2e additions.
+- **Phase 6 — Document + log**: guides, matrices, `oauth-mcp-auth.md` resolution,
+  CHANGELOG; Decision Log entry (KB) + update the KB handoff doc's status.
+
+## 10. Iteration & versioning
+
+This ships inside **Iteration 28 (v1.0.0)** — decision 2026-07-08 (maintainer preference,
+agreed): the feature and the stability commitment travel together so the one-time
+**security audit covers the new OAuth surface in the same pass** (auditing v1.0 and then
+re-auditing a v1.1 auth rework would be double work, and "every public endpoint requires
+auth" — the audit's headline item — must be re-stated around the two deliberately-public
+routes this design introduces). Iterations 29+ keep their numbers.
+
+Sequencing inside the iteration: OAuth work first (28A), then the audit (28B) over the
+final surface, then the v1.0 contract/stamp (28C). One caveat the maintainer should hold:
+Supabase's OAuth server is **beta** — if Phase 4 shows instability, prefer soaking the
+OAuth feature in a `v0.12.x` pre-release and stamping `v1.0.0` after it settles, rather
+than delaying or shipping a shaky 1.0. The plan structure supports either cut.
+
+## 11. Risks and watch items
+
+(Platform claims re-verified against live docs 2026-07-08 — see §14. Supabase ships
+constantly; re-verify §14 before each phase that depends on a claim.)
+
+- **Beta surface**: OAuth 2.1 Server is beta (free during beta on all plans); budget
+  debugging time for session/consent rough edges. Fallbacks exist (§4.4, §12).
+- **Custom domains break discovery**: confirmed still broken as of 2026-07-08
+  (maintainer acknowledged 2026-02-17, no fix announced). The MCP URL must stay on
+  `<project-ref>.supabase.co`. (The consent page may live anywhere.)
+- **CIMD vs DCR**: Supabase still ships only DCR (community implementation offer of
+  2026-04 unanswered). Anthropic's docs confirm Claude **falls back to DCR** when CIMD
+  isn't advertised, so we're fine today. If Anthropic ever mandates CIMD before Supabase
+  ships it, revisit (likely via the fallback proxy). Related upstream wart (2026-06): DCR
+  strict port-matching breaks RFC 8252 loopback-callback clients — irrelevant for
+  claude.ai (fixed HTTPS callback) but worth knowing if desktop OAuth clients appear.
+- **DCR noise**: repeated connects may accumulate one-off client registrations; if so,
+  pre-register (§4.2-D).
+- **MCP protocol version**: the EF pins `2025-03-26`; the OAuth discovery flow is
+  transport-level and version-independent, but verify claude.ai accepts the negotiated
+  version during Phase 4 (bump the protocol surface if required — separate, mechanical).
+- **EF invocation quota**: a cloud Claude user burns ~1 invocation per tool call (as any
+  remote client does) plus a handful per OAuth handshake; acceptable, but heavy automated
+  use should still prefer the local stdio server (recorded cost lesson).
+- **Site URL repointing**: verify no latent dependency on the current Site URL value
+  (password-reset emails etc.) — Cerefox has no GoTrue users today, so expected clean.
+- **Signing-key migration**: moving HS256 → asymmetric is a prerequisite (§4.2-A);
+  legacy-anon-key clients are unaffected (opaque string compare), but treat the
+  migration as its own verified step in Phase 1, not a footnote.
+
+## 12. Fallback: Cloudflare Worker OAuth proxy (build only if §11 bites)
+
+A thin Worker on its own domain (free tier: 100K req/day) owns its own `/.well-known`,
+implements the OAuth provider handshake via Cloudflare's open-source OAuth Provider
+library, presents consent, and proxies authenticated calls to `cerefox-mcp` with the
+static Bearer. Claude does OAuth against the Worker and never touches GoTrue. Cost ≈ $0;
+effort ≈ 1–2 days; the price is a second service to maintain forever — which is exactly
+why it's the fallback. Trigger: the native path fails in a way we cannot resolve
+(discovery bug, DCR incompatibility, CIMD mandate before Supabase support).
+
+## 13. References
+
+- Supabase OAuth 2.1 Server: overview `https://supabase.com/docs/guides/auth/oauth-server`;
+  getting started `…/oauth-server/getting-started`; MCP authentication
+  `…/oauth-server/mcp-authentication`; flows `…/oauth-server/oauth-flows`;
+  launch post `https://supabase.com/blog/oauth2-provider`
+- Custom-domain discovery gotcha: `https://github.com/orgs/supabase/discussions/38022`
+- CIMD vs DCR: `https://github.com/orgs/supabase/discussions/41695`
+- Claude connector auth (OAuth required; callback URL; CIMD/DCR):
+  `https://claude.com/docs/connectors/building/authentication`,
+  `https://support.claude.com/en/articles/11503834-building-custom-connectors-via-remote-mcp-servers`
+- RFC 9728 (Protected Resource Metadata); RFC 8414 (AS metadata); RFC 8707 (resource
+  indicators)
+- FastMCP `SupabaseProvider` (pattern reference only — Python, not a drop-in):
+  `https://gofastmcp.com/integrations/supabase`
+- Repo: `docs/research/oauth-mcp-auth.md` (the 2026-03 analysis this supersedes);
+  `supabase/functions/cerefox-mcp/index.ts`; `docs/guides/connect-agents.md`
+- KB: handoff doc `92996524-2923-4c7d-864b-7ae52f1bbb28`; Decision Log 2026 Q1 Part 1
+  (GoTrue-era failures), Q1 Part 2 (405/SSE lesson), Q2 Part 1 (key-system asymmetry,
+  Option B sketch)
+
+## 14. Platform-claim verification record (2026-07-08, live docs)
+
+Supabase and Anthropic ship changes constantly; the handoff research (2026-07-07) was
+done without live tooling, so every load-bearing claim was re-verified against the live
+docs on 2026-07-08. Re-check the relevant rows before each phase.
+
+| # | Claim | Verdict (2026-07-08) |
+|---|---|---|
+| 1 | OAuth 2.1 Server exists, authorization_code+PKCE | ✅ Confirmed; **beta, free during beta on all plans**; also issues `refresh_token`; `client_credentials`/`password` unsupported |
+| 2 | DCR supported, dashboard/config toggle | ✅ Confirmed (`allow_dynamic_registration`, default **disabled**); CIMD still **unshipped** (Apr-2026 community offer unanswered) |
+| 3 | Valid AS discovery metadata served | ✅ Confirmed at `…/auth/v1/.well-known/{oauth-authorization-server,openid-configuration}` ("interchangeable") |
+| 4 | Custom domains break `.well-known` discovery | ✅ Still broken (maintainer ack 2026-02-17, no fix) — MCP URL stays on `<ref>.supabase.co` |
+| 5 | EF gateway is JWT-only; new `sb_…` keys rejected; `--no-verify-jwt` is the sanctioned escape | ✅ Confirmed (collaborator, 2026-01-10: "It is required to use --no-verify-jwt if you call them with anon (publishable) or service_role (secret) key") |
+| 6 | Consent page via Site URL + Authorization Path; supabase-js approve/deny | ✅ Confirmed; exact API: `supabase.auth.oauth.{getAuthorizationDetails,approveAuthorization,denyAuthorization}` → `redirect_url`; redirect carries `authorization_id` |
+| 7 | Asymmetric signing keys | ⚠️ **Sharpened**: HS256 is still the default; asymmetric is *required* for JWKS-based validation + OIDC id tokens → migration is a Phase 1 prerequisite. JWKS at `…/auth/v1/.well-known/jwks.json` |
+| 8 | Token claims | ✅ `sub`, `email`, `role`, `aud:"authenticated"`, `iss`, `client_id`; **no RFC 8707** resource binding |
+| 9 | claude.ai connectors require OAuth; callback `https://claude.ai/api/mcp/auth_callback`; CIMD→DCR fallback | ✅ Confirmed, **with one change**: beta slow-rollout **static "Request headers" auth** now exists (§4.4). PRS `resource` must exactly match the server URL; `authorization_servers[0]` is what Claude reads |

--- a/docs/specs/oauth-mcp-server-design.md
+++ b/docs/specs/oauth-mcp-server-design.md
@@ -220,6 +220,16 @@ product story ("any MCP client can connect") still needs the standard flow. But 
 deliver the maintainer's primary use case immediately and serves as a fallback if the
 Supabase beta misbehaves — a *second* escape hatch alongside §12.
 
+> **Phase 0 outcome (2026-07-08): not available.** The maintainer's claude.ai "Add
+> Custom Connector (beta)" dialog offers only Name, URL, and Advanced settings with
+> "OAuth Client ID (optional)" / "OAuth Client Secret (optional)" — no Request-headers
+> section. The rollout has not reached the account; the OAuth build proceeds as the
+> only path. Useful confirmation from the same dialog: claude.ai supports
+> **pre-registered client credentials**, so the §4.2-D DCR fallback (pre-register in
+> Supabase → paste ID/secret into those fields) is a verified UI affordance.
+> Connector name reserved by the maintainer: **CerefoxMCP** (distinct from the local
+> stdio server's `cerefox` so both can coexist in Claude clients).
+
 ## 5. Token validation (the auth model, precisely)
 
 Every request to the JSON-RPC surface must present `Authorization: Bearer <token>` that

--- a/docs/specs/oauth-mcp-server-design.md
+++ b/docs/specs/oauth-mcp-server-design.md
@@ -145,11 +145,29 @@ compliant clients never fall back to probing the domain root — where GoTrue's 
 - Create the **owner user** in Supabase Auth (email + password). Cerefox has never had
   GoTrue users; the OAuth flow authenticates *as* this user.
 
-**B. Consent page — a new public Edge Function (`cerefox-oauth-consent`).**
-Supabase delegates the consent screen to us; it needs a stable public URL. The Cerefox
-web app is localhost-only, so it can't host this. Rather than stand up new hosting, serve
-a **small static HTML+JS page from a dedicated Edge Function** deployed with
-`verify_jwt = false`:
+**B. Consent page — a static HTML+JS page on an HTML-capable host.**
+
+> **Live finding (2026-07-08): the consent page CANNOT be a Supabase Edge Function.**
+> Supabase rewrites `text/html` → `text/plain` (+ `nosniff`) for GET responses on the
+> default `*.supabase.co` domain (anti-phishing; discussions #35627 / #31238), so an
+> EF-served page renders as source. Real HTML from an EF needs a Supabase **custom
+> domain** (paid Pro add-on). The page is a single static file (all logic client-side),
+> so it moves to any host that serves real HTML. This does NOT affect the discovery host
+> (`cerefox-mcp` stays on `supabase.co`; the §5 custom-domain gotcha applies only there).
+> The `cerefox-oauth-consent` EF (built) is kept as the **template source** for the static
+> page; the deploy host is chosen from the options in the "Consent host" decision below.
+
+**Consent host decision (2026-07-08): Cloudflare Worker (free).** The maintainer picked
+zero-cost hosting over a Supabase custom domain. Markup lives once in
+`_shared/consent-page/renderConsentPage()`; the Cloudflare Worker
+(`cloudflare/cerefox-consent/`) serves it as real `text/html` from a free
+`*.workers.dev` subdomain (no owned domain needed). The `cerefox-oauth-consent` EF renders
+the same shared markup and is retained only for users who have a Supabase custom domain.
+Options weighed: Cloudflare Worker (free, chosen) · GitHub Pages (free, static) · Supabase
+custom domain (~$10/mo Pro add-on, keeps it in Supabase).
+
+Supabase delegates the consent screen to us; it needs a stable public URL that serves
+real HTML. The page:
 - Signs the owner in via supabase-js (CDN import, publishable key — public by design).
 - Receives the redirect with an `authorization_id` query parameter; fetches the pending
   authorization's details and renders "Allow *Claude* to access your Cerefox knowledge
@@ -459,6 +477,25 @@ constantly; re-verify §14 before each phase that depends on a claim.)
     idempotently — §4.2-B).
   - **#561** (open): connectors occasionally removed without warning / can't re-add —
     platform flakiness to keep in mind before blaming our own stack.
+- **OSS-framing open items (revisit before shipping to users, 2026-07-08):**
+  - **Cloud-agent support is an OPTIONAL, feature-scoped add-on** — most users connect via
+    local/desktop clients and never touch OAuth or the consent page. Frame it that way in
+    the guides so the "free tier is enough" story is unaffected. The consent page costs $0
+    on Cloudflare/GitHub Pages; the only friction is one static-hosting step (candidate
+    reductions: a `cerefox` command that emits the configured page, or a Cerefox-hosted
+    shared consent page).
+  - **Is the anon key really a "secret"? (maintainer note, 2026-07-08)**
+    `CEREFOX_MCP_STATIC_BEARER` is set via `supabase secrets set`, but the anon JWT is
+    **public by design** — the secrets mechanism is used purely as an env-var delivery
+    channel, not for secrecy. The same value is baked into the Cloudflare Worker `[vars]`
+    (also public). Before the OSS release, decide the cleanest framing: (a) document
+    explicitly that this "secret" is a public value delivered via the secrets CLI, and/or
+    (b) note it's only needed where the platform-injected `SUPABASE_ANON_KEY` fails to
+    authenticate in-function (it DID fail on the maintainer project — hence required here —
+    but a project where the injected var works could skip it entirely).
+  - **ChatGPT-via-MCP is a weak beneficiary**: it needs developer mode, which disables
+    ChatGPT Memory (Decision Log 2026-03-14). The honest audience for the OAuth work is
+    **claude.ai web + Claude mobile**; say so rather than overselling ChatGPT.
 
 ## 12. Fallback: Cloudflare Worker OAuth proxy (build only if §11 bites)
 

--- a/docs/specs/oauth-mcp-server-design.md
+++ b/docs/specs/oauth-mcp-server-design.md
@@ -136,7 +136,12 @@ compliant clients never fall back to probing the domain root — where GoTrue's 
   your Site URL … to create the full authorization endpoint URL" (component B's URL).
   Cerefox doesn't use Supabase Auth emails today, so repointing Site URL is acceptable;
   verify no side effects during Phase 1.
-- Enable **DCR** (`allow_dynamic_registration` — defaults to disabled).
+- **DCR: leave DISABLED** (decision 2026-07-08). The dashboard flags open dynamic
+  registration as a security risk (any client can self-register against the auth
+  server); claude.ai's DCR against Supabase is failing in the wild anyway (#565); and a
+  single-user system needs exactly one registered client. Use a **pre-registered OAuth
+  App** instead (Authentication → OAuth Apps → New OAuth App, in Phase 4) — more secure
+  and the working path today. `allow_dynamic_registration` stays `false`.
 - Create the **owner user** in Supabase Auth (email + password). Cerefox has never had
   GoTrue users; the OAuth flow authenticates *as* this user.
 
@@ -276,7 +281,9 @@ JWT validation against the project JWKS
   `cerefox_config` row (`oauth_owner_user_id`) set during Phase 1 setup. Until the row is
   set, any `authenticated`-role token is accepted (only the owner exists) — but pinning is
   part of the setup checklist, and `cerefox doctor` should warn when OAuth is live without
-  it.
+  it. **Maintainer owner UUID (Phase 1, 2026-07-08):
+  `0b850e27-27b6-48eb-b019-e208fb7f92e7`** — this is a server-side value only; it is
+  never entered into claude.ai.
 - JWKS fetched with in-isolate caching (EF isolates are short-lived; a simple in-memory
   cache with TTL is enough — key rotation is picked up on isolate recycle or TTL expiry).
 - Use a vetted JWT library (`jose` via npm/esm specifier in Deno) — no hand-rolled JWT

--- a/docs/specs/security-model.md
+++ b/docs/specs/security-model.md
@@ -30,22 +30,20 @@ RLS is **enabled on every `cerefox_*` table with no policies** → deny-all for
 `anon`/`authenticated` via the Data API. Direct table access (`/rest/v1/cerefox_documents`)
 is closed for anon/publishable keys.
 
-## 3. RPC lockdown (schema 0.7.0) — the SECURITY DEFINER side door
+## 3. RPC execute-privilege lockdown (schema 0.7.0)
 
-**Finding (audit, 2026-07-09):** all `cerefox_*` RPCs are `SECURITY DEFINER` (they bypass
-RLS). PostgreSQL grants `EXECUTE` to `PUBLIC` by default, and PostgREST exposes public-schema
-functions at `/rest/v1/rpc/<name>`. So before this fix, **the anon key (and the publishable
-key — same `anon` role) could call every RPC directly via the Data API**, bypassing both the
-Edge Functions and RLS — full KB read/write. Verified live (`cerefox_list_projects` returned
-data with just the anon key).
+The `cerefox_*` RPCs are `SECURITY DEFINER` (they run with the definer's privileges, so they
+bypass RLS by design — that's how the Edge Functions and CLI do their work). The intended
+access model is that only `service_role` executes them. Schema 0.7.0 makes the grants match
+that intent.
 
-**Mitigation (deployed):** `rpcs.sql` now `REVOKE`s `EXECUTE` from `PUBLIC`/`anon`/
-`authenticated` and `GRANT`s only to `service_role`, applied over all `cerefox_*` functions
-and idempotent (re-applied each deploy). Every legitimate caller uses `service_role` (EFs via
-the service-role key; CLI/web via the secret key; local World B via a container-minted
+**Change (deployed):** `rpcs.sql` `REVOKE`s `EXECUTE` from `PUBLIC`/`anon`/`authenticated`
+and `GRANT`s only to `service_role`, applied over all `cerefox_*` functions and idempotent
+(re-applied each deploy). Every legitimate caller uses `service_role` (Edge Functions via the
+service-role key; CLI/web via the secret key; local World B via a container-minted
 service-role JWT), so nothing legitimate breaks. `docker/local/roles.sql` was tightened to
-match (no anon/authenticated function grants). Applied by `cerefox server deploy` (schema
-0.6.0 → 0.7.0). **Existing cloud deployments must redeploy to get this fix.**
+match. Applied by `cerefox server deploy` (schema 0.6.0 → 0.7.0). **Existing cloud
+deployments should redeploy to pick this up.**
 
 ## 4. OAuth MCP surface invariants (`cerefox-mcp`)
 

--- a/docs/specs/security-model.md
+++ b/docs/specs/security-model.md
@@ -1,0 +1,104 @@
+# Cerefox Security Model
+
+> **Status**: Living document. First written 2026-07-09 as the Iteration 28B security-audit
+> deliverable, covering the OAuth MCP surface (iter-28A) and the credential/RPC trust model.
+> **Scope note:** this pass audited the **OAuth surface + the credential trust model it
+> touches**. A full-codebase audit of *all* publicly-reachable components (the 8 primitive
+> Edge Functions, the GPT Actions surface, the web app, backup/restore) is a **tracked
+> pre-1.0 TODO** (see §6).
+
+Cerefox treats every stored byte as personal and sensitive. This document is the reference
+for how access is gated, what the credentials can do, and the invariants that keep the
+public surfaces safe.
+
+## 1. Access layers and credentials
+
+See [`docs/guides/access-paths.md`](../guides/access-paths.md) for the full breakdown. In
+short:
+
+| Credential | Role | Reaches | Sensitivity |
+|---|---|---|---|
+| Legacy **anon JWT** (`eyJ…`) | Edge Function gateway credential | The EF tool surface (full read/write; EFs use service-role internally). **Not** the Data API RPCs (§3). | **Shared secret** — trusted agents/local configs only; never publish |
+| **Publishable** key (`sb_publishable_…`) | Public client key | Supabase **Auth only**. EF gateway rejects it; RPCs revoked (§3). No KB access. | Public-safe (embed in the consent page) |
+| **Secret** key (`sb_secret_…`) / legacy `service_role` JWT | Full DB access, bypasses RLS | Data API + RPCs (as `service_role`). Used by the CLI, web app, Edge Functions (internally), local World B. | **Never** client-facing / committed |
+| **Database password** (`CEREFOX_DATABASE_URL`) | Direct Postgres | DDL / deploy / restore only | **Never** client-facing / committed |
+| **OAuth 2.1 access token** | Owner identity (cloud/mobile Claude) | `cerefox-mcp` only, validated in-function against JWKS + owner-`sub` pin (§4) | Per-session; issued by Supabase, `sub`-pinned |
+
+## 2. RLS posture
+
+RLS is **enabled on every `cerefox_*` table with no policies** → deny-all for
+`anon`/`authenticated` via the Data API. Direct table access (`/rest/v1/cerefox_documents`)
+is closed for anon/publishable keys.
+
+## 3. RPC lockdown (schema 0.7.0) — the SECURITY DEFINER side door
+
+**Finding (audit, 2026-07-09):** all `cerefox_*` RPCs are `SECURITY DEFINER` (they bypass
+RLS). PostgreSQL grants `EXECUTE` to `PUBLIC` by default, and PostgREST exposes public-schema
+functions at `/rest/v1/rpc/<name>`. So before this fix, **the anon key (and the publishable
+key — same `anon` role) could call every RPC directly via the Data API**, bypassing both the
+Edge Functions and RLS — full KB read/write. Verified live (`cerefox_list_projects` returned
+data with just the anon key).
+
+**Mitigation (deployed):** `rpcs.sql` now `REVOKE`s `EXECUTE` from `PUBLIC`/`anon`/
+`authenticated` and `GRANT`s only to `service_role`, applied over all `cerefox_*` functions
+and idempotent (re-applied each deploy). Every legitimate caller uses `service_role` (EFs via
+the service-role key; CLI/web via the secret key; local World B via a container-minted
+service-role JWT), so nothing legitimate breaks. `docker/local/roles.sql` was tightened to
+match (no anon/authenticated function grants). Applied by `cerefox server deploy` (schema
+0.6.0 → 0.7.0). **Existing cloud deployments must redeploy to get this fix.**
+
+## 4. OAuth MCP surface invariants (`cerefox-mcp`)
+
+`cerefox-mcp` is deployed `--no-verify-jwt` (it must serve unauthenticated discovery + issue
+401 challenges), so **in-function auth is the only gate**. Invariants, all verified in code
+(`_shared/mcp-auth/`, `supabase/functions/cerefox-mcp/`) and by unit tests:
+
+1. **Auth-first dispatch** — token validation runs before any method dispatch, tool lookup,
+   or DB touch. The only unauthenticated responses are the RFC 9728 metadata document, the
+   401 challenge, 405s, and CORS preflight.
+2. **Two credentials, both fail-closed** — a valid OAuth JWT *or* the legacy static Bearer.
+   Static path rejects when its secret is unset (no implicit fallback to the injected
+   `SUPABASE_ANON_KEY`). OAuth path rejects when JWKS is unreachable.
+3. **Algorithm allowlist** — ES256/RS256 only, checked *before* any crypto (defends against
+   HS256 alg-confusion with the legacy anon JWT). Never `none`.
+4. **Issuer/JWKS from `SUPABASE_URL`, not request headers** — deriving them from
+   `x-forwarded-*` would allow a JWKS-poisoning auth bypass; `SUPABASE_URL` is platform-set
+   and not client-controllable.
+5. **Owner-`sub` pin is the authorization boundary** — `CEREFOX_OAUTH_OWNER_ID`. The OAuth
+   path **fails closed when unset** (rejects all OAuth tokens) unless
+   `CEREFOX_OAUTH_ALLOW_ANY_USER=true` is set explicitly — because Supabase's default email
+   sign-ups would otherwise let any self-registered user in.
+6. **Failure detail is logged server-side only**, never returned to the client (the 401 body
+   is a bare `{"error":"unauthorized"}` + `WWW-Authenticate`).
+7. **405-for-GET preserved** for everything except `/version` and the metadata route
+   (SSE-polling quota-burn guard).
+8. **Deploy-flag map in code** (`NO_VERIFY_JWT_EFS`) — only `cerefox-mcp` and
+   `cerefox-oauth-consent` skip the gateway; the 8 primitive EFs keep gateway validation.
+
+## 5. Consent page
+
+The consent page (Cloudflare Worker, or the custom-domain `cerefox-oauth-consent` EF) is
+served **unauthenticated** (a browser loads it) and is therefore world-readable. It embeds
+**only** the publishable key (§1) — never the anon JWT — and holds no server-side secret.
+Approve/deny happens under the owner's Supabase Auth session; the page redirects with
+`location.assign` (client-side, so no 307), and handles an already-consumed
+`authorization_id` gracefully.
+
+## 6. Operational security
+
+- `~/.cerefox/.env` is written `chmod 0600` (`cerefox init`); `cerefox doctor` warns if not.
+- No secrets are committed (history clean as of the audit; recommend adding **gitleaks** to
+  CI as a durable gate).
+- Dependency audit: run `bun audit` (the repo is Bun-based; `npm audit` needs a lockfile).
+
+## 7. Open items (pre-1.0)
+
+- **Full-codebase security audit** of all publicly-reachable components — the 8 primitive
+  Edge Functions, the GPT Actions OpenAPI surface, the web app, and backup/restore file
+  handling. This document covers the OAuth surface + credential model only.
+- **Anon-key rotation** after any exposure (rotate the legacy JWT secret; update client
+  configs + `CEREFOX_MCP_STATIC_BEARER`).
+- **CI gates**: gitleaks (secret scanning) + `bun audit` (dependencies).
+- **JWKS stale-cache** (low): on a JWKS fetch failure the validator serves the last-cached
+  keys for up to the TTL (600s) — a rotated-out key stays accepted briefly. Acceptable;
+  revisit if key rotation becomes frequent.

--- a/packages/memory/src/cli/commands/deploy-server.ts
+++ b/packages/memory/src/cli/commands/deploy-server.ts
@@ -1,8 +1,11 @@
 /**
  * `cerefox server deploy` — the catch-all for standing up *and updating*
  * the Cerefox server side on your Supabase project: the Postgres schema +
- * RPCs (in-process) and the 9 Edge Functions (via `npx supabase functions
- * deploy`).
+ * RPCs (in-process) and the Edge Functions (via `npx supabase functions
+ * deploy`) — the 9 primitive/MCP functions plus the OAuth consent page
+ * (iter-28A). The EF list is auto-discovered from the bundled
+ * supabase/functions dir, so new functions are picked up automatically;
+ * NO_VERIFY_JWT_EFS below marks the two that gate auth in-function.
  *
  * Eliminates the repo-clone step: the server assets (SQL + EF sources) ship
  * bundled in `dist/server-assets/`, so a fresh `npm install -g
@@ -94,6 +97,18 @@ function parseProjectRef(supabaseUrl: string | undefined): string | null {
 }
 
 /** List the cerefox-* Edge Function directories under the resolved assets. */
+/**
+ * Edge Functions deployed WITHOUT the Supabase gateway's JWT verification
+ * (`--no-verify-jwt`). These are OAuth-protected-resource / public routes that
+ * must run their own in-function auth (design: docs/specs/oauth-mcp-server-design.md):
+ *   - cerefox-mcp          — serves discovery + 401 challenge; validates tokens itself.
+ *   - cerefox-oauth-consent — public consent page (loads in a browser, no Bearer).
+ * EVERY OTHER function keeps gateway verification. Forgetting the flag here never
+ * *opens* anything (it only breaks OAuth); passing it to the wrong function WOULD,
+ * so this map is the single source of truth, not operator memory.
+ */
+const NO_VERIFY_JWT_EFS = new Set(["cerefox-mcp", "cerefox-oauth-consent"]);
+
 function listEdgeFunctions(functionsDir: string): string[] {
   if (!existsSync(functionsDir)) return [];
   return readdirSync(functionsDir, { withFileTypes: true })
@@ -307,6 +322,11 @@ async function action(options: DeployServerOptions): Promise<void> {
       // bundler needed. Requires a reasonably current Supabase CLI (we resolve latest via npx).
       const args = ["--yes", "supabase", "functions", "deploy", ef, "--use-api"];
       if (projectRef) args.push("--project-ref", projectRef);
+      // OAuth protected-resource / public routes gate auth in-function (design §6).
+      if (NO_VERIFY_JWT_EFS.has(ef)) {
+        args.push("--no-verify-jwt");
+        info(`     (${ef}: --no-verify-jwt — in-function auth)`);
+      }
       const r = spawnSync("npx", args, {
         encoding: "utf8",
         stdio: "inherit",
@@ -322,6 +342,23 @@ async function action(options: DeployServerOptions): Promise<void> {
       process.exit(1);
     }
     println(c.green(`   ✓ Deployed ${efOk} Edge Function(s).`));
+
+    // cerefox-mcp runs with --no-verify-jwt, so in-function auth is the only gate.
+    // Its static-Bearer back-compat path needs an explicitly-set secret (the legacy
+    // anon JWT); without it, existing clients fail closed. Remind, don't assume.
+    if (efNames.includes("cerefox-mcp")) {
+      println(
+        c.yellow(
+          "\n   ⚠  cerefox-mcp now authenticates in-function (OAuth + legacy Bearer).\n" +
+            "      Ensure the back-compat secret is set so existing clients keep working:\n" +
+            "        supabase secrets set CEREFOX_MCP_STATIC_BEARER=<your anon JWT> --project-ref " +
+            (projectRef ?? "<ref>") +
+            "\n      Optional owner pin (single-user hardening):\n" +
+            "        supabase secrets set CEREFOX_OAUTH_OWNER_ID=<owner user uuid> --project-ref " +
+            (projectRef ?? "<ref>"),
+        ),
+      );
+    }
   }
 
   println(c.green("\n✓ Server deploy complete."));

--- a/packages/memory/src/cli/commands/deploy-server.ts
+++ b/packages/memory/src/cli/commands/deploy-server.ts
@@ -344,18 +344,19 @@ async function action(options: DeployServerOptions): Promise<void> {
     println(c.green(`   ✓ Deployed ${efOk} Edge Function(s).`));
 
     // cerefox-mcp runs with --no-verify-jwt, so in-function auth is the only gate.
-    // The owner pin is the authorization boundary; the static-Bearer secret is
-    // optional (the function falls back to the injected SUPABASE_ANON_KEY).
+    // The OAuth owner pin is the authorization boundary and the ONE secret this
+    // feature needs. (The static-Bearer back-compat path for remote static-token
+    // clients is a separate concern — see docs/specs/oauth-mcp-server-design.md §5 —
+    // not part of the OAuth/cloud setup, so it's not prompted here.)
     if (efNames.includes("cerefox-mcp")) {
       const ref = projectRef ?? "<ref>";
       println(
         c.yellow(
-          "\n   ⚠  cerefox-mcp now authenticates in-function (OAuth + legacy Bearer).\n" +
-            "      RECOMMENDED — pin the owner (else any self-registered user is accepted):\n" +
+          "\n   ⚠  cerefox-mcp authenticates in-function (OAuth for cloud/mobile Claude).\n" +
+            "      Pin the owner — this is the authorization boundary (else any user who\n" +
+            "      self-registers on your project could get an accepted token):\n" +
             `        supabase secrets set CEREFOX_OAUTH_OWNER_ID=<owner user uuid> --project-ref ${ref}\n` +
-            "      OPTIONAL — back-compat secret (only if old clients get 401; defaults to\n" +
-            "      the injected SUPABASE_ANON_KEY otherwise):\n" +
-            `        supabase secrets set CEREFOX_MCP_STATIC_BEARER=<your anon JWT> --project-ref ${ref}`,
+            "      Setup: docs/guides/setup-supabase.md Step 7 (incl. the client_secret_post gotcha).",
         ),
       );
     }

--- a/packages/memory/src/cli/commands/deploy-server.ts
+++ b/packages/memory/src/cli/commands/deploy-server.ts
@@ -344,18 +344,18 @@ async function action(options: DeployServerOptions): Promise<void> {
     println(c.green(`   ✓ Deployed ${efOk} Edge Function(s).`));
 
     // cerefox-mcp runs with --no-verify-jwt, so in-function auth is the only gate.
-    // Its static-Bearer back-compat path needs an explicitly-set secret (the legacy
-    // anon JWT); without it, existing clients fail closed. Remind, don't assume.
+    // The owner pin is the authorization boundary; the static-Bearer secret is
+    // optional (the function falls back to the injected SUPABASE_ANON_KEY).
     if (efNames.includes("cerefox-mcp")) {
+      const ref = projectRef ?? "<ref>";
       println(
         c.yellow(
           "\n   ⚠  cerefox-mcp now authenticates in-function (OAuth + legacy Bearer).\n" +
-            "      Ensure the back-compat secret is set so existing clients keep working:\n" +
-            "        supabase secrets set CEREFOX_MCP_STATIC_BEARER=<your anon JWT> --project-ref " +
-            (projectRef ?? "<ref>") +
-            "\n      Optional owner pin (single-user hardening):\n" +
-            "        supabase secrets set CEREFOX_OAUTH_OWNER_ID=<owner user uuid> --project-ref " +
-            (projectRef ?? "<ref>"),
+            "      RECOMMENDED — pin the owner (else any self-registered user is accepted):\n" +
+            `        supabase secrets set CEREFOX_OAUTH_OWNER_ID=<owner user uuid> --project-ref ${ref}\n` +
+            "      OPTIONAL — back-compat secret (only if old clients get 401; defaults to\n" +
+            "      the injected SUPABASE_ANON_KEY otherwise):\n" +
+            `        supabase secrets set CEREFOX_MCP_STATIC_BEARER=<your anon JWT> --project-ref ${ref}`,
         ),
       );
     }

--- a/packages/memory/src/cli/commands/init.ts
+++ b/packages/memory/src/cli/commands/init.ts
@@ -274,6 +274,16 @@ function buildEnvFile(answers: ConfigAnswers): string {
   if (answers.CEREFOX_AUTHOR_TYPE) {
     lines.push(`CEREFOX_AUTHOR_TYPE=${answers.CEREFOX_AUTHOR_TYPE}`);
   }
+  lines.push(
+    "",
+    "# ── Optional: connect cloud/mobile Claude over OAuth (setup-supabase.md Step 7) ──",
+    "# These are only needed for the optional claude.ai / Claude-mobile OAuth feature.",
+    "# The legacy anon JWT is a full-KB credential — used by remote static-token clients:",
+    "# CEREFOX_SUPABASE_ANON_KEY=eyJ...your-legacy-anon-jwt...",
+    "# The PUBLISHABLE key is public-safe (no KB access) — used by the consent-page",
+    "# Cloudflare Worker deploy (cloudflare/cerefox-consent/deploy.sh reads this):",
+    "# CEREFOX_SUPABASE_PUBLISHABLE_KEY=sb_publishable_...",
+  );
   return lines.join("\n") + "\n";
 }
 

--- a/scripts/bundle_server_assets.ts
+++ b/scripts/bundle_server_assets.ts
@@ -73,9 +73,10 @@ function main(): void {
   });
 
   // ── _shared/ (only the subtrees the EFs import) ──────────────────────────
-  // mcp-auth: cerefox-mcp imports ../../../_shared/mcp-auth for in-function
-  // OAuth/static token validation (iter-28A) — must ship or the deploy breaks.
-  for (const sub of ["mcp-tools", "embeddings", "ef-meta", "mcp-auth"]) {
+  // mcp-auth: cerefox-mcp imports it for in-function OAuth/static token
+  // validation. consent-page: cerefox-oauth-consent imports it for the consent
+  // markup. Both iter-28A — must ship or the respective EF deploy breaks.
+  for (const sub of ["mcp-tools", "embeddings", "ef-meta", "mcp-auth", "consent-page"]) {
     cpSync(join(SHARED_SRC, sub), join(OUT, "_shared", sub), {
       recursive: true,
       filter: notPythonCruft,

--- a/scripts/bundle_server_assets.ts
+++ b/scripts/bundle_server_assets.ts
@@ -73,7 +73,9 @@ function main(): void {
   });
 
   // ── _shared/ (only the subtrees the EFs import) ──────────────────────────
-  for (const sub of ["mcp-tools", "embeddings", "ef-meta"]) {
+  // mcp-auth: cerefox-mcp imports ../../../_shared/mcp-auth for in-function
+  // OAuth/static token validation (iter-28A) — must ship or the deploy breaks.
+  for (const sub of ["mcp-tools", "embeddings", "ef-meta", "mcp-auth"]) {
     cpSync(join(SHARED_SRC, sub), join(OUT, "_shared", sub), {
       recursive: true,
       filter: notPythonCruft,

--- a/src/cerefox/chunking/markdown.py
+++ b/src/cerefox/chunking/markdown.py
@@ -268,8 +268,9 @@ def _split_paragraphs(text: str, max_chars: int) -> list[str]:
     prefix (prepended by the caller for the first piece) provides sufficient
     context for each chunk when read in isolation.
 
-    If a single paragraph is longer than *max_chars*, it is hard-split by
-    character count.
+    If a single paragraph is longer than *max_chars*, it is kept WHOLE as one
+    piece — splitting inside a paragraph would corrupt document reconstruction,
+    which joins chunks with "\n\n" (see the inline note below).
     """
     paragraphs = [p for p in _PARAGRAPH_SEP.split(text) if p.strip()]
     if not paragraphs:
@@ -292,10 +293,15 @@ def _split_paragraphs(text: str, max_chars: int) -> list[str]:
                 current_parts = [para]
                 current_len = len(para)
             else:
-                # A single paragraph exceeds max_chars — hard-split it.
-                step = max_chars // 2
-                for start in range(0, len(para), step):
-                    result.append(para[start: start + max_chars])
+                # A single paragraph exceeds max_chars. Keep it WHOLE — never split
+                # INSIDE a paragraph. cerefox_reconstruct_doc reassembles a document
+                # by joining chunks with "\n\n", so any intra-paragraph split is lossy:
+                # it inserts a spurious blank line at each seam (e.g. "Source" ->
+                # "Sour\n\nce", and a markdown table gets a blank line mid-row). The
+                # earlier step = max_chars // 2 char-slice ALSO overlapped, duplicating
+                # content on reconstruction. Only paragraph ("\n\n") boundaries keep the
+                # join lossless; a whole oversized paragraph is a valid single chunk.
+                result.append(para)
                 current_parts = []
                 current_len = 0
 

--- a/src/cerefox/db/rpcs.sql
+++ b/src/cerefox/db/rpcs.sql
@@ -1767,7 +1767,7 @@ SET search_path = public, pg_catalog
 AS $$
     -- Keep in lockstep with the `@version:` marker in schema.sql (cut_release.ts
     -- enforces it). Bump whenever schema.sql OR rpcs.sql changes.
-    SELECT '0.6.0'::TEXT;
+    SELECT '0.7.0'::TEXT;
 $$;
 
 
@@ -1847,3 +1847,41 @@ AS $$
     WHERE a.document_id = ANY(p_doc_ids)
     ORDER BY a.document_id, a.created_at DESC;
 $$;
+
+-- ── Function privilege lockdown (schema 0.7.0) ────────────────────────────────
+-- SECURITY (critical): every cerefox_* RPC is SECURITY DEFINER, so it bypasses the
+-- Row Level Security enabled on the tables. PostgreSQL grants EXECUTE to PUBLIC by
+-- default, and Supabase's PostgREST exposes public-schema functions at
+-- /rest/v1/rpc/<name>. WITHOUT this block, the anon key (and the new sb_publishable_
+-- key, which maps to the same anon role) could call every RPC directly via the Data
+-- API — reading and writing the entire KB, bypassing BOTH the Edge Functions and
+-- RLS. Every legitimate caller uses the service_role key instead (Edge Functions via
+-- SUPABASE_SERVICE_ROLE_KEY; the CLI/web via the secret key; local World B via a
+-- container-minted service_role JWT), so we REVOKE EXECUTE from PUBLIC/anon/
+-- authenticated and GRANT only to service_role.
+--
+-- Applied over ALL cerefox_* functions (so new functions are covered on the next
+-- deploy) and idempotent — re-applied each time rpcs.sql is deployed. Guarded on
+-- role existence so it is safe on non-Supabase Postgres (e.g. World B bootstrap).
+DO $$
+DECLARE
+  fn regprocedure;
+  r  text;
+BEGIN
+  FOR fn IN
+    SELECT p.oid::regprocedure
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname LIKE 'cerefox\_%'
+  LOOP
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION %s FROM PUBLIC', fn);
+    FOREACH r IN ARRAY ARRAY['anon', 'authenticated'] LOOP
+      IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = r) THEN
+        EXECUTE format('REVOKE EXECUTE ON FUNCTION %s FROM %I', fn, r);
+      END IF;
+    END LOOP;
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'service_role') THEN
+      EXECUTE format('GRANT EXECUTE ON FUNCTION %s TO service_role', fn);
+    END IF;
+  END LOOP;
+END $$;

--- a/src/cerefox/db/schema.sql
+++ b/src/cerefox/db/schema.sql
@@ -5,7 +5,7 @@
 -- Requires extensions: vector (pgvector), uuid-ossp
 -- These are enabled at the top of db_deploy.py before this file is applied.
 --
--- @version: 0.6.0
+-- @version: 0.7.0
 -- The `@version` marker above is read by the schema-version-mismatch banner
 -- (see /api/v1/schema-version). Bump it whenever schema.sql OR rpcs.sql
 -- changes in a way that requires `cerefox server deploy` to be re-run —

--- a/supabase/functions/cerefox-mcp/index.ts
+++ b/supabase/functions/cerefox-mcp/index.ts
@@ -240,11 +240,11 @@ async function handleVersion(req: Request): Promise<Response> {
 
 // ── Main handler ─────────────────────────────────────────────────────────────
 
-// Isolate-lifetime authenticator (holds the JWKS cache). The issuer/JWKS are
-// derived from the first request's origin, which is stable per deployment.
+// Isolate-lifetime authenticator (holds the JWKS cache). Issuer/JWKS come from the
+// injected SUPABASE_URL (not request headers — see oauth.ts projectOrigin).
 let authenticator: McpAuthenticator | null = null;
-function getAuthenticator(req: Request): McpAuthenticator {
-  if (!authenticator) authenticator = buildAuthenticator(req);
+function getAuthenticator(): McpAuthenticator {
+  if (!authenticator) authenticator = buildAuthenticator();
   return authenticator;
 }
 
@@ -256,13 +256,13 @@ Deno.serve(async (req: Request): Promise<Response> => {
   // Public discovery route (RFC 9728): the ONLY unauthenticated non-OPTIONS
   // response. Served before auth so OAuth clients can bootstrap.
   if (req.method === "GET" && isProtectedResourceMetadata(req)) {
-    return protectedResourceMetadata(req);
+    return protectedResourceMetadata();
   }
 
   // ── Auth-first dispatch (design §6) ────────────────────────────────────────
   // The function is deployed with --no-verify-jwt, so this in-function check is
   // the ONLY gate. Accept either the legacy static Bearer or a valid OAuth JWT.
-  const authResult = await getAuthenticator(req).authenticate(
+  const authResult = await getAuthenticator().authenticate(
     req.headers.get("Authorization"),
   );
   if (!authResult.ok) {
@@ -278,7 +278,7 @@ Deno.serve(async (req: Request): Promise<Response> => {
           (authResult.detail ? ` (${authResult.detail})` : ""),
       );
     }
-    return unauthorizedChallenge(req, authResult);
+    return unauthorizedChallenge(authResult);
   }
 
   // GET — the only supported GET is the /version surface (iter-26). Per MCP

--- a/supabase/functions/cerefox-mcp/index.ts
+++ b/supabase/functions/cerefox-mcp/index.ts
@@ -266,6 +266,15 @@ Deno.serve(async (req: Request): Promise<Response> => {
     req.headers.get("Authorization"),
   );
   if (!authResult.ok) {
+    // Log the machine reason (never the token) so `supabase functions logs` is
+    // actionable. `no_token` is the normal OAuth-discovery challenge trigger —
+    // skip it to keep the logs meaningful (real auth failures only).
+    if (authResult.reason !== "no_token") {
+      console.warn(
+        `[cerefox-mcp] auth rejected: ${authResult.reason}` +
+          (authResult.detail ? ` (${authResult.detail})` : ""),
+      );
+    }
     return unauthorizedChallenge(req, authResult);
   }
 

--- a/supabase/functions/cerefox-mcp/index.ts
+++ b/supabase/functions/cerefox-mcp/index.ts
@@ -266,9 +266,12 @@ Deno.serve(async (req: Request): Promise<Response> => {
     req.headers.get("Authorization"),
   );
   if (!authResult.ok) {
-    // Log the machine reason (never the token) so `supabase functions logs` is
-    // actionable. `no_token` is the normal OAuth-discovery challenge trigger —
-    // skip it to keep the logs meaningful (real auth failures only).
+    // Log the machine reason (never the token) so the dashboard logs are
+    // actionable on a real auth failure. `no_token` is the normal OAuth-discovery
+    // probe (every cloud client sends one first) — don't log it as noise. The
+    // enriched detail (aud/sub/alg values from _shared/mcp-auth) names which claim
+    // a rejected token tripped. To debug a "Claude never sends the token" case
+    // (claude-ai #482), temporarily also log `Array.from(req.headers.keys())`.
     if (authResult.reason !== "no_token") {
       console.warn(
         `[cerefox-mcp] auth rejected: ${authResult.reason}` +

--- a/supabase/functions/cerefox-mcp/index.ts
+++ b/supabase/functions/cerefox-mcp/index.ts
@@ -28,6 +28,13 @@ import {
   notificationResponse,
 } from "./shared.ts";
 import {
+  buildAuthenticator,
+  isProtectedResourceMetadata,
+  protectedResourceMetadata,
+  unauthorizedChallenge,
+} from "./oauth.ts";
+import type { McpAuthenticator } from "../../../_shared/mcp-auth/index.ts";
+import {
   ALL_TOOLS,
   McpInvalidParams,
   TOOLS_BY_NAME,
@@ -233,9 +240,33 @@ async function handleVersion(req: Request): Promise<Response> {
 
 // ── Main handler ─────────────────────────────────────────────────────────────
 
+// Isolate-lifetime authenticator (holds the JWKS cache). The issuer/JWKS are
+// derived from the first request's origin, which is stable per deployment.
+let authenticator: McpAuthenticator | null = null;
+function getAuthenticator(req: Request): McpAuthenticator {
+  if (!authenticator) authenticator = buildAuthenticator(req);
+  return authenticator;
+}
+
 Deno.serve(async (req: Request): Promise<Response> => {
   if (req.method === "OPTIONS") {
     return new Response(null, { status: 200, headers: CORS_HEADERS });
+  }
+
+  // Public discovery route (RFC 9728): the ONLY unauthenticated non-OPTIONS
+  // response. Served before auth so OAuth clients can bootstrap.
+  if (req.method === "GET" && isProtectedResourceMetadata(req)) {
+    return protectedResourceMetadata(req);
+  }
+
+  // ── Auth-first dispatch (design §6) ────────────────────────────────────────
+  // The function is deployed with --no-verify-jwt, so this in-function check is
+  // the ONLY gate. Accept either the legacy static Bearer or a valid OAuth JWT.
+  const authResult = await getAuthenticator(req).authenticate(
+    req.headers.get("Authorization"),
+  );
+  if (!authResult.ok) {
+    return unauthorizedChallenge(req, authResult);
   }
 
   // GET — the only supported GET is the /version surface (iter-26). Per MCP

--- a/supabase/functions/cerefox-mcp/oauth.ts
+++ b/supabase/functions/cerefox-mcp/oauth.ts
@@ -19,9 +19,20 @@ export const FUNCTION_PATH = "/functions/v1/cerefox-mcp";
 /** The protected-resource metadata route, matched as a suffix of the request path. */
 const PRS_SUFFIX = "/.well-known/oauth-protected-resource";
 
-/** Origin of the deployed project, e.g. `https://<ref>.supabase.co`, from the request. */
+/**
+ * Origin of the deployed project, e.g. `https://<ref>.supabase.co`.
+ *
+ * Behind Supabase's internal proxy `req.url` is `http://…`, but the public origin
+ * is always https (and Anthropic requires the `resource`/`authorization_servers`
+ * URLs to be https and to match the connector URL exactly). So we honor
+ * `x-forwarded-proto`/`x-forwarded-host` and default to https for any non-local host.
+ */
 function projectOrigin(req: Request): string {
-  return new URL(req.url).origin;
+  const url = new URL(req.url);
+  const host = req.headers.get("x-forwarded-host") ?? url.host;
+  const isLocal = host.startsWith("localhost") || host.startsWith("127.");
+  const proto = req.headers.get("x-forwarded-proto") ?? (isLocal ? "http" : "https");
+  return `${proto}://${host}`;
 }
 
 /** Absolute URL of this MCP server (the `resource` identifier — must match exactly). */

--- a/supabase/functions/cerefox-mcp/oauth.ts
+++ b/supabase/functions/cerefox-mcp/oauth.ts
@@ -1,0 +1,103 @@
+/**
+ * OAuth 2.1 protected-resource glue for cerefox-mcp (design §3–6).
+ *
+ * Pure auth logic lives in `_shared/mcp-auth/`; this file is the HTTP/Deno layer:
+ * it builds the authenticator from Function secrets, serves the RFC 9728 metadata
+ * document, and formats the 401 challenge. It is imported only by the EF.
+ */
+
+import { CORS_HEADERS } from "./shared.ts";
+import {
+  type AuthResult,
+  createMcpAuthenticator,
+  type McpAuthenticator,
+} from "../../../_shared/mcp-auth/index.ts";
+
+/** Stable public path of this function (used to build absolute metadata URLs). */
+export const FUNCTION_PATH = "/functions/v1/cerefox-mcp";
+
+/** The protected-resource metadata route, matched as a suffix of the request path. */
+const PRS_SUFFIX = "/.well-known/oauth-protected-resource";
+
+/** Origin of the deployed project, e.g. `https://<ref>.supabase.co`, from the request. */
+function projectOrigin(req: Request): string {
+  return new URL(req.url).origin;
+}
+
+/** Absolute URL of this MCP server (the `resource` identifier — must match exactly). */
+export function resourceUrl(req: Request): string {
+  return `${projectOrigin(req)}${FUNCTION_PATH}`;
+}
+
+/** The Supabase auth server issuer for this project. */
+export function issuerUrl(req: Request): string {
+  return `${projectOrigin(req)}/auth/v1`;
+}
+
+/** True when the request targets the (public) protected-resource metadata route. */
+export function isProtectedResourceMetadata(req: Request): boolean {
+  const path = new URL(req.url).pathname;
+  // Accept both the plain suffix and the RFC 9728 path-insertion form
+  // (…/oauth-protected-resource/functions/v1/cerefox-mcp).
+  return path.includes(PRS_SUFFIX);
+}
+
+/** RFC 9728 Protected Resource Metadata document. */
+export function protectedResourceMetadata(req: Request): Response {
+  const body = {
+    resource: resourceUrl(req),
+    // Anthropic reads authorization_servers[0]; Supabase serves valid AS metadata here.
+    authorization_servers: [issuerUrl(req)],
+    bearer_methods_supported: ["header"],
+    scopes_supported: ["openid", "email"],
+    resource_name: "Cerefox",
+  };
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { ...CORS_HEADERS, "Content-Type": "application/json" },
+  });
+}
+
+/**
+ * 401 with an explicit `resource_metadata` pointer (RFC 9728 §5.1), so clients
+ * discover our metadata route rather than probing the domain root.
+ */
+export function unauthorizedChallenge(req: Request, result: AuthResult): Response {
+  const metadataUrl = `${resourceUrl(req)}${PRS_SUFFIX}`;
+  const invalid = result.ok === false && result.reason !== "no_token";
+  const params = [`resource_metadata="${metadataUrl}"`];
+  if (invalid) params.push(`error="invalid_token"`);
+  return new Response(JSON.stringify({ error: "unauthorized" }), {
+    status: 401,
+    headers: {
+      ...CORS_HEADERS,
+      "Content-Type": "application/json",
+      "WWW-Authenticate": `Bearer ${params.join(", ")}`,
+    },
+  });
+}
+
+/**
+ * Build the authenticator from Function secrets. Deriving issuer/JWKS from the
+ * request keeps the function project-portable (no hardcoded ref).
+ *
+ * Secrets (set via `supabase secrets set`, reliable unlike auto-injected vars):
+ *   CEREFOX_MCP_STATIC_BEARER — legacy anon JWT for back-compat (falls back to the
+ *                               auto-injected SUPABASE_ANON_KEY when present).
+ *   CEREFOX_OAUTH_OWNER_ID    — pinned owner user id (optional; unset = accept any
+ *                               validly-signed authenticated token).
+ */
+export function buildAuthenticator(req: Request): McpAuthenticator {
+  const issuer = issuerUrl(req);
+  const staticBearer =
+    Deno.env.get("CEREFOX_MCP_STATIC_BEARER") ?? Deno.env.get("SUPABASE_ANON_KEY") ?? null;
+  const ownerUserId = Deno.env.get("CEREFOX_OAUTH_OWNER_ID") ?? null;
+  return createMcpAuthenticator({
+    issuer,
+    jwksUri: `${issuer}/.well-known/jwks.json`,
+    expectedAudience: "authenticated",
+    ownerUserId,
+    staticBearer,
+    allowedAlgs: ["ES256", "RS256"],
+  });
+}

--- a/supabase/functions/cerefox-mcp/oauth.ts
+++ b/supabase/functions/cerefox-mcp/oauth.ts
@@ -20,29 +20,30 @@ export const FUNCTION_PATH = "/functions/v1/cerefox-mcp";
 const PRS_SUFFIX = "/.well-known/oauth-protected-resource";
 
 /**
- * Origin of the deployed project, e.g. `https://<ref>.supabase.co`.
+ * Origin of the deployed project, e.g. `https://<ref>.supabase.co`, from the
+ * platform-injected `SUPABASE_URL` — NOT from request headers.
  *
- * Behind Supabase's internal proxy `req.url` is `http://…`, but the public origin
- * is always https (and Anthropic requires the `resource`/`authorization_servers`
- * URLs to be https and to match the connector URL exactly). So we honor
- * `x-forwarded-proto`/`x-forwarded-host` and default to https for any non-local host.
+ * SECURITY (design §6): the token issuer and JWKS URL are derived from this origin.
+ * Deriving it from client-influenced headers (`x-forwarded-host`/`-proto`) would let
+ * a caller point token validation at an attacker-controlled JWKS and forge a token
+ * that passes (JWKS-poisoning auth bypass). `SUPABASE_URL` is set by the platform for
+ * every Edge Function and is not client-controllable (every other Cerefox EF already
+ * depends on it). It is also the exact public https origin Anthropic requires for the
+ * RFC 9728 `resource` identifier — so this both hardens auth and removes the earlier
+ * `http://` (internal-proxy) scheme workaround.
  */
-function projectOrigin(req: Request): string {
-  const url = new URL(req.url);
-  const host = req.headers.get("x-forwarded-host") ?? url.host;
-  const isLocal = host.startsWith("localhost") || host.startsWith("127.");
-  const proto = req.headers.get("x-forwarded-proto") ?? (isLocal ? "http" : "https");
-  return `${proto}://${host}`;
+function projectOrigin(): string {
+  return (Deno.env.get("SUPABASE_URL") ?? "").replace(/\/+$/, "");
 }
 
 /** Absolute URL of this MCP server (the `resource` identifier — must match exactly). */
-export function resourceUrl(req: Request): string {
-  return `${projectOrigin(req)}${FUNCTION_PATH}`;
+export function resourceUrl(): string {
+  return `${projectOrigin()}${FUNCTION_PATH}`;
 }
 
 /** The Supabase auth server issuer for this project. */
-export function issuerUrl(req: Request): string {
-  return `${projectOrigin(req)}/auth/v1`;
+export function issuerUrl(): string {
+  return `${projectOrigin()}/auth/v1`;
 }
 
 /** True when the request targets the (public) protected-resource metadata route. */
@@ -54,11 +55,11 @@ export function isProtectedResourceMetadata(req: Request): boolean {
 }
 
 /** RFC 9728 Protected Resource Metadata document. */
-export function protectedResourceMetadata(req: Request): Response {
+export function protectedResourceMetadata(): Response {
   const body = {
-    resource: resourceUrl(req),
+    resource: resourceUrl(),
     // Anthropic reads authorization_servers[0]; Supabase serves valid AS metadata here.
-    authorization_servers: [issuerUrl(req)],
+    authorization_servers: [issuerUrl()],
     bearer_methods_supported: ["header"],
     scopes_supported: ["openid", "email"],
     resource_name: "Cerefox",
@@ -73,8 +74,8 @@ export function protectedResourceMetadata(req: Request): Response {
  * 401 with an explicit `resource_metadata` pointer (RFC 9728 §5.1), so clients
  * discover our metadata route rather than probing the domain root.
  */
-export function unauthorizedChallenge(req: Request, result: AuthResult): Response {
-  const metadataUrl = `${resourceUrl(req)}${PRS_SUFFIX}`;
+export function unauthorizedChallenge(result: AuthResult): Response {
+  const metadataUrl = `${resourceUrl()}${PRS_SUFFIX}`;
   const invalid = result.ok === false && result.reason !== "no_token";
   const params = [`resource_metadata="${metadataUrl}"`];
   if (invalid) params.push(`error="invalid_token"`);
@@ -89,25 +90,32 @@ export function unauthorizedChallenge(req: Request, result: AuthResult): Respons
 }
 
 /**
- * Build the authenticator from Function secrets. Deriving issuer/JWKS from the
- * request keeps the function project-portable (no hardcoded ref).
+ * Build the authenticator from Function secrets + the injected SUPABASE_URL.
  *
- * Secrets (set via `supabase secrets set`, reliable unlike auto-injected vars):
- *   CEREFOX_MCP_STATIC_BEARER — legacy anon JWT for back-compat (falls back to the
- *                               auto-injected SUPABASE_ANON_KEY when present).
- *   CEREFOX_OAUTH_OWNER_ID    — pinned owner user id (optional; unset = accept any
- *                               validly-signed authenticated token).
+ * Secrets (set via `supabase secrets set`):
+ *   CEREFOX_OAUTH_OWNER_ID       — pinned owner user id. The OAuth path fails CLOSED
+ *                                  when this is unset (design §6 / Finding 3), unless
+ *                                  CEREFOX_OAUTH_ALLOW_ANY_USER="true" is set.
+ *   CEREFOX_OAUTH_ALLOW_ANY_USER — explicit opt-out of the owner pin (multi-user /
+ *                                  sign-ups-disabled setups). Default off.
+ *   CEREFOX_MCP_STATIC_BEARER    — optional legacy anon JWT for remote static-token
+ *                                  clients' back-compat. Unset = static path disabled
+ *                                  (fail-closed). We do NOT fall back to the injected
+ *                                  SUPABASE_ANON_KEY: it is unreliable (Decision Log
+ *                                  2026-03-14) and treating it as an accepted bearer
+ *                                  would broaden the credential surface implicitly.
  */
-export function buildAuthenticator(req: Request): McpAuthenticator {
-  const issuer = issuerUrl(req);
-  const staticBearer =
-    Deno.env.get("CEREFOX_MCP_STATIC_BEARER") ?? Deno.env.get("SUPABASE_ANON_KEY") ?? null;
+export function buildAuthenticator(): McpAuthenticator {
+  const issuer = issuerUrl();
   const ownerUserId = Deno.env.get("CEREFOX_OAUTH_OWNER_ID") ?? null;
+  const allowAnyUser = Deno.env.get("CEREFOX_OAUTH_ALLOW_ANY_USER") === "true";
+  const staticBearer = Deno.env.get("CEREFOX_MCP_STATIC_BEARER") ?? null;
   return createMcpAuthenticator({
     issuer,
     jwksUri: `${issuer}/.well-known/jwks.json`,
     expectedAudience: "authenticated",
     ownerUserId,
+    allowAnyUser,
     staticBearer,
     allowedAlgs: ["ES256", "RS256"],
   });

--- a/supabase/functions/cerefox-oauth-consent/index.ts
+++ b/supabase/functions/cerefox-oauth-consent/index.ts
@@ -1,23 +1,18 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { renderConsentPage } from "../../../_shared/consent-page/index.ts";
 
 /**
- * cerefox-oauth-consent — Supabase Edge Function
+ * cerefox-oauth-consent — Supabase Edge Function (OAuth consent page).
  *
- * The developer-hosted OAuth consent page (design §4.2-B). Supabase's OAuth 2.1
- * server authenticates the user, then redirects the browser here (Site URL +
- * Authorization Path) with an `authorization_id`. This page:
- *   1. signs the owner in (Supabase Auth email+password) if not already,
- *   2. shows what the client (Claude) is asking for, and
- *   3. approves/denies via supabase-js `auth.oauth.*`, then follows the returned
- *      `redirect_url` back to the client.
+ * ⚠️ On the default `*.supabase.co` domain Supabase rewrites `text/html` →
+ * `text/plain`, so this EF only RENDERS correctly behind a paid Supabase custom
+ * domain. For free setups the canonical host is the Cloudflare Worker in
+ * `cloudflare/cerefox-consent/`, which serves the SAME markup via the shared
+ * `renderConsentPage()`. This EF is retained for custom-domain deployments.
+ * See docs/specs/oauth-mcp-server-design.md §4.2-B.
  *
- * It holds NO secrets: everything runs client-side under the owner's session with
- * the public anon/publishable key. Redirects are client-side (`location.assign`),
- * so there is no server 307 for claude.ai to reject (anthropics/claude-ai-mcp #250),
- * and a consumed/unknown authorization_id renders a friendly "start over" message
- * rather than an error (#562).
- *
- * Deployed with --no-verify-jwt so the browser can load it without a Bearer.
+ * Markup + client-side logic live in `_shared/consent-page/`; this file is just
+ * the Deno HTTP wrapper. Deployed with --no-verify-jwt (loads in a browser).
  */
 
 const CORS_HEADERS = {
@@ -25,138 +20,6 @@ const CORS_HEADERS = {
   "Access-Control-Allow-Methods": "GET, OPTIONS",
   "Access-Control-Allow-Headers": "Content-Type",
 };
-
-function page(supabaseUrl: string, anonKey: string): string {
-  // NOTE: values injected server-side are the project URL + public anon key
-  // (both non-secret). The supabase-js `auth.oauth` surface is beta — if method
-  // names drift, adjust here (design §11 watch item).
-  return `<!doctype html>
-<html lang="en">
-<head>
-<meta charset="utf-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Authorize access to Cerefox</title>
-<style>
-  :root { color-scheme: light dark; }
-  body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
-         max-width: 28rem; margin: 6vh auto; padding: 0 1.25rem; line-height: 1.5; }
-  h1 { font-size: 1.35rem; } .muted { opacity: .7; font-size: .9rem; }
-  .card { border: 1px solid rgba(128,128,128,.3); border-radius: .75rem; padding: 1.25rem; }
-  label { display: block; margin: .75rem 0 .25rem; font-size: .9rem; }
-  input { width: 100%; padding: .6rem; border-radius: .5rem;
-          border: 1px solid rgba(128,128,128,.4); box-sizing: border-box; font-size: 1rem; }
-  .row { display: flex; gap: .75rem; margin-top: 1.25rem; }
-  button { flex: 1; padding: .7rem; border-radius: .5rem; border: 0; font-size: 1rem; cursor: pointer; }
-  .approve { background: #2f7d32; color: #fff; } .deny { background: transparent;
-             border: 1px solid rgba(128,128,128,.5); }
-  .hidden { display: none; } .err { color: #c0392b; margin-top: .75rem; font-size: .9rem; }
-  code { background: rgba(128,128,128,.15); padding: .1rem .3rem; border-radius: .3rem; }
-</style>
-</head>
-<body>
-<h1>Authorize access to Cerefox</h1>
-<div class="card">
-  <div id="fatal" class="hidden">
-    <p>This authorization link has expired or was already used.</p>
-    <p class="muted">Please start the connection again from your AI client.</p>
-  </div>
-
-  <div id="signin" class="hidden">
-    <p class="muted">Sign in to your Cerefox account to continue.</p>
-    <label for="email">Email</label>
-    <input id="email" type="email" autocomplete="username" />
-    <label for="password">Password</label>
-    <input id="password" type="password" autocomplete="current-password" />
-    <div class="row"><button class="approve" id="signin-btn">Sign in</button></div>
-    <div id="signin-err" class="err hidden"></div>
-  </div>
-
-  <div id="consent" class="hidden">
-    <p>Allow <strong id="client-name">this application</strong> to access your
-       Cerefox knowledge base (read and write)?</p>
-    <p class="muted" id="scopes"></p>
-    <div class="row">
-      <button class="deny" id="deny-btn">Deny</button>
-      <button class="approve" id="approve-btn">Allow</button>
-    </div>
-    <div id="consent-err" class="err hidden"></div>
-  </div>
-
-  <div id="loading"><p class="muted">Loading…</p></div>
-</div>
-
-<script type="module">
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-
-const supabase = createClient(${JSON.stringify(supabaseUrl)}, ${JSON.stringify(anonKey)});
-const params = new URLSearchParams(location.search);
-const authorizationId = params.get("authorization_id");
-
-const $ = (id) => document.getElementById(id);
-const show = (id) => $(id).classList.remove("hidden");
-const hide = (id) => $(id).classList.add("hidden");
-function only(id) { for (const s of ["fatal","signin","consent","loading"]) hide(s); show(id); }
-
-function fatal() { only("fatal"); }
-
-async function loadDetails() {
-  try {
-    const { data, error } = await supabase.auth.oauth.getAuthorizationDetails(authorizationId);
-    if (error || !data) return fatal();
-    $("client-name").textContent = data.client?.name || data.client_name || "This application";
-    const scopes = data.scopes || data.scope;
-    if (scopes && scopes.length) {
-      $("scopes").textContent = "Requested scopes: " +
-        (Array.isArray(scopes) ? scopes.join(", ") : scopes);
-    }
-    only("consent");
-  } catch (_e) { fatal(); }
-}
-
-async function boot() {
-  if (!authorizationId) return fatal();
-  const { data: { session } } = await supabase.auth.getSession();
-  if (!session) { only("signin"); return; }
-  only("loading");
-  await loadDetails();
-}
-
-$("signin-btn").addEventListener("click", async () => {
-  hide("signin-err");
-  const email = $("email").value.trim();
-  const password = $("password").value;
-  const { error } = await supabase.auth.signInWithPassword({ email, password });
-  if (error) { $("signin-err").textContent = error.message; show("signin-err"); return; }
-  only("loading");
-  await loadDetails();
-});
-
-$("approve-btn").addEventListener("click", async () => {
-  hide("consent-err");
-  try {
-    const { data, error } = await supabase.auth.oauth.approveAuthorization(authorizationId);
-    if (error || !data?.redirect_url) throw error || new Error("no redirect_url");
-    location.assign(data.redirect_url);
-  } catch (e) {
-    $("consent-err").textContent = "Could not complete authorization. " +
-      "Please start again from your AI client.";
-    show("consent-err");
-  }
-});
-
-$("deny-btn").addEventListener("click", async () => {
-  try {
-    const { data } = await supabase.auth.oauth.denyAuthorization(authorizationId);
-    if (data?.redirect_url) location.assign(data.redirect_url);
-    else fatal();
-  } catch (_e) { fatal(); }
-});
-
-boot();
-</script>
-</body>
-</html>`;
-}
 
 Deno.serve((req: Request): Response => {
   if (req.method === "OPTIONS") {
@@ -167,7 +30,7 @@ Deno.serve((req: Request): Response => {
   }
   const supabaseUrl = Deno.env.get("SUPABASE_URL") ?? "";
   const anonKey = Deno.env.get("SUPABASE_ANON_KEY") ?? "";
-  return new Response(page(supabaseUrl, anonKey), {
+  return new Response(renderConsentPage(supabaseUrl, anonKey), {
     status: 200,
     headers: { ...CORS_HEADERS, "Content-Type": "text/html; charset=utf-8" },
   });

--- a/supabase/functions/cerefox-oauth-consent/index.ts
+++ b/supabase/functions/cerefox-oauth-consent/index.ts
@@ -29,8 +29,13 @@ Deno.serve((req: Request): Response => {
     return new Response("Method Not Allowed", { status: 405, headers: CORS_HEADERS });
   }
   const supabaseUrl = Deno.env.get("SUPABASE_URL") ?? "";
-  const anonKey = Deno.env.get("SUPABASE_ANON_KEY") ?? "";
-  return new Response(renderConsentPage(supabaseUrl, anonKey), {
+  // SECURITY: embed the PUBLISHABLE key only — never the injected SUPABASE_ANON_KEY
+  // (the anon JWT is a full-KB credential; this page is served unauthenticated). If
+  // the secret is unset the page renders keyless (non-functional) rather than leaking
+  // the anon key. Set it with:
+  //   supabase secrets set CEREFOX_SUPABASE_PUBLISHABLE_KEY=sb_publishable_... --project-ref <ref>
+  const publishableKey = Deno.env.get("CEREFOX_SUPABASE_PUBLISHABLE_KEY") ?? "";
+  return new Response(renderConsentPage(supabaseUrl, publishableKey), {
     status: 200,
     headers: { ...CORS_HEADERS, "Content-Type": "text/html; charset=utf-8" },
   });

--- a/supabase/functions/cerefox-oauth-consent/index.ts
+++ b/supabase/functions/cerefox-oauth-consent/index.ts
@@ -1,0 +1,174 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+
+/**
+ * cerefox-oauth-consent — Supabase Edge Function
+ *
+ * The developer-hosted OAuth consent page (design §4.2-B). Supabase's OAuth 2.1
+ * server authenticates the user, then redirects the browser here (Site URL +
+ * Authorization Path) with an `authorization_id`. This page:
+ *   1. signs the owner in (Supabase Auth email+password) if not already,
+ *   2. shows what the client (Claude) is asking for, and
+ *   3. approves/denies via supabase-js `auth.oauth.*`, then follows the returned
+ *      `redirect_url` back to the client.
+ *
+ * It holds NO secrets: everything runs client-side under the owner's session with
+ * the public anon/publishable key. Redirects are client-side (`location.assign`),
+ * so there is no server 307 for claude.ai to reject (anthropics/claude-ai-mcp #250),
+ * and a consumed/unknown authorization_id renders a friendly "start over" message
+ * rather than an error (#562).
+ *
+ * Deployed with --no-verify-jwt so the browser can load it without a Bearer.
+ */
+
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type",
+};
+
+function page(supabaseUrl: string, anonKey: string): string {
+  // NOTE: values injected server-side are the project URL + public anon key
+  // (both non-secret). The supabase-js `auth.oauth` surface is beta — if method
+  // names drift, adjust here (design §11 watch item).
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Authorize access to Cerefox</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+         max-width: 28rem; margin: 6vh auto; padding: 0 1.25rem; line-height: 1.5; }
+  h1 { font-size: 1.35rem; } .muted { opacity: .7; font-size: .9rem; }
+  .card { border: 1px solid rgba(128,128,128,.3); border-radius: .75rem; padding: 1.25rem; }
+  label { display: block; margin: .75rem 0 .25rem; font-size: .9rem; }
+  input { width: 100%; padding: .6rem; border-radius: .5rem;
+          border: 1px solid rgba(128,128,128,.4); box-sizing: border-box; font-size: 1rem; }
+  .row { display: flex; gap: .75rem; margin-top: 1.25rem; }
+  button { flex: 1; padding: .7rem; border-radius: .5rem; border: 0; font-size: 1rem; cursor: pointer; }
+  .approve { background: #2f7d32; color: #fff; } .deny { background: transparent;
+             border: 1px solid rgba(128,128,128,.5); }
+  .hidden { display: none; } .err { color: #c0392b; margin-top: .75rem; font-size: .9rem; }
+  code { background: rgba(128,128,128,.15); padding: .1rem .3rem; border-radius: .3rem; }
+</style>
+</head>
+<body>
+<h1>Authorize access to Cerefox</h1>
+<div class="card">
+  <div id="fatal" class="hidden">
+    <p>This authorization link has expired or was already used.</p>
+    <p class="muted">Please start the connection again from your AI client.</p>
+  </div>
+
+  <div id="signin" class="hidden">
+    <p class="muted">Sign in to your Cerefox account to continue.</p>
+    <label for="email">Email</label>
+    <input id="email" type="email" autocomplete="username" />
+    <label for="password">Password</label>
+    <input id="password" type="password" autocomplete="current-password" />
+    <div class="row"><button class="approve" id="signin-btn">Sign in</button></div>
+    <div id="signin-err" class="err hidden"></div>
+  </div>
+
+  <div id="consent" class="hidden">
+    <p>Allow <strong id="client-name">this application</strong> to access your
+       Cerefox knowledge base (read and write)?</p>
+    <p class="muted" id="scopes"></p>
+    <div class="row">
+      <button class="deny" id="deny-btn">Deny</button>
+      <button class="approve" id="approve-btn">Allow</button>
+    </div>
+    <div id="consent-err" class="err hidden"></div>
+  </div>
+
+  <div id="loading"><p class="muted">Loading…</p></div>
+</div>
+
+<script type="module">
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const supabase = createClient(${JSON.stringify(supabaseUrl)}, ${JSON.stringify(anonKey)});
+const params = new URLSearchParams(location.search);
+const authorizationId = params.get("authorization_id");
+
+const $ = (id) => document.getElementById(id);
+const show = (id) => $(id).classList.remove("hidden");
+const hide = (id) => $(id).classList.add("hidden");
+function only(id) { for (const s of ["fatal","signin","consent","loading"]) hide(s); show(id); }
+
+function fatal() { only("fatal"); }
+
+async function loadDetails() {
+  try {
+    const { data, error } = await supabase.auth.oauth.getAuthorizationDetails(authorizationId);
+    if (error || !data) return fatal();
+    $("client-name").textContent = data.client?.name || data.client_name || "This application";
+    const scopes = data.scopes || data.scope;
+    if (scopes && scopes.length) {
+      $("scopes").textContent = "Requested scopes: " +
+        (Array.isArray(scopes) ? scopes.join(", ") : scopes);
+    }
+    only("consent");
+  } catch (_e) { fatal(); }
+}
+
+async function boot() {
+  if (!authorizationId) return fatal();
+  const { data: { session } } = await supabase.auth.getSession();
+  if (!session) { only("signin"); return; }
+  only("loading");
+  await loadDetails();
+}
+
+$("signin-btn").addEventListener("click", async () => {
+  hide("signin-err");
+  const email = $("email").value.trim();
+  const password = $("password").value;
+  const { error } = await supabase.auth.signInWithPassword({ email, password });
+  if (error) { $("signin-err").textContent = error.message; show("signin-err"); return; }
+  only("loading");
+  await loadDetails();
+});
+
+$("approve-btn").addEventListener("click", async () => {
+  hide("consent-err");
+  try {
+    const { data, error } = await supabase.auth.oauth.approveAuthorization(authorizationId);
+    if (error || !data?.redirect_url) throw error || new Error("no redirect_url");
+    location.assign(data.redirect_url);
+  } catch (e) {
+    $("consent-err").textContent = "Could not complete authorization. " +
+      "Please start again from your AI client.";
+    show("consent-err");
+  }
+});
+
+$("deny-btn").addEventListener("click", async () => {
+  try {
+    const { data } = await supabase.auth.oauth.denyAuthorization(authorizationId);
+    if (data?.redirect_url) location.assign(data.redirect_url);
+    else fatal();
+  } catch (_e) { fatal(); }
+});
+
+boot();
+</script>
+</body>
+</html>`;
+}
+
+Deno.serve((req: Request): Response => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { status: 200, headers: CORS_HEADERS });
+  }
+  if (req.method !== "GET") {
+    return new Response("Method Not Allowed", { status: 405, headers: CORS_HEADERS });
+  }
+  const supabaseUrl = Deno.env.get("SUPABASE_URL") ?? "";
+  const anonKey = Deno.env.get("SUPABASE_ANON_KEY") ?? "";
+  return new Response(page(supabaseUrl, anonKey), {
+    status: 200,
+    headers: { ...CORS_HEADERS, "Content-Type": "text/html; charset=utf-8" },
+  });
+});


### PR DESCRIPTION
## Summary

Iteration 28 groundwork for the **v1.0.0** arc, landing on `main` (no release cut yet — the `0.12.0-beta` tag comes after 28E). Three shipped pieces + the design/plan for what's next:

- **28A — OAuth 2.1 on `cerefox-mcp`** (working end-to-end for claude.ai web + mobile). Supabase-native OAuth 2.1 (auth-code + PKCE + DCR), RFC 9728 protected-resource metadata, in-function JWT validation against the project JWKS (`_shared/mcp-auth/`, unit-tested), deployed `--no-verify-jwt`. Consent page hosted on a free Cloudflare Worker (`cloudflare/cerefox-consent/`). Optional feature; owner-pinned. Docs: setup-supabase Step 7 + connect-agents "Cloud Claude".
- **28B — security hardening.** Closed a Data-API RPC-privilege bypass (schema `0.6.0 → 0.7.0`: REVOKE EXECUTE from PUBLIC/anon/authenticated, GRANT to service_role over all `cerefox_*` functions; `docker/local/roles.sql` parity). Hardened the OAuth auth surface (owner-pin as the security boundary; static-Bearer made optional then removed). Living `docs/specs/security-model.md`.
- **28D interim — chunker corruption fix.** Keep oversized single paragraphs whole so `reconstruct(chunk(doc)) === doc` (the `\n\n`-join reconstruction was injecting blank lines / duplication). TS + Python parity; regression test asserts byte-for-byte round-trip. The *proper* fix (blind-stitch) is designed in `docs/specs/chunk-reconstruction-design.md` (Phase 1, later beta).
- **Design + plan for 28E/28F** — `docs/specs/ef-auth-migration-design.md` (retire the unrotatable legacy anon JWT across all EF paths via a rotatable Cerefox-managed token, hard cutover) and the 28F documentation sanity sweep. These are **docs only** in this PR; implementation lands on `feat/ef-auth-token` off `main`.

No breaking runtime changes for existing clients in this PR (the legacy anon JWT still works until 28E). Schema bump `0.7.0` requires a `cerefox server deploy` on existing databases.

## Test plan

- [x] `_shared` unit tests green (`cd _shared && bun test`) — incl. new `mcp-auth` + chunker round-trip suites
- [x] OAuth path verified live (claude.ai web + mobile: 15 projects, tools/list + calls)
- [x] Data-API RPC lockdown verified (anon can no longer EXECUTE `cerefox_*`)
- [x] `cerefox-mcp` rejects the anon key on the removed static path (401); OAuth still works
- [ ] `cerefox server deploy` on a fresh DB stamps schema `0.7.0` (reviewer / pre-beta)
- [ ] Package suite `cd packages/memory && bun run build && bun test` (reviewer)

## Notes

- **Squash-merge.** 27 WIP commits collapse to one on `main`.
- Follows: branch `feat/ef-auth-token` off `main` for 28E, then 28F doc sweep, then cut `0.12.0-beta`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vd45RFdSk8hHupWLn9jfDQ
