### PR TITLE
iter-28H beta.2 follow-ups: deploy --yes, macOS keychain UX, #110 CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,25 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
-Open roadmap.
+### Fixed
+- **`cerefox document list --project` no longer fails on large projects** (#109,
+  #110 — thanks [@tdebasis](https://github.com/tdebasis)!). Project-scoped
+  listing used to fetch every document id in the project and replay them in an
+  `id=in.(…)` filter, whose URL blew past the Node fetch ~16KB header budget
+  once a project crossed roughly 400 active documents
+  (`UND_ERR_HEADERS_OVERFLOW`). It is now a single PostgREST embedded-resource
+  query, filtered server-side and genuinely bounded by `--limit`.
+
+### Added
+- **`cerefox server deploy --yes`** — skip the deployment confirmation for
+  scripted or agent-driven runs.
+
+### Changed
+- **EF deploys on macOS: keychain heads-up + `SUPABASE_ACCESS_TOKEN` documented.**
+  The Supabase CLI reads its login token from the macOS Keychain, firing a
+  password dialog per function deploy; the deploy pre-flight now warns about
+  this up-front, and `configuration.md` documents setting `SUPABASE_ACCESS_TOKEN`
+  in `~/.cerefox/.env` to skip the dialogs entirely.
 
 ---
 

--- a/_shared/__tests__/mcp-auth.test.ts
+++ b/_shared/__tests__/mcp-auth.test.ts
@@ -35,7 +35,9 @@ function strToB64Url(s: string): string {
 }
 
 let keyPair: CryptoKeyPair;
-let publicJwk: JsonWebKey;
+// `kid` is a standard JWK member (RFC 7517 §4.5) but missing from the TS lib's
+// JsonWebKey type, so widen it here.
+let publicJwk: JsonWebKey & { kid?: string };
 
 beforeAll(async () => {
   keyPair = (await crypto.subtle.generateKey(

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -13,18 +13,6 @@
 
 ## Known Tasks (Not Yet Scheduled)
 
-### Deploy UX (found dogfooding 1.0.1-beta.1, 2026-08-01)
-- [ ] **`cerefox server deploy --yes`** — there is no non-interactive confirm, so
-  scripted/agent-driven deploys must pipe `y` into stdin. Add a `--yes` flag
-  (mirroring `self-update --yes`).
-- [ ] **Document `SUPABASE_ACCESS_TOKEN` in `configuration.md` + deploy pre-flight**
-  — on macOS the Supabase CLI reads its login token from the Keychain, which fires
-  a password dialog *per function deploy* (9× per full deploy; denying strands the
-  deploy mid-run with `LegacyPlatformAuthRequiredError`). Setting
-  `SUPABASE_ACCESS_TOKEN` in `~/.cerefox/.env` bypasses the keychain entirely
-  (the config loader exports it to the child CLI). Document it; consider having
-  the deploy pre-flight suggest it when the token is absent on darwin.
-
 ### Data Safety
 - [ ] **Metadata versioning / recovery** — version snapshots capture content only;
   a metadata wipe is unrecoverable (bit us in the v0.11.1 incident). Proposal with

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -518,6 +518,13 @@ The success message echoes the resolved author / author_type back so you can sur
 | `--schema-only` | flag | off | Deploy only schema + RPCs (skip Edge Functions). |
 | `--functions-only` | flag | off | Deploy only the 9 Edge Functions (skip schema). |
 | `--dry-run` | flag | off | Preview what would happen; make no changes. |
+| `--project-ref <ref>` | string | derived from `CEREFOX_SUPABASE_URL` | Supabase project ref for the Edge Function deploys (needed only for custom domains, where the ref can't be derived). |
+| `--yes` | flag | off | Skip the deployment confirmation (for scripted/non-interactive runs). |
+
+> **macOS**: the Edge Function step shells out to the Supabase CLI, which reads its
+> login token from the Keychain — expect a password dialog per function (click
+> "Always Allow"). To skip the dialogs, set `SUPABASE_ACCESS_TOKEN` in
+> `~/.cerefox/.env` — see [`configuration.md`](configuration.md#supabase--database).
 
 Detects fresh vs. existing databases: a fresh DB gets schema + RPCs + migration stamps; an existing DB gets pending migrations applied and `rpcs.sql` re-applied in place. There is deliberately **no `--reset`** here — the destructive wipe lives only in the contributor script `bun scripts/db_deploy.ts --reset`. See [`setup-supabase.md`](setup-supabase.md).
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -43,11 +43,13 @@ Full rule documented in [`docs/specs/polish-and-distribution-design.md` §7](../
 | `CEREFOX_ACCESS_TOKENS` | `""` | Server-side (Function secret) | The **server-side accepted set** — a comma-separated list of Cerefox tokens, set as a Supabase **Function secret** (not local `.env`). A request is accepted if its Bearer matches any token in the set, enabling zero-downtime rotation. Managed by `cerefox token generate` / `rotate`. |
 | `CEREFOX_SUPABASE_ANON_KEY` | `""` | *(deprecated / unused)* | Formerly the legacy anon JWT Bearer for Edge Function calls. **Retired in iter-28E** — Edge Functions now authenticate the Cerefox access token in-function. Retained only so an old `.env` still parses; no longer read. |
 | `CEREFOX_DATABASE_URL` | `""` | For scripts | Direct Postgres URL for deployment scripts. **Use the Session Pooler** (port `5432`) — Transaction Pooler (`6543`) does not support DDL. Username must include the project-ref suffix (`postgres.<project-ref>`). Append `?sslmode=require`. See [`setup-supabase.md` → Connection pooling (2026)](setup-supabase.md#connection-pooling-2026). |
+| `SUPABASE_ACCESS_TOKEN` | *(unset)* | For EF deploys (optional) | Supabase **personal access token** (`sbp_…`, from [supabase.com/dashboard/account/tokens](https://supabase.com/dashboard/account/tokens)), read by the **Supabase CLI** that `cerefox server deploy` shells out to for Edge Function deploys. Optional — without it the CLI falls back to its `supabase login` credential, which on **macOS lives in the Keychain and triggers a password dialog per function deploy** (9 per full deploy; a denied dialog fails that function with `LegacyPlatformAuthRequiredError`). Setting it in `~/.cerefox/.env` avoids the dialogs entirely: Cerefox exports every key from its `.env` to the environment, so the child CLI inherits it. Not a `CEREFOX_` variable — the name is the Supabase CLI's own. **Keep secret** (it grants management access to your Supabase account). |
 
 **When each is needed:**
 - `CEREFOX_SUPABASE_URL` + `CEREFOX_SUPABASE_KEY` — used by the CLI, web UI, and local MCP server (ingestion, search) via the Supabase Data API
 - `CEREFOX_ACCESS_TOKEN` — used to call the Edge Functions (remote MCP, GPT Actions, direct HTTP) and by `cerefox doctor` / the live e2e tests; `CEREFOX_ACCESS_TOKENS` is its server-side counterpart (the accepted set). Generate both with `cerefox token generate`.
 - `CEREFOX_DATABASE_URL` — used only for schema deploys (`cerefox server deploy`, or the contributor scripts `bun scripts/db_*.ts`) via a direct Postgres connection
+- `SUPABASE_ACCESS_TOKEN` — optional; only consumed by the Supabase CLI during `cerefox server deploy` Edge Function deploys (recommended on macOS to avoid per-function Keychain dialogs)
 
 ---
 

--- a/docs/guides/setup-supabase.md
+++ b/docs/guides/setup-supabase.md
@@ -128,6 +128,15 @@ npx supabase link         # prompts for your project ref (the ID in your Supabas
 Your project ref is in the Supabase dashboard URL:
 `https://supabase.com/dashboard/project/<project-ref>`
 
+> **macOS Keychain dialogs**: the Supabase CLI stores the `login` token in the
+> Keychain and reads it back **once per function deploy** — expect up to 9
+> password dialogs per full deploy (click **"Always Allow"**; denying one fails
+> that function with `LegacyPlatformAuthRequiredError`). To skip the Keychain
+> entirely, create a personal access token at
+> [supabase.com/dashboard/account/tokens](https://supabase.com/dashboard/account/tokens)
+> and set it in `~/.cerefox/.env` as `SUPABASE_ACCESS_TOKEN=sbp_…` — see
+> [`configuration.md`](configuration.md#supabase--database).
+
 After it finishes, verify in the Supabase Dashboard → **Edge Functions** — all 9
 functions should appear with a green "Active" status.
 

--- a/docs/guides/upgrading.md
+++ b/docs/guides/upgrading.md
@@ -30,7 +30,9 @@ cerefox doctor           # verify
 database it applies **every** pending migration (regardless of which version
 you're coming from — so there are no per-version steps to follow), re-applies
 `rpcs.sql`, and redeploys all nine Edge Functions from npm-bundled assets. No
-repo clone required.
+repo clone required. On **macOS**, set `SUPABASE_ACCESS_TOKEN` in
+`~/.cerefox/.env` first to avoid a Keychain password dialog per function deploy
+(see [`configuration.md`](configuration.md#supabase--database)).
 
 **Re-embed only when a release says so.** If a release changes the embedding
 model or FTS / title weighting, also run `cerefox server reindex --all` — that's

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -3531,6 +3531,19 @@ Strict SemVer becomes binding. **Design**: [`docs/specs/polish-and-distribution-
 
 ### 28H — v1.0.1 (post-release fixes; first patch of the stable line)
 
+**Update (2026-08-01): beta.1 installed + validated on BOTH worlds.** Cloud:
+migration 0013 applied to prod (schema 0.8.2 — the existing-DB half of #26
+validated), 9 EFs redeployed, doctor green. Local: upgraded via the env-override
+path (the 1.0.0 host script predates the `upgrade <tag>` verb — bootstrap
+chicken-and-egg, same class as #106; the verb itself gets its live test on the
+NEXT upgrade). Also merged **#110** (@tdebasis's fix for #109: project-scoped
+`document list` blowing the ~16KB fetch header budget past ~400 docs — single
+`!inner` embed now) and scoped a **beta.2** with it + two dogfood findings:
+`server deploy --yes`, and the macOS Keychain dialog storm on EF deploys
+(pre-flight heads-up + `SUPABASE_ACCESS_TOKEN` documented in configuration.md).
+Branch: `iter-28h/beta2-followups`. Fresh-Supabase #26 validation still pending
+(supervised) before stable 1.0.1.
+
 **Status: BUILT + `1.0.1-beta.1` CUT (2026-07-18); dogfood + validation pending.**
 All 7 items implemented on `iter-28h/v1.0.1`, merged via PR #108; `1.0.1-beta.1`
 published to npm (beta dist-tag) and ghcr (`v1.0.1-beta.1`, `:latest` untouched).

--- a/packages/memory/src/cli/commands/deploy-server.ts
+++ b/packages/memory/src/cli/commands/deploy-server.ts
@@ -24,7 +24,8 @@
  *
  * Flags: --dry-run (plan only, no prompt), --schema-only, --functions-only,
  * --project-ref (override the ref derived from CEREFOX_SUPABASE_URL for EF
- * deploys). There is deliberately NO --reset (drop-everything) here — a full wipe is a
+ * deploys), --yes (skip the confirmation, for scripted/agent-driven runs).
+ * There is deliberately NO --reset (drop-everything) here — a full wipe is a
  * contributor/recovery operation; use `bun scripts/db_deploy.ts --reset`
  * (repo clone, typed-`yes` guard) if you truly need it.
  */
@@ -56,6 +57,7 @@ interface DeployServerOptions {
   schemaOnly?: boolean;
   functionsOnly?: boolean;
   projectRef?: string;
+  yes?: boolean;
 }
 
 /** One pre-flight check + its remediation when failed. */
@@ -216,6 +218,23 @@ async function action(options: DeployServerOptions): Promise<void> {
   }
   println(c.green("\n✓ All prerequisites satisfied."));
 
+  // On macOS the Supabase CLI reads its login token from the Keychain, firing a
+  // password dialog PER function deploy (9× per full run) — and a denied dialog
+  // strands the deploy mid-run with LegacyPlatformAuthRequiredError. Setting
+  // SUPABASE_ACCESS_TOKEN skips the Keychain entirely; the config loader exports
+  // ~/.cerefox/.env into process.env, so the child CLI inherits it from there.
+  if (doFunctions && process.platform === "darwin" && !process.env.SUPABASE_ACCESS_TOKEN) {
+    println(
+      c.cyan(
+        "\n  ℹ  Heads-up (macOS): the Supabase CLI will read its login token from the\n" +
+          "     Keychain — expect a password dialog per function (click \"Always Allow\").\n" +
+          "     To skip the dialogs entirely, put a personal access token\n" +
+          "     (supabase.com/dashboard/account/tokens) in ~/.cerefox/.env:\n" +
+          "       SUPABASE_ACCESS_TOKEN=sbp_…",
+      ),
+    );
+  }
+
   // ── Detect fresh vs existing (read-only probe) ───────────────────────────
   let schemaMode: "fresh" | "existing" | "unknown" = "unknown";
   let pending: string[] = [];
@@ -264,10 +283,12 @@ async function action(options: DeployServerOptions): Promise<void> {
     process.exit(0);
   }
 
-  const proceed = await confirm("\nProceed with deployment to Supabase?", true /* default No */);
-  if (!proceed) {
-    println(c.dim("Aborted."));
-    process.exit(0);
+  if (!options.yes) {
+    const proceed = await confirm("\nProceed with deployment to Supabase?", true /* default No */);
+    if (!proceed) {
+      println(c.dim("Aborted."));
+      process.exit(0);
+    }
   }
 
   // ── Schema ────────────────────────────────────────────────────────────────
@@ -411,5 +432,6 @@ export function registerDeployServer(program: Command): void {
       "--project-ref <ref>",
       "Supabase project ref for Edge Function deploys (default: derived from CEREFOX_SUPABASE_URL).",
     )
+    .option("--yes", "Non-interactive (skip the deployment confirmation).")
     .action(action);
 }

--- a/packages/memory/test/read-commands.test.ts
+++ b/packages/memory/test/read-commands.test.ts
@@ -109,11 +109,11 @@ describe("cerefox read commands (live)", () => {
       expect(Array.isArray(projects)).toBe(true);
       for (const p of projects) {
         const { status, stderr } = run(["document", "list", "--project", p.name, "--json"]);
-        expect(status).toBe(0);
         if (status !== 0) {
           // eslint-disable-next-line no-console
           console.error(`project "${p.name}" failed:`, stderr);
         }
+        expect(status).toBe(0);
       }
     },
     30000,


### PR DESCRIPTION
## Summary
Follow-ups scoped for `1.0.1-beta.2`, all found dogfooding beta.1:

- **`cerefox server deploy --yes`** — non-interactive confirm for scripted/agent-driven deploys (previously required piping `y` into stdin).
- **macOS Keychain UX for EF deploys**: pre-flight now prints a heads-up when `SUPABASE_ACCESS_TOKEN` is unset on darwin (the Supabase CLI otherwise fires a Keychain password dialog *per function* — 9 per full deploy — and a denied dialog fails that function with `LegacyPlatformAuthRequiredError`). `configuration.md` documents setting `SUPABASE_ACCESS_TOKEN` in `~/.cerefox/.env` to skip the Keychain entirely.
- **CHANGELOG** entry crediting #109/#110 (@tdebasis's large-project `document list` fix, merged separately).
- **Test polish**: the per-project diagnostic in #110's regression test now logs before the assertion (was unreachable); widened `JsonWebKey` with `kid` in `mcp-auth.test.ts` (pre-existing typecheck break from TS lib drift).
- plan.md / TODO.md bookkeeping.

## Test plan
- [x] `bun run typecheck` clean (including the pre-existing mcp-auth break, now fixed)
- [x] `_shared` suite: 282 pass / 0 fail
- [x] Package build + suite: 153 pass / 0 fail (live, incl. #110's regression test)
- [x] Built-bin smoke: `--yes` registered; keychain heads-up fires with token unset, silent with token present
- [ ] Cut `1.0.1-beta.2` and dogfood (upgrade path itself live-tests 28H item 3 + #106)

🤖 Generated with [Claude Code](https://claude.com/claude-code)