### PR TITLE
iter-28H: v1.0.1 fixes and improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
+### Fixed
+- **Explicit Data API grants for `service_role`** (#26; schema 0.8.1 → 0.8.2 —
+  redeploy with `cerefox server deploy`). Supabase is removing the implicit
+  privileges Data API roles get on `public` tables (already the default for
+  projects created after 2026-05-30; enforced on existing projects 2026-10-30);
+  without explicit GRANTs, tables become invisible to PostgREST even for
+  `service_role`. `anon`/`authenticated` deliberately get nothing.
+- **`cerefox self-update` refreshes the bundled docs via the newly installed
+  binary** (#106) — the version stamp and sync logic now come from the new
+  release, not the still-running old process. Also fixes a stale internal verb
+  (the sync ran the pre-v0.9 command name).
+- **`cerefox document ingest --document-id` no longer renames the document to
+  the local filename** when `--title` is omitted — it keeps the existing title.
+- **Missing-author warning on every CLI write verb**: `document edit` and
+  `document version archive` now warn (like ingest already did) when a write
+  will be attributed to "unknown".
+
+### Changed
+- **`cerefox doctor`'s Edge-Function check is calmer and clearer**: the
+  above-minimum "older than bundled" case is informational (ℹ, not ⚠ — warnings
+  are reserved for real compatibility violations) and names both versions
+  plainly. Releases also bump the Edge-Function version at every **stable** cut,
+  so stable deployments never display a pre-release EF label.
+- **`cerefox-local upgrade --latest`** (or `upgrade <tag>`) re-points the
+  persisted image pin in one command.
+- **Small-VM hint at local-embedder selection**: the installer and
+  `cerefox-local init` note when the Docker VM has under 3 GB of memory
+  (the local embedder is happiest with ≥ 4 GB).
+
 Open roadmap.
 
 ---

--- a/docker/local/cerefox-local
+++ b/docker/local/cerefox-local
@@ -60,6 +60,18 @@ set_env_port() {
 # EXCLUDES container-managed vars (SUPABASE_URL/KEY, DATABASE_URL, POSTGREST_UPSTREAM,
 # the JWT secret) — those are generated/owned inside the container. The single codebase
 # reads these the same way in-container as it does for the cloud CLI.
+# 28H item 4: local-embedder memory hint. Peak inference memory is sub-batched,
+# so small VMs work, but ≥ 4 GB is the comfortable recommendation (Colima
+# defaults to 2 GB and the difference is very noticeable).
+warn_if_small_vm() {
+  _mem=$(docker info --format '{{.MemTotal}}' 2>/dev/null || echo 0)
+  if [ "${_mem:-0}" -gt 0 ] && [ "$_mem" -lt 3221225472 ]; then
+    _gb=$(awk "BEGIN{printf \"%.1f\", $_mem/1073741824}")
+    echo "ℹ Your Docker VM has ${_gb} GB of memory. The local embedder works but is"
+    echo "  happier with ≥ 4 GB (Colima: colima start --memory 4)."
+  fi
+}
+
 PASSTHROUGH_VARS="CEREFOX_EMBEDDER CEREFOX_MIN_SEARCH_SCORE CEREFOX_MAX_RESPONSE_BYTES CEREFOX_MAX_CHUNK_CHARS CEREFOX_MIN_CHUNK_CHARS CEREFOX_VERSION_RETENTION_HOURS CEREFOX_VERSION_CLEANUP_ENABLED CEREFOX_OPENAI_BASE_URL CEREFOX_OPENAI_EMBEDDING_MODEL CEREFOX_OPENAI_EMBEDDING_DIMENSIONS CEREFOX_AUTHOR_NAME CEREFOX_AUTHOR_TYPE CEREFOX_REQUESTOR_NAME"
 
 # Emit `-e VAR=value` for each passthrough var present in $ENV_FILE.
@@ -236,6 +248,7 @@ case "$cmd" in
     [ -n "$key" ] || echo "  (no OpenAI key set — ingest + semantic search stay disabled; re-run 'cerefox-local init' to add one)"
     recreate
     if [ "$embedder" = "local" ] && [ "$cur_embedder" != "local" ]; then
+      warn_if_small_vm
       echo "Downloading the local embedding model (one-time)…"
       docker exec -i "$CONTAINER" cerefox embedder-warmup || \
         echo "⚠ warmup failed (model downloads on first search instead)"
@@ -265,6 +278,15 @@ case "$cmd" in
   logs)          need_docker; docker logs "$@" "$CONTAINER" ;;
 
   upgrade)
+    # Optional target (28H item 3): `upgrade --latest` re-points the persisted
+    # pin to the moving :latest tag; `upgrade <tag>` (e.g. v1.0.1) pins that tag.
+    # No argument keeps the current pin (explicit CEREFOX_LOCAL_IMAGE env wins).
+    case "${1:-}" in
+      --latest) IMAGE="ghcr.io/fstamatelopoulos/cerefox-local:latest"; shift ;;
+      v*)       IMAGE="ghcr.io/fstamatelopoulos/cerefox-local:$1"; shift ;;
+      "") ;;
+      *) die "unknown upgrade option: $1 (use --latest or a version tag like v1.0.1)" ;;
+    esac
     need_docker
     echo "Pulling $IMAGE …"; docker pull "$IMAGE"
     # Persist the image ref so every later verb (init, start, …) recreates from

--- a/docker/local/install-local.sh
+++ b/docker/local/install-local.sh
@@ -115,6 +115,18 @@ for arg in "$@"; do
   esac
 done
 
+# 28H item 4: local-embedder memory hint. Peak inference memory is sub-batched,
+# so small VMs work, but ≥ 4 GB is the comfortable recommendation (Colima
+# defaults to 2 GB and the difference is very noticeable).
+warn_if_small_vm() {
+  _mem=$(docker info --format '{{.MemTotal}}' 2>/dev/null || echo 0)
+  if [ "${_mem:-0}" -gt 0 ] && [ "$_mem" -lt 3221225472 ]; then
+    _gb=$(awk "BEGIN{printf \"%.1f\", $_mem/1073741824}")
+    echo "ℹ Your Docker VM has ${_gb} GB of memory. The local embedder works but is"
+    echo "  happier with ≥ 4 GB (Colima: colima start --memory 4)."
+  fi
+}
+
 PRESERVED_OVERRIDES=""
 ENV_ARGS=""
 if [ -f "$CONFIG_DIR/.env" ]; then
@@ -169,6 +181,7 @@ umask 077
 # Local embedder selected → download the model NOW (one-time, with progress) so the
 # first search isn't slow. Failure is non-fatal: it downloads on first use instead.
 if [ "${CEREFOX_EMBEDDER:-}" = "local" ]; then
+  warn_if_small_vm
   echo "Downloading the local embedding model (~130 MB, one-time)…"
   docker exec -i "$CONTAINER" cerefox embedder-warmup || \
     echo "⚠ warmup failed (the model will download on first search instead)"

--- a/packages/memory/src/cli/commands/document-edit.ts
+++ b/packages/memory/src/cli/commands/document-edit.ts
@@ -16,6 +16,7 @@
 import type { Command } from "commander";
 
 import {
+  warn,
   c,
   notFound,
   println,
@@ -99,6 +100,11 @@ async function action(documentId: string, options: EditOptions): Promise<void> {
 
   const author = resolveAuthor(options.author);
   const authorType = resolveAuthorType(options.authorType);
+  if (author === "unknown") {
+    warn(
+      "No --author / CEREFOX_AUTHOR_NAME set — audit log will record this write as 'unknown'.",
+    );
+  }
   await client.raw.rpc("cerefox_create_audit_entry", {
     p_document_id: documentId,
     p_operation: "update-metadata",

--- a/packages/memory/src/cli/commands/ingest.ts
+++ b/packages/memory/src/cli/commands/ingest.ts
@@ -99,8 +99,12 @@ async function action(
     Boolean(options.paste),
   );
 
-  const title = options.title ?? titleFromPath;
-  if (!title || title.trim() === "") {
+  // On an update-by-id WITHOUT an explicit --title, keep the document's
+  // existing title (28H item 6): deriving it from the filename silently RENAMED
+  // the target document (observed live). null = "fetch current" below.
+  const updatingById = Boolean(options.documentId);
+  let title = options.title ?? (updatingById ? null : titleFromPath);
+  if (title !== null && (!title || title.trim() === "")) {
     throw userError(
       options.paste
         ? "--title is required with --paste."
@@ -144,6 +148,24 @@ async function action(
   const supabase = createClient(settings.supabaseUrl, settings.supabaseKey, {
     auth: { persistSession: false },
   });
+  // Update-by-id without --title: fetch and KEEP the existing title (28H item 6)
+  // instead of renaming the document to the local filename.
+  if (title === null) {
+    const { data, error } = await supabase
+      .from("cerefox_documents")
+      .select("title")
+      .eq("id", options.documentId)
+      .maybeSingle();
+    if (error || !data?.title) {
+      throw userError(
+        `Could not resolve document ${options.documentId} to keep its title` +
+          `${error ? ` (${error.message})` : ""}.`,
+        "Pass --title explicitly, or check the --document-id.",
+      );
+    }
+    title = data.title as string;
+    println(c.dim(`  (keeping existing title: ${JSON.stringify(title)})`));
+  }
   const pipeline = new IngestionPipeline({
     supabase,
     openAiApiKey: settings.openaiApiKey,

--- a/packages/memory/src/cli/commands/self-update.ts
+++ b/packages/memory/src/cli/commands/self-update.ts
@@ -150,19 +150,28 @@ async function action(options: SelfUpdateOptions): Promise<void> {
   println(c.green(`✓ Upgraded to ${target}.`));
 
   // Refresh the bundled-docs ingest so the KB stays in lockstep.
-  // Best-effort: if the user has no config yet (e.g. self-update before
-  // init), the sync is skipped with a clear message.
+  //
+  // MUST run in a child process of the FRESHLY INSTALLED binary (#106): this
+  // process is still the OLD bundle, so an in-process `await import(...)` would
+  // run the old sync code and stamp the old PKG_VERSION on the synced docs (the
+  // .md files on disk are already new — the package manager replaced them —
+  // which made the bug subtle: fresh content, stale version stamp). The package
+  // manager replaces the global bin file in place, so re-executing our own
+  // argv[1] loads the new code — the same pattern `init` uses to run
+  // `server deploy`.
+  //
+  // Best-effort: if the user has no config yet (e.g. self-update before init),
+  // the child prints its own clear skip message.
   println("");
-  println(c.dim("Refreshing bundled-docs ingest…"));
-  try {
-    const { runSyncSelfDocs } = await import("./sync-self-docs.ts");
-    await runSyncSelfDocs({});
-  } catch (err) {
+  println(c.dim("Refreshing bundled-docs ingest (using the new version)…"));
+  const sync = spawnSync(process.execPath, [process.argv[1], "guides", "ingest"], {
+    stdio: "inherit",
+  });
+  if (sync.status !== 0) {
     println(
-      cErr.yellow("⚠ ") +
-        `Could not refresh self-docs: ${err instanceof Error ? err.message : String(err)}`,
+      cErr.yellow("⚠ ") + "Could not refresh self-docs (see output above).",
     );
-    println(c.dim("  Run `cerefox sync-self-docs` manually after a successful `cerefox init`."));
+    println(c.dim("  Run `cerefox guides ingest` manually after a successful `cerefox init`."));
   }
 }
 

--- a/packages/memory/src/cli/commands/version-archive.ts
+++ b/packages/memory/src/cli/commands/version-archive.ts
@@ -11,6 +11,7 @@
 import type { Command } from "commander";
 
 import {
+  warn,
   c,
   notFound,
   println,
@@ -44,6 +45,11 @@ async function setArchived(
 
   const author = resolveAuthor(options.author);
   const authorType = resolveAuthorType(options.authorType);
+  if (author === "unknown") {
+    warn(
+      "No --author / CEREFOX_AUTHOR_NAME set — audit log will record this write as 'unknown'.",
+    );
+  }
   const op = archived ? "archive" : "unarchive";
 
   await client.raw.rpc("cerefox_create_audit_entry", {

--- a/packages/memory/src/cli/util/checks.ts
+++ b/packages/memory/src/cli/util/checks.ts
@@ -665,9 +665,14 @@ export async function checkEdgeFunctionsCompat(): Promise<CheckResult> {
     case "above-min-but-old":
       return {
         name: "edge functions",
-        status: "warn",
-        detail: `Deployed EF v${deployed} works but is older than the bundled Edge Functions (v${EF_VERSION}).`,
-        hint: "Update the Edge Functions (see remediation below).",
+        // Above-minimum ⇒ informational, not a warning (28H item 5, decided
+        // 2026-07-12): ⚠ is reserved for actual compatibility violations.
+        status: "skipped",
+        detail:
+          `Deployed Edge Functions (v${deployed}) are older than the ones bundled with ` +
+          `this client (v${EF_VERSION}). Compatible — nothing is broken — but redeploying ` +
+          `picks up the latest server-side fixes.`,
+        hint: "Redeploy with: cerefox server deploy --functions-only",
       };
     default:
       return {

--- a/scripts/cut_release.ts
+++ b/scripts/cut_release.ts
@@ -570,13 +570,22 @@ async function main(): Promise<void> {
   assertSchemaVersionGuard();
   ok("schema_version guard passed.");
 
-  // EF_VERSION bumps only when EF code changed since the last tag.
-  const bumpEf = efsChangedSinceLastTag();
+  // EF_VERSION bumps when EF code changed since the last tag — OR
+  // unconditionally at a STABLE cut (28H item 5, decided 2026-07-12): a stable
+  // release must never ship Edge Functions labeled with a pre-release version
+  // (1.0.0 shipped EFs labeled 1.0.0-rc.4 because nothing EF-side changed after
+  // rc.4 — correct but confusing in doctor forever after). The cost is one
+  // redeploy of identical EF code at the stable cut, which users do anyway.
+  const isStableCut = !newVersion.includes("-");
+  const efChanged = efsChangedSinceLastTag();
+  const bumpEf = efChanged || isStableCut;
   const literalsToBump: VersionLiteralFile[] = bumpEf
     ? [...VERSION_LITERAL_FILES, EF_VERSION_LITERAL]
     : VERSION_LITERAL_FILES;
-  if (bumpEf) {
+  if (efChanged) {
     info("Edge Function source changed since last tag — EF_VERSION will bump.");
+  } else if (isStableCut) {
+    info("Stable cut — EF_VERSION bumps unconditionally (no pre-release EF labels on stable).");
   } else {
     info("No Edge Function changes since last tag — leaving EF_VERSION as-is.");
   }

--- a/src/cerefox/db/migrations/0013_explicit_grants.sql
+++ b/src/cerefox/db/migrations/0013_explicit_grants.sql
@@ -1,0 +1,32 @@
+-- 0013_explicit_grants.sql — issue #26: explicit Data API grants for service_role
+-- (Supabase implicit-grant removal). Idempotent; safe on existing deployments.
+
+-- ── Explicit Data API grants (issue #26; schema 0.8.2) ─────────────────────────
+-- Supabase is removing the implicit privileges the Data API roles get on
+-- `public` tables (default for projects created after 2026-05-30; enforced on
+-- existing projects 2026-10-30). Without explicit GRANTs a table is invisible
+-- to PostgREST even for service_role (42501). Cerefox grants ONLY service_role
+-- (the CLI / MCP / web all use service-role-equivalent keys; anon/authenticated
+-- deliberately get nothing, matching the RPC EXECUTE posture from iter-28B).
+-- Guarded: on the local (World B) stack this file deploys BEFORE roles.sql
+-- creates service_role, so missing-role must be a no-op (roles.sql re-runs the
+-- grants implicitly via its own PostgREST wiring; the next deploy picks them up).
+DO $$
+DECLARE t TEXT;
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'service_role') THEN
+        GRANT USAGE ON SCHEMA public TO service_role;
+        FOREACH t IN ARRAY ARRAY[
+            'cerefox_projects', 'cerefox_documents', 'cerefox_document_versions',
+            'cerefox_audit_log', 'cerefox_document_projects', 'cerefox_chunks',
+            'cerefox_migrations', 'cerefox_config', 'cerefox_usage_log'
+        ] LOOP
+            IF to_regclass('public.' || t) IS NOT NULL THEN
+                EXECUTE format('GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.%I TO service_role', t);
+            END IF;
+        END LOOP;
+        -- Future cerefox_* tables created by the deploying role keep working.
+        ALTER DEFAULT PRIVILEGES IN SCHEMA public
+            GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO service_role;
+    END IF;
+END $$;

--- a/src/cerefox/db/rpcs.sql
+++ b/src/cerefox/db/rpcs.sql
@@ -1776,7 +1776,7 @@ SET search_path = public, pg_catalog
 AS $$
     -- Keep in lockstep with the `@version:` marker in schema.sql (cut_release.ts
     -- enforces it). Bump whenever schema.sql OR rpcs.sql changes.
-    SELECT '0.8.1'::TEXT;
+    SELECT '0.8.2'::TEXT;
 $$;
 
 -- ── cerefox_content_format_stats ─────────────────────────────────────────────

--- a/src/cerefox/db/schema.sql
+++ b/src/cerefox/db/schema.sql
@@ -5,7 +5,7 @@
 -- Requires extensions: vector (pgvector), uuid-ossp
 -- These are enabled at the top of db_deploy.py before this file is applied.
 --
--- @version: 0.8.1
+-- @version: 0.8.2
 -- The `@version` marker above is read by the schema-version-mismatch banner
 -- (see /api/v1/schema-version). Bump it whenever schema.sql OR rpcs.sql
 -- changes in a way that requires `cerefox server deploy` to be re-run —
@@ -386,3 +386,33 @@ ALTER TABLE cerefox_audit_log              ENABLE ROW LEVEL SECURITY;
 ALTER TABLE cerefox_migrations            ENABLE ROW LEVEL SECURITY;
 ALTER TABLE cerefox_config                ENABLE ROW LEVEL SECURITY;
 ALTER TABLE cerefox_usage_log             ENABLE ROW LEVEL SECURITY;
+
+-- ── Explicit Data API grants (issue #26; schema 0.8.2) ─────────────────────────
+-- Supabase is removing the implicit privileges the Data API roles get on
+-- `public` tables (default for projects created after 2026-05-30; enforced on
+-- existing projects 2026-10-30). Without explicit GRANTs a table is invisible
+-- to PostgREST even for service_role (42501). Cerefox grants ONLY service_role
+-- (the CLI / MCP / web all use service-role-equivalent keys; anon/authenticated
+-- deliberately get nothing, matching the RPC EXECUTE posture from iter-28B).
+-- Guarded: on the local (World B) stack this file deploys BEFORE roles.sql
+-- creates service_role, so missing-role must be a no-op (roles.sql re-runs the
+-- grants implicitly via its own PostgREST wiring; the next deploy picks them up).
+DO $$
+DECLARE t TEXT;
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'service_role') THEN
+        GRANT USAGE ON SCHEMA public TO service_role;
+        FOREACH t IN ARRAY ARRAY[
+            'cerefox_projects', 'cerefox_documents', 'cerefox_document_versions',
+            'cerefox_audit_log', 'cerefox_document_projects', 'cerefox_chunks',
+            'cerefox_migrations', 'cerefox_config', 'cerefox_usage_log'
+        ] LOOP
+            IF to_regclass('public.' || t) IS NOT NULL THEN
+                EXECUTE format('GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.%I TO service_role', t);
+            END IF;
+        END LOOP;
+        -- Future cerefox_* tables created by the deploying role keep working.
+        ALTER DEFAULT PRIVILEGES IN SCHEMA public
+            GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO service_role;
+    END IF;
+END $$;


### PR DESCRIPTION
## Summary
All seven iteration-28H items for v1.0.1:

- **#26 — explicit Data API grants for `service_role`** (schema 0.8.1 → 0.8.2, migration `0013_explicit_grants.sql`). Supabase is removing implicit privileges on `public` tables (default for projects created after 2026-05-30; enforced on existing projects 2026-10-30). Guarded DO block; `anon`/`authenticated` deliberately get nothing.
- **#106 — `self-update` refreshes bundled docs via the newly installed binary** (child-process re-exec), so the version stamp comes from the new release. Also fixes the sync calling the retired pre-v0.9 verb.
- **`document ingest --document-id` keeps the existing title** when `--title` is omitted (no more filename-derived renames).
- **Missing-author warning** on `document edit` and `document version archive` (parity with ingest).
- **Doctor EF check is informational (ℹ) with honest wording** for the above-minimum case; `cut_release.ts` bumps `EF_VERSION` unconditionally at stable cuts so stable deployments never show a pre-release EF label.
- **`cerefox-local upgrade --latest` / `upgrade <tag>`** re-points the persisted image pin.
- **Small-VM memory hint** when selecting the local embedder on a Docker VM under 3 GB.

## Test plan
- [x] `_shared` unit suite: 282 pass / 0 fail
- [x] Package build + CLI smoke green
- [x] `cut_release.ts --check` healthy (schema literals in lockstep)
- [x] Live: migration 0013 applies clean on local Postgres (9 tables granted to `service_role`)
- [x] Live: retitle guard, author warnings, doctor ℹ text, VM hint (on a real 1.9 GB VM)
- [ ] Dogfood as `1.0.1-beta.1` on both worlds (cloud + Cerefox Local)
- [ ] Fresh Supabase project deploy validates #26 in the grant-enforcement environment (before stable 1.0.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)