### PR TITLE
fix(search): embedder-aware default min score (nomic 0.6, openai 0.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
   the MCP-clients check points at host-side `cerefox-local configure-agent`
   instead of warning about configs it cannot see. A healthy local install now
   reports "All checks passed" instead of an error + warning.
+- **Search threshold auto-calibrates per embedder.** The default semantic floor
+  is now 0.6 with the local (nomic) embedder and 0.5 with OpenAI — nomic scores
+  unrelated text higher, so the OpenAI-calibrated 0.5 let weak matches through
+  on Cerefox Local. `CEREFOX_MIN_SEARCH_SCORE` / `--min-score` still override.
 
 Open roadmap.
 

--- a/_shared/mcp-tools/_utils.ts
+++ b/_shared/mcp-tools/_utils.ts
@@ -36,6 +36,15 @@ export function getMaxResponseBytes(): number {
 export const DEFAULT_MIN_SEARCH_SCORE = 0.5;
 
 /**
+ * Nomic's cosine-score distribution sits higher than OpenAI's: unrelated text
+ * lands ~0.4–0.55 (vs ~0.1–0.3), so the 0.5 floor calibrated for
+ * text-embedding-3-small lets weak matches through on the local embedder
+ * (rc.3 dogfood: an unrelated doc passed at vec≈0.54). 0.6 restores the
+ * intended precision; relevant nomic matches score ~0.7+.
+ */
+export const DEFAULT_MIN_SEARCH_SCORE_LOCAL = 0.6;
+
+/**
  * Resolve the minimum cosine-similarity floor for hybrid/semantic search
  * (vector-only matches below this are dropped; FTS matches always pass).
  * Overridable via the `CEREFOX_MIN_SEARCH_SCORE` env var (0.0–1.0). The Python
@@ -49,9 +58,14 @@ export const DEFAULT_MIN_SEARCH_SCORE = 0.5;
 export function getMinSearchScore(): number {
   const raw = (globalThis as { process?: { env?: Record<string, string | undefined> } })
     .process?.env?.CEREFOX_MIN_SEARCH_SCORE;
-  if (raw === undefined || raw === "") return DEFAULT_MIN_SEARCH_SCORE;
+  const fallback =
+    (globalThis as { process?: { env?: Record<string, string | undefined> } })
+      .process?.env?.CEREFOX_EMBEDDER === "local"
+      ? DEFAULT_MIN_SEARCH_SCORE_LOCAL
+      : DEFAULT_MIN_SEARCH_SCORE;
+  if (raw === undefined || raw === "") return fallback;
   const n = Number.parseFloat(raw);
-  return Number.isNaN(n) || n < 0 || n > 1 ? DEFAULT_MIN_SEARCH_SCORE : n;
+  return Number.isNaN(n) || n < 0 || n > 1 ? fallback : n;
 }
 
 export function applyByteBudget(

--- a/docs/guides/setup-local.md
+++ b/docs/guides/setup-local.md
@@ -60,6 +60,10 @@ data volume, so it survives `cerefox-local upgrade`.
 > `cerefox-local server reindex` to re-embed everything. `cerefox-local doctor`
 > flags any mismatch.
 
+> Scores are calibrated per embedder: with the local model the default semantic
+> threshold is **0.6** (vs 0.5 for OpenAI) because nomic scores unrelated text
+> higher. Override per call with `--min-score` or via `CEREFOX_MIN_SEARCH_SCORE`.
+
 ---
 
 ## Step 1 — Install

--- a/packages/memory/src/cli/commands/search.ts
+++ b/packages/memory/src/cli/commands/search.ts
@@ -283,7 +283,7 @@ export function registerSearch(program: Command): void {
     )
     .option("--mode <mode>", "Search mode: docs (default), hybrid, fts.", "docs")
     .option("--alpha <float>", "Semantic weight 0..1 (default: 0.7).", "0.7")
-    .option("--min-score <float>", "Minimum cosine similarity threshold (default: CEREFOX_MIN_SEARCH_SCORE or 0.5).")
+    .option("--min-score <float>", "Minimum cosine similarity threshold (default: CEREFOX_MIN_SEARCH_SCORE; else 0.5, or 0.6 with the local embedder).")
     .option("--max-bytes <n>", "Response size budget in bytes (default: CEREFOX_MAX_RESPONSE_BYTES or 200000).")
     .option("-r, --requestor <name>", "Agent / user name (recorded in usage log).")
     .option("--json", "Emit machine-readable JSON instead of the default text.")


### PR DESCRIPTION
rc.3 dogfood: hybrid search for "resume" on Cerefox Local returned an unrelated Greek doc at hybrid score 0.380 (vec ≈ 0.54). Root cause: the 0.5 semantic floor is calibrated on OpenAI's score distribution; nomic scores unrelated text ~0.4–0.55, so the floor is too permissive on the local embedder. Mechanics verified correct (--min-score 0.6 dropped it; no FTS match involved).

Fix: `getMinSearchScore()` — the single helper behind CLI / local+remote MCP / web API — defaults to **0.6 when `CEREFOX_EMBEDDER=local`**, 0.5 otherwise; `CEREFOX_MIN_SEARCH_SCORE` / `--min-score` still override. Docs note in setup-local.md.

Validated live in the rc.3 container: flag-free search now returns only relevant results (0.73–0.75); weak match gone. `_shared` 282 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vd45RFdSk8hHupWLn9jfDQ