### PR TITLE
fix(local-embedder): sub-batch ONNX inference to survive small Docker VMs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
+### Fixed
+- **Local-embedder inference is sub-batched (default 4 texts per call,
+  `CEREFOX_ONNX_BATCH`).** A 12-text single inference was OOM-killed (exit 137)
+  on Colima's default 2 GB Docker VM — the container shares that VM with
+  Postgres, PostgREST, and the web server. Sub-batching keeps peak memory flat,
+  fixing `server reindex` and large-document ingest on small VMs.
+  `setup-local.md` now documents the ≥ 4 GB VM recommendation.
+
 Open roadmap.
 
 ---

--- a/_shared/embeddings/onnx-embedder.ts
+++ b/_shared/embeddings/onnx-embedder.ts
@@ -208,8 +208,32 @@ export async function warmup(): Promise<void> {
  * Mean pooling + L2 normalisation (sentence-transformers convention; nomic
  * expects both). Returns plain `number[][]` to match the OpenAI path.
  */
+/**
+ * Per-inference sub-batch. Peak tensor memory scales with the batch, and the
+ * container shares a (often small) Docker VM with Postgres + PostgREST + the
+ * web server — a 12-text single call was OOM-killed on Colima's default 2 GB
+ * VM (rc.2 dogfood, exit 137). 4 keeps peak memory flat at personal scale;
+ * override with CEREFOX_ONNX_BATCH.
+ */
+const DEFAULT_ONNX_BATCH = 4;
+
+function onnxBatchSize(): number {
+  const env = (globalThis as { process?: { env?: Record<string, string | undefined> } })
+    .process?.env ?? {};
+  const n = Number.parseInt(env.CEREFOX_ONNX_BATCH ?? "", 10);
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_ONNX_BATCH;
+}
+
 export async function onnxEmbed(texts: string[], role: EmbedRole): Promise<number[][]> {
   if (texts.length === 0) return [];
+  const batch = onnxBatchSize();
+  if (texts.length > batch) {
+    const out: number[][] = [];
+    for (let i = 0; i < texts.length; i += batch) {
+      out.push(...(await onnxEmbed(texts.slice(i, i + batch), role)));
+    }
+    return out;
+  }
   const pipeline = await ensurePipeline();
   const inputs = buildPrefixedInputs(texts, role);
   const out = await pipeline(inputs, { pooling: "mean", normalize: true });

--- a/docs/guides/setup-local.md
+++ b/docs/guides/setup-local.md
@@ -49,6 +49,10 @@ install; switching later requires a re-index (see below).
 The local model (~130 MB) downloads once — at install/init when selected — into the
 data volume, so it survives `cerefox-local upgrade`.
 
+> **Memory**: give the Docker VM **≥ 4 GB** for comfortable local-embedder use
+> (Colima defaults to 2 GB: `colima start --memory 4`). Inference is
+> sub-batched to keep peak memory flat, so smaller VMs work — just slower.
+
 > **Switching embedders on existing data is breaking**: the two models produce
 > incompatible vector spaces, so documents embedded with one are invisible to
 > semantic search under the other. `cerefox-local init` warns and requires


### PR DESCRIPTION
rc.2 dogfood finding (rc.3-bound). `server reindex` was OOM-killed (docker `container oom` event → `exec_die` 137, dying silently right after "embedder ready") on Colima's **default 2 GB VM** — the container shares the VM with Postgres + PostgREST + the web server, and a 12-text single inference tipped it over. The same would hit **large-document ingest**.

Fix: `onnxEmbed` sub-batches inference (default 4 texts/call, `CEREFOX_ONNX_BATCH` override), keeping peak memory flat. `setup-local.md` documents the ≥ 4 GB VM recommendation (smaller still works, just slower).

Verified: 12 texts embed clean through the sub-batched path (768-dim each); the affected install completed `reindex` with small batches and `doctor` shows `✓ embedder … matches all existing chunks`. `_shared` 282 pass; build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vd45RFdSk8hHupWLn9jfDQ