### PR TITLE
fix(doctor): World-B awareness — no bogus errors inside Cerefox Local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
+### Fixed
+- **`cerefox-local doctor` no longer reports bogus World-A findings.** Inside the
+  Cerefox Local container: the config check passes when settings resolve from
+  environment variables (the container has no `.env` file by design), the
+  Edge-Function check is skipped (a local backend has no Edge Functions), and
+  the MCP-clients check points at host-side `cerefox-local configure-agent`
+  instead of warning about configs it cannot see. A healthy local install now
+  reports "All checks passed" instead of an error + warning.
+
 Open roadmap.
 
 ---

--- a/packages/memory/src/cli/util/checks.ts
+++ b/packages/memory/src/cli/util/checks.ts
@@ -98,6 +98,18 @@ export function checkConfig(): CheckResult {
     };
   }
   if (!existsSync(envPath)) {
+    // No file is fine when the settings resolve from the ENVIRONMENT — that is
+    // how the Cerefox Local container is configured (boot-minted credentials in
+    // /run/cerefox-runtime.env; no .env file exists by design). The check's real
+    // question is "is the client configured?", not "does a file exist?".
+    const settings = loadSettings();
+    if (settings.supabaseUrl && settings.supabaseKey) {
+      return {
+        name: "config",
+        status: "ok",
+        detail: "configured via environment variables (no .env file — normal for Cerefox Local)",
+      };
+    }
     return {
       name: "config",
       status: "error",
@@ -476,9 +488,13 @@ export function checkMcpConfigs(): CheckResult {
   if (found.length === 0) {
     return {
       name: "mcp clients",
-      status: "warn",
-      detail: "No MCP client configs reference Cerefox.",
-      hint: "Run `cerefox configure-agent --tool claude-code` (or `--tool claude-desktop`) to wire up a client.",
+      status: isLocalBackend() ? "skipped" : "warn",
+      detail: isLocalBackend()
+        ? "checked from inside the container — host MCP configs are not visible here."
+        : "No MCP client configs reference Cerefox.",
+      hint: isLocalBackend()
+        ? "Configure agents on the host with `cerefox-local configure-agent`."
+        : "Run `cerefox configure-agent --tool claude-code` (or `--tool claude-desktop`) to wire up a client.",
     };
   }
   return {
@@ -579,7 +595,20 @@ export async function checkPostgres(): Promise<CheckResult> {
  * `cerefox token generate`), or before the EFs are deployed (aggregator 404),
  * the check reports `skipped` rather than failing — expected transitional states.
  */
+/** True inside the Cerefox Local all-in-one container (World B): the server
+ * fronts a local PostgREST — there are no Edge Functions in this world. */
+function isLocalBackend(): boolean {
+  return Boolean(process.env.CEREFOX_POSTGREST_UPSTREAM);
+}
+
 export async function checkEdgeFunctionsCompat(): Promise<CheckResult> {
+  if (isLocalBackend()) {
+    return {
+      name: "edge functions",
+      status: "skipped",
+      detail: "local backend — Edge Functions are not used (cloud-only surface).",
+    };
+  }
   const settings = loadSettings();
   if (!settings.supabaseUrl) {
     return {


### PR DESCRIPTION
rc.3 dogfood finding. `cerefox-local doctor` reported **✗ 1 error (1 warning)** on a fully healthy install — three World-A (cloud) assumptions leaking into the container:

1. **config ✗**: demanded `~/.cerefox/.env`; the container is configured entirely via environment (boot-minted credentials in `/run/cerefox-runtime.env` — no file exists by design). Now ✓ when settings resolve from env, with an explanatory detail.
2. **edge functions ℹ (misleading)**: nagged to run `cerefox token generate`; World B has **no Edge Functions**. Now skipped with "local backend — Edge Functions are not used". Marker: `CEREFOX_POSTGREST_UPSTREAM` (set only in the local all-in-one image).
3. **mcp clients ⚠**: looked for host MCP configs from inside the container. Now points at host-side `cerefox-local configure-agent`.

Validated live in the running rc.3 container (injected bin): **"✓ All checks passed"**. Cloud doctor regression-checked — unchanged (including its correct EF-drift warning). `_shared` 282 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vd45RFdSk8hHupWLn9jfDQ