### PR TITLE
fix: compareSemver pre-release precedence + embedder-first init prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
+Feature freeze for 1.0.0 (release-candidate line): fixes only from here to stable.
+
+### Fixed
+- **Version comparisons now honor SemVer pre-release precedence.** `compareSemver`
+  truncated versions to the numeric `X.Y.Z`, so every `1.0.0-*` pre-release (and
+  `1.0.0` itself) compared equal — silencing `doctor`'s "Edge Functions older
+  than bundled" warning across the entire beta line (a user following doctor
+  ended up two EF releases stale with no hint). Also fixes the same comparison
+  in the MCP startup banner and the client↔server compatibility matrix.
+- **`cerefox-local init` asks for the embedder first** — choosing `[2] Local`
+  now skips the OpenAI-key prompt entirely (the local embedder needs no key;
+  an existing key is kept silently).
+
 Open roadmap.
 
 ---

--- a/_shared/__tests__/compatibility.test.ts
+++ b/_shared/__tests__/compatibility.test.ts
@@ -24,8 +24,8 @@ describe("compareSemver", () => {
     expect(compareSemver("1.0.0", "0.9.9")).toBe(1);
   });
 
-  test("ignores prerelease suffixes", () => {
-    expect(compareSemver("0.8.0-rc.1", "0.8.0")).toBe(0);
+  test("pre-release sorts below its stable (SemVer §11 — was 'ignored' pre-1.0)", () => {
+    expect(compareSemver("0.8.0-rc.1", "0.8.0")).toBe(-1);
     expect(compareSemver("0.8.0-rc.1", "0.7.9")).toBe(1);
   });
 
@@ -185,5 +185,17 @@ describe("checkServerCompatibility", () => {
   test("matrix constants are semver strings", () => {
     expect(COMPATIBILITY.minSchema).toMatch(/^\d+\.\d+\.\d+/);
     expect(COMPATIBILITY.minEdgeFunctions).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});
+
+describe("compareSemver — pre-release precedence (SemVer §11)", () => {
+  test("pre-releases order within a line; all below the stable", () => {
+    expect(compareSemver("1.0.0-beta.3", "1.0.0-beta.4")).toBe(-1);
+    expect(compareSemver("1.0.0-beta.4", "1.0.0-rc.1")).toBe(-1);
+    expect(compareSemver("1.0.0-rc.1", "1.0.0")).toBe(-1);
+    expect(compareSemver("1.0.0", "1.0.0-beta.9")).toBe(1);
+    expect(compareSemver("1.0.0-beta", "1.0.0-beta.1")).toBe(-1);
+    expect(compareSemver("0.11.1", "1.0.0-beta.1")).toBe(-1);
+    expect(compareSemver("1.0.0-beta.4", "1.0.0-beta.4")).toBe(0);
   });
 });

--- a/_shared/compatibility/index.ts
+++ b/_shared/compatibility/index.ts
@@ -40,18 +40,50 @@ export type CompatLevel =
  * `0.8.0`). Returns -1 if a<b, 0 if equal, 1 if a>b.
  */
 export function compareSemver(a: string, b: string): number {
-  const norm = (v: string) =>
-    v
-      .split(/[.-]/)
-      .slice(0, 3)
-      .map((p) => Number.parseInt(p, 10))
-      .map((n) => (Number.isFinite(n) ? n : 0));
-  const pa = norm(a);
-  const pb = norm(b);
+  // Core X.Y.Z compare, then SemVer §11 pre-release precedence. The previous
+  // implementation truncated to the numeric triple, so EVERY 1.0.0-* pre-release
+  // (and 1.0.0 itself) compared equal — which silenced doctor's "EF older than
+  // bundled" warning across the 1.0.0-beta line (found in the beta.4 dogfood).
+  const split = (v: string): { core: number[]; pre: string[] } => {
+    const [core, ...preParts] = v.split("-");
+    return {
+      core: core.split(".").slice(0, 3).map((p) => {
+        const n = Number.parseInt(p, 10);
+        return Number.isFinite(n) ? n : 0;
+      }),
+      pre: preParts.length ? preParts.join("-").split(".") : [],
+    };
+  };
+  const pa = split(a);
+  const pb = split(b);
   for (let i = 0; i < 3; i++) {
-    const x = pa[i] ?? 0;
-    const y = pb[i] ?? 0;
+    const x = pa.core[i] ?? 0;
+    const y = pb.core[i] ?? 0;
     if (x !== y) return x < y ? -1 : 1;
+  }
+  // Equal cores: no pre-release outranks any pre-release (1.0.0 > 1.0.0-rc.1).
+  if (pa.pre.length === 0 && pb.pre.length === 0) return 0;
+  if (pa.pre.length === 0) return 1;
+  if (pb.pre.length === 0) return -1;
+  // Identifier-by-identifier: numeric < alphanumeric; numerics numerically,
+  // alphanumerics lexically; a shorter prefix sorts lower (beta < beta.1).
+  const len = Math.max(pa.pre.length, pb.pre.length);
+  for (let i = 0; i < len; i++) {
+    const x = pa.pre[i];
+    const y = pb.pre[i];
+    if (x === undefined) return -1;
+    if (y === undefined) return 1;
+    const xn = /^\d+$/.test(x) ? Number.parseInt(x, 10) : null;
+    const yn = /^\d+$/.test(y) ? Number.parseInt(y, 10) : null;
+    if (xn !== null && yn !== null) {
+      if (xn !== yn) return xn < yn ? -1 : 1;
+    } else if (xn !== null) {
+      return -1; // numeric identifiers sort below alphanumeric
+    } else if (yn !== null) {
+      return 1;
+    } else if (x !== y) {
+      return x < y ? -1 : 1;
+    }
   }
   return 0;
 }

--- a/docker/local/cerefox-local
+++ b/docker/local/cerefox-local
@@ -164,16 +164,6 @@ case "$cmd" in
       # shellcheck disable=SC1090
       cur_bind="$(. "$ENV_FILE"; echo "${CEREFOX_LOCAL_BIND:-127.0.0.1}")"
     fi
-    if [ -z "$key" ] && [ -t 0 ]; then
-      if [ -n "$cur_key" ]; then
-        printf 'OpenAI API key [Enter to keep current …%s]: ' "$(printf '%s' "$cur_key" | tail -c 4)"
-      else
-        printf 'OpenAI API key (sk-…, Enter to skip): '
-      fi
-      read -r key || true
-    fi
-    [ -z "$key" ] && key="$cur_key"     # keep current when left blank
-    [ -z "$port" ] && port="$cur_port"
     # Embedder choice (iter-31). Interactive when a TTY and not passed via flag.
     cur_embedder="openai"
     if [ -f "$ENV_FILE" ]; then
@@ -189,6 +179,18 @@ case "$cmd" in
       case "$_c" in 1) embedder=openai ;; 2) embedder=local ;; esac
     fi
     [ -z "$embedder" ] && embedder="$cur_embedder"
+    # OpenAI key — only prompt on the OpenAI path (the local embedder needs no
+    # key; any existing key is kept silently so switching back later is easy).
+    if [ -z "$key" ] && [ -t 0 ] && [ "$embedder" != "local" ]; then
+      if [ -n "$cur_key" ]; then
+        printf 'OpenAI API key [Enter to keep current …%s]: ' "$(printf '%s' "$cur_key" | tail -c 4)"
+      else
+        printf 'OpenAI API key (sk-…, Enter to skip): '
+      fi
+      read -r key || true
+    fi
+    [ -z "$key" ] && key="$cur_key"     # keep current when left blank
+    [ -z "$port" ] && port="$cur_port"
     if [ "$embedder" != "$cur_embedder" ]; then
       echo "⚠  Changing the embedder puts existing documents in a DIFFERENT vector space."
       echo "   Semantic search will be broken for them until you run: cerefox-local server reindex"


### PR DESCRIPTION
Two beta.4 dogfood findings, both rc.1-bound fixes (no beta.5 needed):

**1. `compareSemver` treated all `1.0.0-*` pre-releases (and `1.0.0`) as equal** — it truncated to the numeric triple. Consequence: doctor's EF-version check was silently blind across the whole beta line; a user following doctor's advice ended up with Edge Functions two releases stale with no warning (observed live: deployed beta.2 vs bundled beta.4, no ⚠). Now implements SemVer §11 pre-release precedence; the old test that codified the truncation is updated. Verified live: the missing warning now appears. This would also have bitten `rc.1 vs 1.0.0`.

**2. `cerefox-local init` prompt order** — it asked for the OpenAI key before the embedder choice; choosing `[2] Local` makes the key unnecessary. Embedder choice now comes first; the key prompt only appears on the OpenAI path (existing key kept silently).

Tests: `_shared` 282 pass (7 new SemVer precedence cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vd45RFdSk8hHupWLn9jfDQ