### PR TITLE
fix(reindex): target the active embedder, not hardcoded OpenAI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 ## [Unreleased]
 
 ### Fixed
+- **`cerefox server reindex` now targets the ACTIVE embedder.** It hardcoded the
+  OpenAI model as its target, so after switching Cerefox Local to the local
+  embedder it reported "(nothing to reindex)" (existing OpenAI-embedded chunks
+  looked already-correct), and `--all` would have stamped the wrong
+  `embedder_primary` on locally-embedded vectors. The staleness filter, the
+  recorded embedder, and the API-key gate all follow `CEREFOX_EMBEDDER` now.
+
+
+### Fixed
 - **`cerefox-local` now persists the pinned image ref.** Installing/upgrading with
   `CEREFOX_LOCAL_IMAGE=<ref>` stores the ref in the host config, and every verb
   that recreates the container (`init`, `start` on a busy port, `upgrade`) uses

--- a/packages/memory/src/cli/commands/reindex.ts
+++ b/packages/memory/src/cli/commands/reindex.ts
@@ -27,7 +27,7 @@ import {
   userError,
   warn,
 } from "../../../../../_shared/cli-core/index.ts";
-import { embedBatch } from "../../../../../_shared/embeddings/index.ts";
+import { activeEmbedderName, embedBatch, resolveEmbedderKind } from "../../../../../_shared/embeddings/index.ts";
 import { loadSettings } from "../../../../../_shared/config/index.ts";
 
 interface ReindexOptions {
@@ -45,14 +45,19 @@ interface ChunkRow {
   cerefox_documents: { title: string | null } | null;
 }
 
-const DEFAULT_MODEL = "text-embedding-3-small";
+// The reindex TARGET is whatever embedder is active (iter-31): reindex exists
+// precisely to migrate chunks TO the configured embedder, so both the staleness
+// filter and the recorded embedder_primary must follow it — a hardcoded OpenAI
+// name made `server reindex` a no-op after switching to the local embedder
+// (chunks looked "already correct") and mis-stamped provenance under --all.
 
 async function action(options: ReindexOptions): Promise<void> {
   const settings = loadSettings();
   if (!settings.supabaseUrl || !settings.supabaseKey) {
     throw userError("Supabase credentials not configured — run `cerefox init` first.");
   }
-  if (!settings.openaiApiKey) {
+  if (!settings.openaiApiKey && resolveEmbedderKind() !== "local") {
+    // The local ONNX embedder (CEREFOX_EMBEDDER=local, iter-31) needs no API key.
     throw userError("OPENAI_API_KEY not set — required for embeddings.");
   }
   const supabase = createClient(settings.supabaseUrl, settings.supabaseKey, {
@@ -74,8 +79,9 @@ async function action(options: ReindexOptions): Promise<void> {
   if (options.documentId) {
     query = query.eq("document_id", options.documentId);
   }
+  const targetModel = activeEmbedderName();
   if (!reindexAll) {
-    query = query.neq("embedder_primary", DEFAULT_MODEL);
+    query = query.neq("embedder_primary", targetModel);
   }
 
   const { data, error } = await query;
@@ -114,7 +120,7 @@ async function action(options: ReindexOptions): Promise<void> {
     });
     let embeddings: number[][];
     try {
-      embeddings = await embedBatch(texts, settings.openaiApiKey);
+      embeddings = await embedBatch(texts, settings.openaiApiKey ?? "");
     } catch (err) {
       errors += slice.length;
       const msg = err instanceof Error ? err.message : String(err);
@@ -126,7 +132,7 @@ async function action(options: ReindexOptions): Promise<void> {
         .from("cerefox_chunks")
         .update({
           embedding_primary: embeddings[i],
-          embedder_primary: DEFAULT_MODEL,
+          embedder_primary: targetModel,
         })
         .eq("id", slice[i].id);
       if (updErr) {


### PR DESCRIPTION
rc.1 dogfood finding #2 (rc.2-bound). `server reindex` predates the embedder abstraction — three coupled bugs:

1. **Staleness filter** compared `embedder_primary` against a hardcoded `text-embedding-3-small` → after switching to the local embedder, every OpenAI-embedded chunk looked "already correct" → **"(nothing to reindex)"** (observed live), leaving semantic search broken across the vector-space switch.
2. **Provenance stamp**: after re-embedding it wrote `embedder_primary = 'text-embedding-3-small'` even when the routed `embedBatch` produced nomic vectors — so `--all` would have silently lied to the doctor mismatch check.
3. **Key gate**: unconditional `OPENAI_API_KEY` requirement (this file's message differed slightly from the ones fixed in #98's gate sweep, so the grep missed it).

All three now follow `activeEmbedderName()` / `CEREFOX_EMBEDDER`. `_shared` 282 pass; build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vd45RFdSk8hHupWLn9jfDQ