### PR TITLE
fix(28G): stale Python command strings in CLI messages

### DIFF
--- a/_shared/__tests__/db_status.test.ts
+++ b/_shared/__tests__/db_status.test.ts
@@ -75,9 +75,9 @@ describe("runDbStatusChecks", () => {
     const report = await runDbStatusChecks(client, { bundledSchemaVersion: "0.3.0" });
     expect(report.functions.every((f) => f.status === "unknown")).toBe(true);
     expect(report.allOk).toBe(false);
-    // Each "unknown" row has a detail nudging the user toward db_deploy.py.
+    // Each "unknown" row has a detail nudging the user toward `cerefox server deploy`.
     for (const f of report.functions) {
-      expect(f.detail).toMatch(/db_deploy/);
+      expect(f.detail).toMatch(/server deploy/);
     }
   });
 

--- a/_shared/db-status/index.ts
+++ b/_shared/db-status/index.ts
@@ -132,7 +132,7 @@ export async function runDbStatusChecks(
         exists === true ? "ok" : exists === false ? "missing" : "unknown";
       const detail =
         status === "unknown"
-          ? "introspection helper not deployed; run `python scripts/db_deploy.py`"
+          ? "introspection helper not deployed; run `cerefox server deploy`"
           : undefined;
       functions.push({ name: f, status, detail });
     } catch (err) {
@@ -225,7 +225,7 @@ export function formatReport(report: DbStatusReport): string {
     lines.push(
       "     legacy deployment that hasn't been redeployed since v0.3.0).");
     lines.push(
-      "     Run `uv run python scripts/db_deploy.py` to install it, then");
+      "     Run `cerefox server deploy` to install it, then");
     lines.push(
       "     re-run this script for a full report.");
     lines.push("");

--- a/packages/memory/src/cli/commands/backup.ts
+++ b/packages/memory/src/cli/commands/backup.ts
@@ -114,8 +114,8 @@ async function action(options: BackupOptions): Promise<void> {
   println(c.dim(`  documents: ${docs.length} · chunks: ${chunkTotal}`));
 
   if (options.git) {
-    println(c.yellow("⚠ ") + "--git commit option not yet ported to the TS CLI.");
-    println(c.dim("  For git-aware backups, run `uv run cerefox backup --git` from a clone."));
+    println(c.yellow("⚠ ") + "--git commit is not implemented; the snapshot was written without a git checkpoint.");
+    println(c.dim("  Commit the backup directory yourself if you want it version-controlled."));
   }
 }
 

--- a/packages/memory/src/cli/commands/init.ts
+++ b/packages/memory/src/cli/commands/init.ts
@@ -217,8 +217,8 @@ async function promptForAnswers(): Promise<ConfigAnswers> {
   println(c.cyan("▶ Step 4/5 — Direct Postgres connection (optional for npm-installed users)"));
   println(
     c.dim(
-      "  Only needed for `uv run python scripts/db_deploy.py` (schema deploy + migrations).\n" +
-        "  npm-installed users without Python can skip — press Enter.\n" +
+      "  Only needed for `cerefox server deploy` (schema deploy + migrations).\n" +
+        "  You can skip this and set CEREFOX_DATABASE_URL later — press Enter.\n" +
         "  Format: postgresql://postgres.<project-ref>:<pw>@…:5432/postgres?sslmode=require",
     ),
   );
@@ -331,16 +331,15 @@ function printMigrationMenu(cwdEnv: string, homeEnv: string): void {
   println("");
   println(c.yellow(`⚠ Found existing config at ${cwdEnv}.`));
   println("");
-  println("This may be from a previous Python install. The TS CLI can use the");
+  println("This may be from an earlier install. The CLI can use the");
   println("same .env — env-var names are identical, no rewrite needed.");
   println("");
   println("  " + c.bold("[c]") + " Copy to " + homeEnv + "  " + c.green("(recommended)"));
-  println(c.dim("      • TS reads the new home from now on"));
-  println(c.dim("      • Python keeps reading " + cwdEnv + " (backward compat)"));
+  println(c.dim("      • The CLI reads the new home from now on"));
   println(c.dim("      • Edit ~/.cerefox/.env going forward; the repo .env is legacy"));
   println("");
   println("  " + c.bold("[u]") + " Use " + cwdEnv + " as-is, skip writing anything");
-  println(c.dim("      • Both TS and Python keep reading the existing file"));
+  println(c.dim("      • The CLI keeps reading the existing file"));
   println(c.dim("      • Defer the migration"));
   println("");
   println("  " + c.bold("[f]") + " Fresh start — interactive prompts, write to " + homeEnv);
@@ -583,7 +582,7 @@ async function action(options: InitOptions): Promise<void> {
         }
       }
       println(c.green(`✓ Copied ${cwdEnv} → ${homeEnv}`));
-      println(c.dim(`  Repo file unchanged — Python still reads it during migration.`));
+      println(c.dim(`  Repo file left unchanged — safe to delete once the new location works.`));
       println("");
 
       // Validate the copied config against live services.

--- a/packages/memory/src/cli/util/checks.ts
+++ b/packages/memory/src/cli/util/checks.ts
@@ -453,8 +453,8 @@ export function checkLegacyShadowEnv(): CheckResult | null {
     status: "skipped",
     detail: `${cwdEnv} (shadowed by ~/.cerefox/.env)`,
     hint:
-      "Python `uv run cerefox …` still reads this file during the v0.5–v0.7 migration window. " +
-      "Safe to delete once Python support is removed (v0.9+).",
+      "Shadowed by ~/.cerefox/.env and no longer read by anything (Python was removed at " +
+      "v1.0.0). Safe to delete.",
   };
 }
 


### PR DESCRIPTION
Follow-up to the Python retirement (#94): the doc sweep missed runtime message strings in the CLI. Updates the doctor `legacy env` hint, `init` prompts, `backup --git`, and db-status hints to stop referencing removed Python commands (`uv run …`, `python scripts/db_deploy.py`). Surfaced by `cerefox doctor` on the beta.2 install.

Verified: `_shared` 274 pass, package build green, no user-facing Python command strings remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vd45RFdSk8hHupWLn9jfDQ