### PR TITLE
fix(cli): bound document list --project to a single query so it stops failing on large projects

### DIFF
--- a/packages/memory/src/cli/commands/list-docs.ts
+++ b/packages/memory/src/cli/commands/list-docs.ts
@@ -55,33 +55,29 @@ async function action(options: {
     projectId = project.id;
   }
 
-  let query = client.raw
-    .from("cerefox_documents")
-    .select("id, title, source, metadata, created_at, updated_at, review_status, deleted_at")
-    .limit(limit);
+  const docCols = "id, title, source, metadata, created_at, updated_at, review_status, deleted_at";
+  // Widened to `string`: the postgrest-js select-string parser's type-level
+  // grammar doesn't recognize the `!inner` embed-hint syntax below, so a
+  // literal-typed ternary here fails to typecheck on the projectId branch
+  // even though it's valid at runtime.
+  const selectCols: string = projectId
+    ? `${docCols}, cerefox_document_projects!inner(project_id)`
+    : docCols;
+
+  let query = client.raw.from("cerefox_documents").select(selectCols).limit(limit);
   query = deleted
     ? query.not("deleted_at", "is", null).order("deleted_at", { ascending: false, nullsFirst: false })
     : query.is("deleted_at", null).order("updated_at", { ascending: false, nullsFirst: false });
 
   if (projectId) {
-    // PostgREST embedding: filter docs through the M2M junction.
-    const { data: junctionRows, error: junctionError } = await client.raw
-      .from("cerefox_document_projects")
-      .select("document_id")
-      .eq("project_id", projectId);
-    if (junctionError) {
-      throw systemError(`Project membership lookup failed: ${junctionError.message}`);
-    }
-    const docIds = (junctionRows ?? []).map((r) => (r as { document_id: string }).document_id);
-    if (docIds.length === 0) {
-      if (options.json) {
-        printJson([]);
-      } else {
-        process.stdout.write(`(no documents in project "${options.project}")\n`);
-      }
-      return;
-    }
-    query = query.in("id", docIds);
+    // PostgREST embedding: filter docs through the M2M junction in a single
+    // query, bounded by `limit` regardless of project size. (Previously:
+    // fetched every document_id for the project unbounded, then re-queried
+    // with `.in("id", docIds)` — that in-list grows with project size and
+    // eventually exceeds the client's ~16KB request-header budget, throwing
+    // `UND_ERR_HEADERS_OVERFLOW` before the request reaches the server. Any
+    // project past ~390-400 active documents hit this 100% of the time.)
+    query = query.eq("cerefox_document_projects.project_id", projectId);
   }
 
   const { data, error } = await query;
@@ -89,7 +85,15 @@ async function action(options: {
     throw systemError(`Could not list documents: ${error.message}`);
   }
 
-  const rows = (data ?? []) as DocRow[];
+  // The embedded `cerefox_document_projects` relation is only present to let
+  // PostgREST filter on it server-side (`.eq()` above); it's not part of the
+  // documented row shape, so drop it before returning/printing.
+  const rows = ((data ?? []) as unknown[]).map((row) => {
+    const { cerefox_document_projects: _junction, ...doc } = row as DocRow & {
+      cerefox_document_projects?: unknown;
+    };
+    return doc as DocRow;
+  });
 
   if (options.json) {
     printJson(rows);
@@ -97,7 +101,11 @@ async function action(options: {
   }
 
   if (rows.length === 0) {
-    process.stdout.write(deleted ? "(trash is empty)\n" : "(no documents)\n");
+    if (projectId) {
+      process.stdout.write(`(no documents in project "${options.project}")\n`);
+    } else {
+      process.stdout.write(deleted ? "(trash is empty)\n" : "(no documents)\n");
+    }
     return;
   }
 

--- a/packages/memory/test/read-commands.test.ts
+++ b/packages/memory/test/read-commands.test.ts
@@ -91,6 +91,34 @@ describe("cerefox read commands (live)", () => {
     expect(stderr).toContain("not found");
   });
 
+  test(
+    "list-docs: --project scoping doesn't error at scale, for every project in the KB",
+    () => {
+      // Regression coverage for the unbounded `id=in.(...)` bug: a
+      // project-scoped `document list` used to build its filter from every
+      // active document_id in the project before applying `--limit`, so once
+      // a project's document count pushed that URL past ~16KB, Node's fetch
+      // threw UND_ERR_HEADERS_OVERFLOW before the request ever reached the
+      // server. Iterating every real project here (rather than a fixed doc
+      // count) means this catches the regression in any KB the moment a
+      // project grows past that threshold, with no synthetic fixture needed.
+      const projects = JSON.parse(run(["project", "list", "--json"]).stdout) as Array<{
+        id: string;
+        name: string;
+      }>;
+      expect(Array.isArray(projects)).toBe(true);
+      for (const p of projects) {
+        const { status, stderr } = run(["document", "list", "--project", p.name, "--json"]);
+        expect(status).toBe(0);
+        if (status !== 0) {
+          // eslint-disable-next-line no-console
+          console.error(`project "${p.name}" failed:`, stderr);
+        }
+      }
+    },
+    30000,
+  );
+
   test("list-metadata-keys: returns key/doc_count/example_values", () => {
     const { stdout, status } = run(["metadata", "keys", "--json"]);
     expect(status).toBe(0);


### PR DESCRIPTION
## Summary

Fixes #109 — `document list --project <name>` throwing `TypeError: fetch failed` (`UND_ERR_HEADERS_OVERFLOW`) once a project crosses ~390-400 active documents.

Root cause: project-scoped listing ran as two queries — an unbounded fetch of every `document_id` in the project, then a second query filtering `cerefox_documents` with `.in("id", docIds)`. That id list, and therefore the request URL, grows linearly with project size and eventually exceeds Node/undici's ~16KB header budget. `--limit` never bounded this, since it only applied to the second query's row count.

## Fix

Replace the two-query/unbounded-`.in()` pattern with a single PostgREST embedded-resource query, filtered server-side:

```ts
.select(`${docCols}, cerefox_document_projects!inner(project_id)`)
.eq("cerefox_document_projects.project_id", projectId)
```

This is bounded by `--limit` regardless of how many documents the project holds — the request no longer scales with project size at all. The embedded `cerefox_document_projects` relation is stripped from each row before output, so `--json`/table output is unchanged from before this fix.

Also restores the friendlier `(no documents in project "X")` empty-state message. Previously this was an early return before the main query even ran (based on the now-removed junction-lookup step); now the inner join just returns zero rows naturally, so the message is produced by the existing post-query empty check instead.

## Verification

- Reproduced the original failure directly against a live project (516 active docs) before the fix; confirmed the identical query returns clean `HTTP 200` via `curl`, isolating the failure to the Node/undici client rather than the server (details in the linked issue).
- After the fix, the same project's full unbounded listing (`--limit 1000`) succeeds and returns all 516+ docs.
- `--json` output shape is unchanged (verified no `cerefox_document_projects` leakage into the response).
- Existing `list-docs` live tests in `packages/memory/test/read-commands.test.ts` pass unmodified.
- Added a new live regression test, `list-docs: --project scoping doesn't error at scale, for every project in the KB`: iterates every project visible to the configured Supabase instance and asserts `document list --project <name>` exits 0. It's data-driven (no synthetic fixture/hardcoded doc count), so it exercises the original failure mode automatically in any environment where a project happens to be large enough — including the environment this fix was developed against, where it exercised the actual 516-doc project that originally failed.
- `bun run build` and `bunx tsc --noEmit` on `packages/memory` are clean for the touched file (the ternary select string needed widening to `string` since the typed postgrest-js select-parser doesn't recognize `!inner` embed-hint syntax at the type level, even though it's valid at runtime).

## Scope

Only `list-docs.ts` (project-scoped `document list`) is touched. Similar junction-then-`.in()` queries exist in `packages/memory/src/web/routes/discovery.ts` (`getProjectsForDocuments`, `getProjectDocCounts`) but operate on bounded inputs in the call sites checked — out of scope here, flagged in the issue as worth a follow-up audit.
