### PR TITLE
fix: metadata-keys crash on scalar metadata (#89) + false-positive MCP schema banner (#90)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,21 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
-Open roadmap.
+### Fixed
+- **`cerefox metadata keys` no longer crashes when any document's `metadata` is a
+  JSON scalar/array** (#89; schema 0.8.0 → 0.8.1 — redeploy via `cerefox server
+  deploy`). One malformed row poisoned the whole listing ("cannot call
+  jsonb_object_keys on a scalar"); the RPC now considers only object-typed
+  metadata. Ingest (Edge Function + MCP tools) additionally rejects non-object
+  `metadata` up front with a clear error, so such rows can't be stored again.
+  Thanks @tdebasis for the precise report and proposed fix.
+- **`cerefox mcp` no longer prints a false-positive "schema version mismatch"
+  banner on every healthy startup** (#90). It compared the npm package version
+  against the deployed schema version — two independent numbering scales that
+  are never equal. It now compares schema-to-schema (the same source `cerefox
+  doctor` uses) and warns only for the real redeploy footgun (the client bundles
+  a newer schema than is deployed), with the correct remediation
+  (`cerefox server deploy`, not the removed Python command). Thanks @tdebasis.
 
 ---
 

--- a/_shared/__tests__/mcp_tools.test.ts
+++ b/_shared/__tests__/mcp_tools.test.ts
@@ -159,6 +159,23 @@ describe("input validation throws McpInvalidParams", () => {
     expect(err).toBeInstanceOf(McpInvalidParams);
   });
 
+  test("cerefox_ingest rejects scalar metadata (issue #89)", async () => {
+    const tool = TOOLS_BY_NAME["cerefox_ingest"];
+    for (const bad of ["i am a scalar", 42, true, ["an", "array"]]) {
+      let err: unknown;
+      try {
+        await tool.handler(
+          noopClient(),
+          { title: "x", content: "y", metadata: bad },
+          { ...FAKE_CTX, openaiApiKey: "test" },
+        );
+      } catch (e) {
+        err = e;
+      }
+      expect(err).toBeInstanceOf(McpInvalidParams);
+    }
+  });
+
   test("cerefox_get_document rejects missing document_id", async () => {
     const tool = TOOLS_BY_NAME["cerefox_get_document"];
     let err: unknown;

--- a/_shared/mcp-tools/ingest.ts
+++ b/_shared/mcp-tools/ingest.ts
@@ -81,6 +81,14 @@ async function handler(
   // {} on create (v0.11.1 — defaulting to {} here used to wipe a document's
   // tags on every content update that didn't re-pass them).
   const metadata = (args.metadata as Record<string, unknown> | undefined) ?? null;
+  // Must be a plain JSON object (or absent). A scalar/array stored in the JSONB
+  // column poisons cerefox_list_metadata_keys for the whole dataset (issue #89),
+  // so reject it at the boundary too, not just in the RPC.
+  if (metadata !== null && (typeof metadata !== "object" || Array.isArray(metadata))) {
+    throw new McpInvalidParams(
+      'metadata must be a JSON object of key/value pairs, e.g. {"type":"note"} — not a string, number, or array',
+    );
+  }
   const update_if_exists = (args.update_if_exists as boolean | undefined) ?? false;
   const author = (args.author as string | undefined) ?? "mcp-agent";
   const author_type = "agent"; // MCP path is always agent

--- a/packages/memory/src/server.ts
+++ b/packages/memory/src/server.ts
@@ -21,8 +21,11 @@ import {
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { existsSync, readFileSync } from "node:fs";
 
+import { compareSemver } from "../../../_shared/compatibility/index.ts";
 import { loadSettings } from "../../../_shared/config/index.ts";
+import { resolveServerAssets } from "../../../_shared/server-assets/index.ts";
 import {
   ALL_TOOLS,
   McpInvalidParams,
@@ -115,19 +118,41 @@ export function buildServer(): ServerHandle {
   };
 }
 
+/** Matches the `-- @version: X.Y.Z` marker at the top of the bundled schema.sql. */
+const SCHEMA_VERSION_RE = /^--\s*@version:\s*(\S+)/m;
+
 async function warnIfSchemaVersionMismatch(
   supabase: SharedSupabaseClient,
 ): Promise<void> {
   try {
     const { data } = await supabase.rpc("cerefox_schema_version");
     const deployed = typeof data === "string" ? data : null;
-    if (deployed && deployed !== PKG_VERSION) {
-      // Match the Python schema-mismatch banner's wording so operators get a
-      // consistent signal regardless of which surface noticed first.
+    if (!deployed) return;
+    // Compare SCHEMA against SCHEMA. The npm package version (PKG_VERSION) is an
+    // independent numbering scale that is never equal to the schema version, so
+    // comparing against it made this banner a permanent false positive on every
+    // healthy startup (issue #90). The bundled schema version is the same source
+    // `cerefox doctor` uses: the `-- @version:` marker in the bundled schema.sql.
+    let bundled: string | null = null;
+    try {
+      const assets = resolveServerAssets();
+      if (existsSync(assets.schemaFile)) {
+        const m = readFileSync(assets.schemaFile, "utf8").match(SCHEMA_VERSION_RE);
+        bundled = m ? m[1] : null;
+      }
+    } catch {
+      /* assets unresolvable (unusual install layout) → skip the check */
+    }
+    if (!bundled) return;
+    // Warn only for the redeploy footgun: client bundles a NEWER schema than is
+    // deployed (user upgraded npm, forgot `cerefox server deploy`). A deployed
+    // schema newer than the bundle is fine (another machine deployed it) and
+    // equal versions are the healthy steady state — both stay silent.
+    if (compareSemver(deployed, bundled) < 0) {
       process.stderr.write(
-        `[cerefox-mcp] ⚠  schema version mismatch: bundled ${PKG_VERSION}, ` +
-          `deployed ${deployed}. Run \`uv run python scripts/db_deploy.py\` ` +
-          `to update the database. Tools may behave unexpectedly until then.\n`,
+        `[cerefox-mcp] ⚠  schema version mismatch: this client bundles v${bundled} ` +
+          `but the deployed schema is v${deployed}. Run \`cerefox server deploy\` ` +
+          `to update it. Tools may behave unexpectedly until then.\n`,
       );
     }
   } catch {

--- a/src/cerefox/db/rpcs.sql
+++ b/src/cerefox/db/rpcs.sql
@@ -1420,8 +1420,10 @@ AS $$
           (WHERE d.metadata ->> k.key IS NOT NULL))[1:5]   AS example_values
     FROM cerefox_documents d,
          LATERAL jsonb_object_keys(d.metadata) AS k(key)
-    WHERE d.metadata IS NOT NULL
-      AND d.metadata != '{}'::jsonb
+    -- jsonb_object_keys() throws on non-object jsonb (scalar/array), and one such
+    -- row would poison the whole listing (issue #89). jsonb_typeof covers NULL
+    -- (returns NULL → filtered), scalars, and arrays; '{}' yields no keys anyway.
+    WHERE jsonb_typeof(d.metadata) = 'object'
     GROUP BY k.key
     ORDER BY doc_count DESC, k.key;
 $$;
@@ -1774,7 +1776,7 @@ SET search_path = public, pg_catalog
 AS $$
     -- Keep in lockstep with the `@version:` marker in schema.sql (cut_release.ts
     -- enforces it). Bump whenever schema.sql OR rpcs.sql changes.
-    SELECT '0.8.0'::TEXT;
+    SELECT '0.8.1'::TEXT;
 $$;
 
 -- ── cerefox_content_format_stats ─────────────────────────────────────────────

--- a/src/cerefox/db/schema.sql
+++ b/src/cerefox/db/schema.sql
@@ -5,7 +5,7 @@
 -- Requires extensions: vector (pgvector), uuid-ossp
 -- These are enabled at the top of db_deploy.py before this file is applied.
 --
--- @version: 0.8.0
+-- @version: 0.8.1
 -- The `@version` marker above is read by the schema-version-mismatch banner
 -- (see /api/v1/schema-version). Bump it whenever schema.sql OR rpcs.sql
 -- changes in a way that requires `cerefox server deploy` to be re-run —

--- a/supabase/functions/cerefox-ingest/index.ts
+++ b/supabase/functions/cerefox-ingest/index.ts
@@ -334,6 +334,16 @@ Deno.serve(async (req: Request) => {
   // a document's tags on every content update that didn't re-pass them).
   const { title, content, document_id = null, project_name, source = "agent", metadata = null, update_if_exists = false, author = "agent", author_type = "agent", expected_content_hash = null, last_write_wins = false } = body;
 
+  // metadata must be a plain JSON object (or absent). A scalar/array stored in
+  // the JSONB column poisons cerefox_list_metadata_keys for the whole dataset
+  // (issue #89) — reject at the boundary too, not just in the RPC.
+  if (metadata !== null && (typeof metadata !== "object" || Array.isArray(metadata))) {
+    return new Response(
+      JSON.stringify({ error: 'metadata must be a JSON object of key/value pairs, e.g. {"type":"note"} — not a string, number, or array' }),
+      { status: 400, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
   // Validate + normalize project_names if provided (full-set destructive form)
   let project_names: string[] | null = null;
   if (body.project_names !== undefined && body.project_names !== null) {


### PR DESCRIPTION
Resolves the two issues @tdebasis reported — both verified still present in 1.0.0-beta.3, both replicated live on a Cerefox Local container, and both fixes validated there before committing.

## #89 — `cerefox metadata keys` crash
- **Repro'd**: inserted a scalar-metadata row locally → `cerefox-local metadata keys` crashed exactly as reported.
- **Fix (as @tdebasis proposed)**: guard is now `jsonb_typeof(d.metadata) = 'object'` (also covers arrays + NULL). **Schema 0.8.0 → 0.8.1** (both literals, lockstep) — ships via `cerefox server deploy`.
- **Validated**: with the scalar row still present, the fixed RPC returns keys correctly.
- **Defense-in-depth**: `cerefox-ingest` EF + the shared MCP ingest handler now reject non-object `metadata` (400 / invalid-params) so such rows can't be stored again. (Request/response *shape* unchanged — no OpenAPI bump needed.)

## #90 — false-positive MCP startup banner
- **Repro'd** live from the beta.3 container: `bundled 1.0.0-beta.3, deployed 0.8.0` + the stale `uv run python scripts/db_deploy.py` remediation (which had survived the #95 sweep — it's written via `process.stderr.write`, not `println`).
- **Fix (as @tdebasis proposed)**: compare schema-to-schema — the bundled `schema.sql` `@version:` marker (same source `doctor` uses) vs `cerefox_schema_version()` — and warn **only** when the deployed schema is older than the bundle (the genuine redeploy footgun). Remediation is now `cerefox server deploy`.
- **Validated both directions**: equal versions → silent; deployed-behind-bundle → the new banner.

## Tests
- [x] `_shared` 275 pass (adds scalar/array-metadata rejection cases)
- [x] package build green
- [x] Live validation on Cerefox Local as above (test rows cleaned up)

Fixes #89
Fixes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vd45RFdSk8hHupWLn9jfDQ