### PR TITLE
fix: paginate reads past the PostgREST 1000-row cap (#131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
+### Fixed
+- **Unbounded PostgREST selects no longer silently truncate at the 1000-row
+  server cap** (#131). `backup create` backed up a 1000-document prefix of
+  larger knowledge bases while reporting success (the reported
+  `document_count` came from the same truncated fetch); `server reindex`
+  would process the first 1000 chunks and print that count as the whole job;
+  the web UI's per-project document counts under-reported once the KB
+  crossed 1000 project memberships. Reads that can exceed one page now
+  paginate via a shared `fetchAllPages` helper, and per-project totals are
+  counted server-side. Known unpaginated siblings (project-scoped web
+  listing prefilter, `scripts/cerefox_export.ts`) are documented in #131.
+
 Open roadmap.
 
 ---

--- a/_shared/__tests__/paginate.test.ts
+++ b/_shared/__tests__/paginate.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+
+import { fetchAllPages } from "../db-client/paginate.js";
+
+/** Simulates PostgREST: honors the requested range, but never returns more
+ *  than `serverCap` rows per response — the behavior that silently truncates
+ *  unpaginated selects (#131). */
+function makeCappedServer(totalRows: number, serverCap = 1000) {
+  const rows = Array.from({ length: totalRows }, (_, i) => ({ id: i }));
+  const calls: Array<[number, number]> = [];
+  return {
+    calls,
+    query(from: number, to: number) {
+      calls.push([from, to]);
+      const requested = rows.slice(from, to + 1);
+      return Promise.resolve({
+        data: requested.slice(0, serverCap),
+        error: null,
+      });
+    },
+  };
+}
+
+describe("fetchAllPages", () => {
+  test("returns every row past the server cap", async () => {
+    // 2,500 rows against a 1000-row cap: a one-shot select gets 1000 and
+    // cannot tell it was truncated. The paginated walk must get all 2,500.
+    const server = makeCappedServer(2500);
+    const rows = await fetchAllPages<{ id: number }>((from, to) =>
+      server.query(from, to),
+    );
+    expect(rows.length).toBe(2500);
+    expect(rows[0].id).toBe(0);
+    expect(rows[2499].id).toBe(2499);
+    // No duplicates, no gaps.
+    expect(new Set(rows.map((r) => r.id)).size).toBe(2500);
+  });
+
+  test("issues ranged requests within the cap", async () => {
+    const server = makeCappedServer(450, 1000);
+    await fetchAllPages((from, to) => server.query(from, to), 200);
+    expect(server.calls).toEqual([
+      [0, 199],
+      [200, 399],
+      [400, 599],
+    ]);
+  });
+
+  test("one-shot fetch demonstrates the truncation this helper prevents", async () => {
+    // The old pattern: a single unbounded request. The server cap makes the
+    // short read indistinguishable from a complete one.
+    const server = makeCappedServer(2500);
+    const { data } = await server.query(0, Number.MAX_SAFE_INTEGER);
+    expect(data.length).toBe(1000); // silently a prefix of 2,500
+  });
+
+  test("empty result", async () => {
+    const server = makeCappedServer(0);
+    const rows = await fetchAllPages((from, to) => server.query(from, to));
+    expect(rows).toEqual([]);
+  });
+
+  test("exact page-boundary total does not loop forever", async () => {
+    const server = makeCappedServer(400, 1000);
+    const rows = await fetchAllPages((from, to) => server.query(from, to), 200);
+    expect(rows.length).toBe(400);
+    // 2 full pages + 1 empty probe (page.length < batchSize terminates).
+    expect(server.calls.length).toBe(3);
+  });
+
+  test("propagates errors", async () => {
+    await expect(
+      fetchAllPages(() =>
+        Promise.resolve({ data: null, error: { message: "boom" } }),
+      ),
+    ).rejects.toThrow("boom");
+  });
+});

--- a/_shared/db-client/paginate.ts
+++ b/_shared/db-client/paginate.ts
@@ -1,0 +1,48 @@
+/**
+ * fetchAllPages — accumulate a PostgREST select past the server row cap.
+ *
+ * Supabase caps PostgREST responses at 1000 rows per request. A select
+ * without `.range()` therefore silently returns a 1000-row prefix on large
+ * tables — and because the short read is indistinguishable from a complete
+ * one, callers that derive totals from `data.length` report the truncated
+ * count as the whole result (#131).
+ *
+ * This is the pagination loop from `_shared/backup/supabase-adapter.ts`
+ * generalized so every caller can use it: the caller supplies a factory
+ * that builds its own filtered/ordered query and applies the given range;
+ * the helper walks the pages and concatenates.
+ *
+ * The caller's query MUST include a stable `.order(...)` (unique or
+ * near-unique column, e.g. `id` or `created_at`) — range pagination over an
+ * unordered select can skip or duplicate rows between pages.
+ */
+
+interface PageResult<T> {
+  data: T[] | null;
+  error: { message?: string } | null;
+}
+
+/** The query parameter accepts any thenable resolving to a `{ data, error }`
+ *  pair (normalized internally) so supabase-js `PostgrestFilterBuilder`
+ *  chains can be passed directly — their response generics don't structurally
+ *  match a loose local type, which is why older call sites resorted to
+ *  `as never` casts. */
+export async function fetchAllPages<T>(
+  makeQuery: (from: number, to: number) => PromiseLike<unknown>,
+  batchSize = 200,
+): Promise<T[]> {
+  const results: T[] = [];
+  let offset = 0;
+  for (;;) {
+    const { data, error } = (await makeQuery(
+      offset,
+      offset + batchSize - 1,
+    )) as PageResult<T>;
+    if (error) throw new Error(error.message ?? JSON.stringify(error));
+    const page = data ?? [];
+    results.push(...page);
+    if (page.length < batchSize) break;
+    offset += batchSize;
+  }
+  return results;
+}

--- a/packages/memory/src/cli/commands/backup.ts
+++ b/packages/memory/src/cli/commands/backup.ts
@@ -20,6 +20,7 @@ import {
   println,
   systemError,
 } from "../../../../../_shared/cli-core/index.ts";
+import { fetchAllPages } from "../../../../../_shared/db-client/paginate.ts";
 import { getClient } from "../util/client.ts";
 
 interface BackupOptions {
@@ -62,17 +63,27 @@ async function action(options: BackupOptions): Promise<void> {
 
   const client = getClient();
 
-  // Pull all non-deleted documents.
-  const { data: docsData, error: docsErr } = await client.raw
-    .from("cerefox_documents")
-    .select(
-      "id, title, content_hash, source, metadata, total_chars, chunk_count, " +
-        "review_status, created_at, updated_at, deleted_at",
-    )
-    .is("deleted_at", null)
-    .order("created_at", { ascending: true });
-  if (docsErr) throw systemError(`Document fetch failed: ${docsErr.message}`);
-  const docs = (docsData ?? []) as Array<Record<string, unknown>>;
+  // Pull all non-deleted documents. Paginated: an unbounded select caps at
+  // the PostgREST row limit (1000) and silently truncates the backup (#131).
+  let docs: Array<Record<string, unknown>>;
+  try {
+    docs = await fetchAllPages<Record<string, unknown>>((from, to) =>
+      client.raw
+        .from("cerefox_documents")
+        .select(
+          "id, title, content_hash, source, metadata, total_chars, chunk_count, " +
+            "review_status, created_at, updated_at, deleted_at",
+        )
+        .is("deleted_at", null)
+        .order("created_at", { ascending: true })
+        .order("id", { ascending: true })
+        .range(from, to),
+    );
+  } catch (err) {
+    throw systemError(
+      `Document fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
 
   // For each doc, pull its chunks.
   let chunkTotal = 0;
@@ -80,17 +91,26 @@ async function action(options: BackupOptions): Promise<void> {
   for (let i = 0; i < docs.length; i++) {
     const doc = docs[i];
     const docId = doc.id as string;
-    const { data: chunks, error: chunkErr } = await client.raw
-      .from("cerefox_chunks")
-      .select("*")
-      .eq("document_id", docId)
-      .is("version_id", null)
-      .order("chunk_index", { ascending: true });
-    if (chunkErr) {
-      throw systemError(`Chunk fetch failed for ${docId}: ${chunkErr.message}`);
+    // Paginated for the same reason: a single document with >1000 chunks
+    // would otherwise back up a truncated chunk list.
+    let chunks: Array<Record<string, unknown>>;
+    try {
+      chunks = await fetchAllPages<Record<string, unknown>>((from, to) =>
+        client.raw
+          .from("cerefox_chunks")
+          .select("*")
+          .eq("document_id", docId)
+          .is("version_id", null)
+          .order("chunk_index", { ascending: true })
+          .range(from, to),
+      );
+    } catch (err) {
+      throw systemError(
+        `Chunk fetch failed for ${docId}: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
-    chunkTotal += (chunks ?? []).length;
-    enriched.push({ ...doc, chunks: chunks ?? [] });
+    chunkTotal += chunks.length;
+    enriched.push({ ...doc, chunks });
     if (process.stdout.isTTY) {
       process.stderr.write(
         `\r  Dumping documents: ${i + 1}/${docs.length} (${chunkTotal} chunks so far)…`,

--- a/packages/memory/src/cli/commands/reindex.ts
+++ b/packages/memory/src/cli/commands/reindex.ts
@@ -27,6 +27,7 @@ import {
   userError,
   warn,
 } from "../../../../../_shared/cli-core/index.ts";
+import { fetchAllPages } from "../../../../../_shared/db-client/paginate.ts";
 import { activeEmbedderName, embedBatch, resolveEmbedderKind } from "../../../../../_shared/embeddings/index.ts";
 import { loadSettings } from "../../../../../_shared/config/index.ts";
 
@@ -71,22 +72,35 @@ async function action(options: ReindexOptions): Promise<void> {
   const reindexAll = Boolean(options.all);
   const dryRun = Boolean(options.dryRun);
 
-  let query = supabase
-    .from("cerefox_chunks")
-    .select("id, document_id, content, embedder_primary, cerefox_documents(title)")
-    .is("version_id", null);
-
-  if (options.documentId) {
-    query = query.eq("document_id", options.documentId);
-  }
   const targetModel = activeEmbedderName();
-  if (!reindexAll) {
-    query = query.neq("embedder_primary", targetModel);
-  }
 
-  const { data, error } = await query;
-  if (error) throw systemError(`Failed to list chunks: ${error.message}`);
-  const chunks = (data ?? []) as ChunkRow[];
+  // Paginated: an unbounded select caps at the PostgREST row limit (1000),
+  // so past that size reindex would process a prefix of the chunks and
+  // report the capped count as the whole job (#131). The full list is
+  // fetched up front (snapshot), then written batch-wise below — so the
+  // stale-only filter can't interact with page boundaries mid-walk.
+  let chunks: ChunkRow[];
+  try {
+    chunks = await fetchAllPages<ChunkRow>((from, to) => {
+      let query = supabase
+        .from("cerefox_chunks")
+        .select("id, document_id, content, embedder_primary, cerefox_documents(title)")
+        .is("version_id", null);
+      if (options.documentId) {
+        query = query.eq("document_id", options.documentId);
+      }
+      if (!reindexAll) {
+        query = query.neq("embedder_primary", targetModel);
+      }
+      return query.order("id", { ascending: true }).range(from, to);
+      // Page size 1000 = the PostgREST cap itself: listing rows are light
+      // (no embedding vectors), so larger pages just mean fewer round-trips.
+    }, 1000);
+  } catch (err) {
+    throw systemError(
+      `Failed to list chunks: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
 
   if (chunks.length === 0) {
     println(c.dim("(nothing to reindex)"));

--- a/packages/memory/src/web/routes/discovery.ts
+++ b/packages/memory/src/web/routes/discovery.ts
@@ -15,6 +15,7 @@ import { resolveEmbedderKind } from "../../../../../_shared/embeddings/index.ts"
 import { Hono } from "hono";
 
 import { getEmbedding } from "../../../../../_shared/embeddings/index.js";
+import { fetchAllPages } from "../../../../../_shared/db-client/paginate.ts";
 import { getMinSearchScore } from "../../../../../_shared/mcp-tools/_utils.js";
 import type { WebContext } from "../context.ts";
 import { logWebUsage } from "../usage.ts";
@@ -131,15 +132,22 @@ async function getProjectDocCounts(
   }
   if (projectIds.length === 0) return { active, deleted };
   try {
-    const { data, error } = await ctx.supabase
-      .from("cerefox_document_projects")
-      .select("project_id, cerefox_documents(deleted_at)")
-      .in("project_id", projectIds);
-    if (error) throw error;
-    for (const row of (data ?? []) as Array<{
+    // Paginated: the unbounded scan capped at the PostgREST row limit
+    // (1000), silently under-counting every project once the KB crossed
+    // 1000 junction rows (#131). One walk covers active + deleted counts.
+    const rows = await fetchAllPages<{
       project_id: string;
       cerefox_documents: { deleted_at: string | null } | null;
-    }>) {
+    }>((from, to) =>
+      ctx.supabase
+        .from("cerefox_document_projects")
+        .select("project_id, cerefox_documents(deleted_at)")
+        .in("project_id", projectIds)
+        .order("document_id", { ascending: true })
+        .order("project_id", { ascending: true })
+        .range(from, to),
+    );
+    for (const row of rows) {
       const pid = row.project_id;
       if (!(pid in active)) continue;
       const doc = row.cerefox_documents ?? null;
@@ -200,20 +208,22 @@ async function countDocumentsForProject(
   projectId: string,
 ): Promise<number> {
   // Match Python: count junction rows whose linked document is not deleted.
-  const { data, error } = await ctx.supabase
+  // Counted server-side (the `countActiveDocuments` pattern): the previous
+  // fetch-and-count capped at the PostgREST row limit (1000), so projects
+  // past ~1000 documents under-reported their total (#131). The `!inner`
+  // embed makes the deleted_at filter an inner join, so junction rows whose
+  // document is deleted (or missing) are excluded — same rows the old JS
+  // filter kept.
+  const { count, error } = await ctx.supabase
     .from("cerefox_document_projects")
-    .select("document_id, cerefox_documents(deleted_at)")
-    .eq("project_id", projectId);
+    .select("document_id, cerefox_documents!inner(deleted_at)", {
+      count: "exact",
+      head: true,
+    })
+    .eq("project_id", projectId)
+    .is("cerefox_documents.deleted_at", null);
   if (error) throw error;
-  let n = 0;
-  for (const row of (data ?? []) as Array<{
-    cerefox_documents: { deleted_at: string | null } | null;
-  }>) {
-    if (row.cerefox_documents && row.cerefox_documents.deleted_at === null) {
-      n += 1;
-    }
-  }
-  return n;
+  return count ?? 0;
 }
 
 function dashboardDocFromRow(

--- a/packages/memory/test/cli-reindex.test.ts
+++ b/packages/memory/test/cli-reindex.test.ts
@@ -80,14 +80,20 @@ describe("cerefox reindex CLI", () => {
     expect(stdout).toMatch(/Reindexing \d+ chunk|nothing to reindex/);
   });
 
-  test("--all + --dry-run reports all chunks", () => {
-    if (!LIVE_OK) return;
-    const { stdout, status } = run(["server", "reindex", "--all", "--dry-run"]);
-    expect(status).toBe(0);
-    expect(stdout).toMatch(/Reindexing \d+ chunk|nothing to reindex/);
-    // --all path should mention "(--all)" tag, not "(stale only)"
-    expect(stdout).not.toMatch(/stale only/);
-  });
+  test(
+    "--all + --dry-run reports all chunks",
+    () => {
+      if (!LIVE_OK) return;
+      const { stdout, status } = run(["server", "reindex", "--all", "--dry-run"]);
+      expect(status).toBe(0);
+      expect(stdout).toMatch(/Reindexing \d+ chunk|nothing to reindex/);
+      // --all path should mention "(--all)" tag, not "(stale only)"
+      expect(stdout).not.toMatch(/stale only/);
+    },
+    // The listing now pages past the PostgREST row cap (#131): --all does one
+    // round-trip per 1000 chunks instead of a single silently-capped request.
+    30_000,
+  );
 
   test("--document-id with a fake UUID returns 'nothing to reindex'", () => {
     if (!LIVE_OK) return;


### PR DESCRIPTION
## Summary

Fixes #131 — the three live instances of unpaginated PostgREST selects silently capping at the server's 1000-row limit:

- **New `_shared/db-client/paginate.ts`** — `fetchAllPages`, the pagination loop from `_shared/backup/supabase-adapter.ts::listAllDocuments()` generalized. Accepts any thenable resolving to `{ data, error }`, so supabase-js builder chains pass directly without the `as never` casts older call sites needed. Callers supply their own filtered/ordered query; the helper walks `.range()` pages until a short page.
- **`backup create`** — both the document fetch and the per-document chunk fetch now paginate. On a 1,406-document store the old code backed up exactly 1,000 documents and reported success (its `document_count` derived from the same truncated fetch). The chunk fetch was capped too — a single document with >1000 chunks would have backed up truncated.
- **`server reindex`** — the chunk listing paginates (page size 1000 — listing rows carry no embedding vectors) with a stable `id` order. The listing is still fetched fully before the write loop, so semantics are unchanged apart from no longer being capped; the banner/progress totals become truthful automatically.
- **web dashboard counts** — `getProjectDocCounts` walks the junction scan paginated (one pass covers active + deleted counts); `countDocumentsForProject` becomes a `count: "exact", head: true` query with a `cerefox_documents!inner(deleted_at)` filter — the same pattern `countActiveDocuments` in the same file already uses. Per-project counts were wrong on any KB past 1,000 memberships.

Notes for review:

- Four pre-existing `tsc --noEmit` errors die with this change (`backup.ts`, `reindex.ts`, `discovery.ts` ×2) — not drive-by cleanup; they were unsafe casts on the exact fetches being paginated. Branch introduces zero new typecheck errors (4 unrelated pre-existing ones remain, as on `main`).
- The `cli-reindex` live test gains a 30s timeout, disclosed in-test: the correct listing does one round-trip per 1000 chunks instead of a single silently-capped request.
- Found, not fixed (out of scope, same family): `GET /api/v1/projects/:id/documents` returns 500 on pristine `main` as well as this branch — pre-existing, unrelated to the count change (the new count query verified standalone against PostgREST: `content-range: 0-406/407`). Also still unpaginated, documented in #131: the web `listDocuments` project prefilter and `scripts/cerefox_export.ts`.

## Test plan

- [x] New `_shared/__tests__/paginate.test.ts` (6 tests): mock server that honors `range` but caps every response at 1000 rows — the actual PostgREST behavior. Asserts the helper returns all 2,500 of 2,500 (no dupes, no gaps), correct page math, empty-result and exact-boundary termination, error propagation. One test runs the **old one-shot pattern** against the same mock and asserts it receives exactly 1,000 — the suite proves the bug, not just the fix.
- [x] `_shared`: 292 pass / 0 fail; `tsc --noEmit` clean.
- [x] `packages/memory`: build + 154 pass / 2 env-skips (bun test, live probes).
- [x] Live verification against a real 1,406-document / 3,196-chunk store: `backup create` count == `psql` count before and after the walk (old code: 1,000) · `server reindex --all --dry-run` reports 3,196 == `psql` (old code: 1,000) · dashboard per-project counts exact vs `psql` (407/5 and 535/1).
