### PR TITLE
security(28B): pre-1.0 defensive review + clamp search result counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,14 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
-Open roadmap.
+### Security
+- **Pre-1.0.0 defensive security review (iter-28B ③).** A full read of the
+  auth, database, Edge Function, web, and CLI surfaces. The material risks were
+  already closed by the earlier auth work; this pass added one hardening fix and
+  documented the review in `docs/specs/security-audit-1.0.md`.
+- **Hardening:** `cerefox-search` and `cerefox-metadata-search` now clamp the
+  requested result count to a sane maximum, so a large `match_count` / `limit`
+  can't drive an oversized query. No API shape change.
 
 ---
 

--- a/docs/specs/security-audit-1.0.md
+++ b/docs/specs/security-audit-1.0.md
@@ -1,0 +1,62 @@
+# Pre-1.0.0 defensive security review
+
+Status: complete (beta.3). Scope: a defensive read of Cerefox's own
+security-sensitive surfaces before the 1.0.0 release, to find and fix hardening
+gaps. This is a review of our own code — it records what was checked, what was
+already solid, and the low-severity hardening applied. It deliberately omits
+exploit detail.
+
+## Method / scope
+
+Read-through of the highest-risk surfaces:
+
+- **Auth**: the Cerefox access-token check (`_shared/ef-auth/`) and the OAuth 2.1
+  JWT validator (`_shared/mcp-auth/`), plus how `cerefox-mcp` wires them.
+- **Database**: the 30 `SECURITY DEFINER` RPCs (`src/cerefox/db/rpcs.sql`) —
+  `search_path` pinning and `EXECUTE` privileges.
+- **Edge Functions**: input bounds, error/info disclosure, CORS.
+- **Web server + SPA**: default bind, request auth, the `/rest/v1` proxy, and
+  markdown rendering (stored-XSS).
+- **CLI**: subprocess handling (command injection) and secret handling.
+- Secret logging across all three runtimes.
+
+## Verified solid (no change needed)
+
+- **Constant-time token compare**, fail-closed when the accepted set is empty,
+  no short-circuit across the set, token value never logged (`ef-auth`).
+- **OAuth JWT**: algorithm allowlist enforced *before* any crypto (rejects
+  `none`/HS256 — the alg-confusion defense), key type matched to alg, and all of
+  `iss`/`aud`/`exp`/`nbf`/`sub` validated. The owner pin **fails closed** when
+  unset (no accidental accept-any-user). Constant-time static path.
+- **401 challenge** returns only `{ error }` + an RFC 9728 `WWW-Authenticate`
+  header — the enriched claim `detail` goes to dashboard logs only, never the client.
+- **All 30 `SECURITY DEFINER` functions pin `search_path`.**
+- **`EXECUTE` revoked** from `PUBLIC`/`anon`/`authenticated`, granted only to
+  `service_role`.
+- **No command-injection surface**: every `spawnSync`/`spawn` uses the array-args
+  form; no `shell: true`, no shell string interpolation.
+- **Web server binds `127.0.0.1` by default** (loopback); `--host 0.0.0.0` is an
+  explicit opt-in, and the cloud-run guide documents adding auth for exposure.
+- **No stored XSS**: the SPA renders with `react-markdown` (v10) and **no
+  `rehype-raw`** and no `dangerouslySetInnerHTML`, so raw HTML in document content
+  is escaped to text, and dangerous URL schemes are stripped by default.
+- **No secret logging**: no token/key value is written to `console.*`.
+- **`/rest/v1` proxy** (local self-hosted only, gated by
+  `CEREFOX_POSTGREST_UPSTREAM`) targets a fixed upstream host — the client
+  controls only the path, so there is no host-redirection / SSRF.
+
+## Findings + disposition
+
+| # | Area | Severity | Finding | Disposition |
+|---|---|---|---|---|
+| 1 | `cerefox-search`, `cerefox-metadata-search` | Low | `match_count` / `limit` were unbounded — the response is byte-capped but the query work (vector sort / FTS ranking / row scan) was not, so an *authenticated* caller could request an oversized LIMIT. | **Fixed** — clamped to `[1, 200]` / `[1, 500]`. |
+| 2 | `token generate/rotate` | Low | The token is passed to `supabase secrets set` as a process argument, so it is briefly visible via `ps` to other local users on a shared host. Inherent to how the Supabase CLI takes the value. | **Accepted / documented.** Single-user tool; brief window; co-located local user required. Revisit if the Supabase CLI gains a stdin/`--env-file` path. |
+| 3 | `rpcs.sql` | Info | `SECURITY DEFINER` functions pin `search_path = public, pg_catalog`. `pg_catalog`-first (or `''` with fully-qualified refs) is marginally stricter. Low-risk on Supabase, where `public` is not writable by untrusted roles. | **Accepted** (defense-in-depth note). |
+| 4 | `/rest/v1` proxy | Info | On a 502 the upstream error string is returned to the client (reveals local topology). Local self-hosted mode only. | **Accepted** (minor; local-only). |
+
+## Outcome
+
+The codebase is well-hardened — the earlier auth migration (iter-28E) and the
+OAuth-surface work (iter-28B) closed the material risks. This review found only
+low-severity items; the one concrete code fix (Finding 1) is applied. No
+release-blocking issue was found for 1.0.0.

--- a/supabase/functions/cerefox-metadata-search/index.ts
+++ b/supabase/functions/cerefox-metadata-search/index.ts
@@ -93,7 +93,9 @@ Deno.serve(async (req: Request): Promise<Response> => {
         { status: 400, headers: { ...CORS_HEADERS, "Content-Type": "application/json" } },
       );
     }
-    const limit = body.limit ?? 10;
+    // Clamp limit to [1, 500]: response is byte-capped, but bound the row work too
+    // so an authenticated caller can't request an unbounded scan. Defensive review, pre-1.0.
+    const limit = Math.min(Math.max(1, Math.floor(Number(body.limit)) || 10), 500);
     const include_content = body.include_content ?? false;
     const requested_max_bytes = body.max_bytes;
 

--- a/supabase/functions/cerefox-search/index.ts
+++ b/supabase/functions/cerefox-search/index.ts
@@ -52,6 +52,11 @@ const EMBEDDING_DIMENSIONS = 768;
 // ceiling is rarely reached under normal usage at the default match_count=5.
 const MAX_BYTES = 200_000;
 
+// Upper bound on match_count. The response is byte-capped separately (MAX_BYTES);
+// this caps the query work (vector sort / FTS ranking) so an authenticated caller
+// cannot request an unbounded LIMIT. Defensive review, pre-1.0.
+const MAX_MATCH_COUNT = 200;
+
 
 interface SearchRequest {
   query: string;
@@ -216,7 +221,7 @@ Deno.serve(async (req: Request) => {
   const {
     query,
     project_name,
-    match_count = 5,
+    match_count: raw_match_count = 5,
     mode = "docs",
     alpha = 0.7,
     min_score = 0.5,
@@ -226,6 +231,8 @@ Deno.serve(async (req: Request) => {
 
   // Enforce ceiling: agents may request less but never more than MAX_BYTES.
   const max_bytes = Math.min(requested_max_bytes ?? MAX_BYTES, MAX_BYTES);
+  // Clamp match_count to [1, MAX_MATCH_COUNT] (bounds query work; see MAX_MATCH_COUNT).
+  const match_count = Math.min(Math.max(1, Math.floor(Number(raw_match_count)) || 5), MAX_MATCH_COUNT);
 
   // Validate metadata_filter: must be a plain object (or null/absent).
   // Reject arrays, strings, and other non-object types to prevent RPC errors.


### PR DESCRIPTION
Beta.3 security workstream. A defensive read of our own auth / DB / Edge Function / web / CLI surfaces before 1.0.0, recorded in `docs/specs/security-audit-1.0.md` (kept free of exploit detail).

**Outcome:** the codebase is well-hardened — the earlier auth migration (28E) + OAuth-surface work (28B) closed the material risks. Verified solid: constant-time token compare (fail-closed), OAuth alg-allowlist + owner-pin (fail-closed), all `SECURITY DEFINER` RPCs pin `search_path`, `EXECUTE` is `service_role`-only, no command-injection surface, loopback bind by default, no stored XSS (react-markdown, no rehype-raw), no secret logging, no proxy SSRF.

**One fix applied:** clamp `match_count` / `limit` in `cerefox-search` and `cerefox-metadata-search` (response was already byte-capped; this bounds the query work too). No API shape change. Remaining findings are low-severity / accepted (documented in the spec).

No release-blocking issue found for 1.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vd45RFdSk8hHupWLn9jfDQ