### PR TITLE
1.0.6: consistent result counts, two-axis search header, alpha + EF-secret tunables, TODO retirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
+### Fixed
+- **Search result counts are consistent between chunk and document views**
+  (schema 0.9.1 → 0.9.2 — redeploy with `cerefox server deploy`). When no
+  result cleared the confidence threshold, the fallback capped *chunks* before
+  they were grouped into documents, so a knowledge base where one document
+  owned several of the top chunks returned fewer results than one where they
+  were spread out. The cap now counts documents.
+- **Search results header no longer conflates two different things.** It read
+  "ranked by documents relevance" in document mode, borrowing the result shape
+  into a slot that otherwise names a ranking method. It now states both, the
+  way the search controls already do: "12 results · documents ranked by hybrid
+  relevance".
+
+### Added
+- **`CEREFOX_SEARCH_ALPHA`** sets the default hybrid fusion weight (1.0 = pure
+  semantic, 0.0 = pure keyword), matching the other retrieval tunables; it was
+  previously per-call only.
+- **Retrieval tunables now apply to the remote MCP / Edge Function path too**,
+  when set as Supabase Function secrets — the shared helpers read `Deno.env`
+  in addition to `process.env`. Previously a server-side search silently used
+  built-in defaults no matter how the deployment was configured.
+
+### Changed
+- **`docs/TODO.md` is retired.** Its unscheduled items moved to GitHub issues
+  (#140–#149), where contributors actually look; obsolete entries (a bug fixed
+  by atomic ingestion, a script deleted with Python) were dropped. The file
+  remains as a pointer.
+
 Open roadmap.
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ cerefox/
 │   ├── requirements-and-specs.md  # Source of truth for requirements
 │   ├── solution-design.md         # Architecture and design decisions
 │   ├── plan.md                    # Implementation plan with progress
-│   └── TODO.md                    # Backlog and future ideas
+│   └── TODO.md                    # RETIRED at v1.0.6 — backlog lives in GitHub issues
 ├── src/
 │   └── cerefox/
 │       └── db/                    # SQL assets ONLY (not Python) — bundled by the TS deploy
@@ -364,7 +364,7 @@ Kept accurate and current at all times:
 | `docs/requirements-and-specs.md` | Requirements | A requirement changes or is added/removed |
 | `docs/solution-design.md` | Architecture | A design decision is made or revised |
 | `docs/plan.md` | Progress + **cross-session hand-off** | A task starts, completes, or is re-scoped |
-| `docs/TODO.md` | Backlog | A new idea or future task surfaces |
+| GitHub issues | Backlog | A new idea or future task surfaces (`docs/TODO.md` retired at v1.0.6) |
 | `docs/e2e-use-cases.md` | Testing | An e2e test is added, removed, or changes status |
 | `CLAUDE.md` | Conventions | Project conventions or structure changes |
 
@@ -404,7 +404,7 @@ These live in `docs/guides/` and are written for someone who has never seen the 
 
 ## Quick Reference
 
-- **Docs**: `docs/plan.md` for current status, `docs/TODO.md` for backlog
+- **Docs**: `docs/plan.md` for current status; GitHub issues for the backlog
 - **Agent guides**: `AGENT_GUIDE.md` (comprehensive reference for AI agents using Cerefox tools), `AGENT_QUICK_REFERENCE.md` (minimal quick reference card -- 8 tools, key rules, workflows)
 - **Schema**: `src/cerefox/db/schema.sql`
 - **Config**: `.env` file or environment variables (see `_shared/config/`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to Cerefox! This guide explains what
 
 ## Where to Start
 
-Check `docs/TODO.md` for the current backlog of ideas and planned features. Pick something that interests you and fits your expertise. If you have a new idea, open an issue to discuss it before starting work.
+Check the [GitHub issues](https://github.com/fstamatelopoulos/cerefox/issues) for the current backlog — bugs, planned work, and unscheduled ideas all live there (`docs/TODO.md` was retired at v1.0.6). Pick something that interests you and fits your expertise; `docs/plan.md` shows what is actively in flight. If you have a new idea, open an issue to discuss it before starting work.
 
 ---
 

--- a/_shared/__tests__/search-below-confidence.test.ts
+++ b/_shared/__tests__/search-below-confidence.test.ts
@@ -147,3 +147,45 @@ describe("getMinTermCoverage env parsing (v1.0.4)", () => {
     expect(getMinTermCoverage()).toBeUndefined();
   });
 });
+
+describe("getSearchAlpha + Deno.env fallback (v1.0.6)", () => {
+  const { getSearchAlpha, DEFAULT_SEARCH_ALPHA } = require("../mcp-tools/_utils.ts");
+  const KEY = "CEREFOX_SEARCH_ALPHA";
+  const prior = process.env[KEY];
+  afterAll(() => {
+    if (prior === undefined) delete process.env[KEY];
+    else process.env[KEY] = prior;
+    delete (globalThis as { Deno?: unknown }).Deno;
+  });
+
+  test("unset → the built-in default", () => {
+    delete process.env[KEY];
+    expect(getSearchAlpha()).toBe(DEFAULT_SEARCH_ALPHA);
+  });
+
+  test("valid env value wins", () => {
+    process.env[KEY] = "0.25";
+    expect(getSearchAlpha()).toBe(0.25);
+  });
+
+  test("out-of-range falls back to the default", () => {
+    process.env[KEY] = "7";
+    expect(getSearchAlpha()).toBe(DEFAULT_SEARCH_ALPHA);
+  });
+
+  test("Deno.env is read when process.env has nothing (Edge Function secrets)", () => {
+    delete process.env[KEY];
+    (globalThis as { Deno?: unknown }).Deno = {
+      env: { get: (k: string) => (k === KEY ? "0.9" : undefined) },
+    };
+    expect(getSearchAlpha()).toBe(0.9);
+  });
+
+  test("process.env still wins over Deno.env", () => {
+    process.env[KEY] = "0.1";
+    (globalThis as { Deno?: unknown }).Deno = {
+      env: { get: () => "0.9" },
+    };
+    expect(getSearchAlpha()).toBe(0.1);
+  });
+});

--- a/_shared/mcp-tools/_utils.ts
+++ b/_shared/mcp-tools/_utils.ts
@@ -45,6 +45,51 @@ export const DEFAULT_MIN_SEARCH_SCORE = 0.5;
 export const DEFAULT_MIN_SEARCH_SCORE_LOCAL = 0.6;
 
 /**
+ * Read an env var in any of Cerefox's three runtimes.
+ *
+ * Node/Bun expose `process.env` (populated from the user's `.env` by
+ * `_shared/config`). Supabase Edge Functions run Deno, where `process` may be
+ * absent but **Function secrets are readable via `Deno.env`** — so reading
+ * both means a secret set on the project configures the remote MCP / EF path
+ * the same way `.env` configures the local one. (Before this, the retrieval
+ * tunables silently fell back to built-in defaults on the remote path.)
+ */
+function readEnv(name: string): string | undefined {
+  const g = globalThis as {
+    process?: { env?: Record<string, string | undefined> };
+    Deno?: { env?: { get(k: string): string | undefined } };
+  };
+  const fromProcess = g.process?.env?.[name];
+  if (fromProcess !== undefined && fromProcess !== "") return fromProcess;
+  try {
+    const fromDeno = g.Deno?.env?.get(name);
+    return fromDeno === "" ? undefined : fromDeno;
+  } catch {
+    // Deno without --allow-env: treat as unset.
+    return undefined;
+  }
+}
+
+/** Parse a 0–1 env value; undefined when unset or out of range. */
+function readUnitInterval(name: string): number | undefined {
+  const raw = readEnv(name);
+  if (raw === undefined) return undefined;
+  const n = Number.parseFloat(raw);
+  return Number.isNaN(n) || n < 0 || n > 1 ? undefined : n;
+}
+
+/**
+ * Default hybrid fusion weight: 1.0 = pure semantic, 0.0 = pure keyword.
+ * Overridable via `CEREFOX_SEARCH_ALPHA` (parity with the other retrieval
+ * tunables; previously alpha was per-call only).
+ */
+export const DEFAULT_SEARCH_ALPHA = 0.7;
+
+export function getSearchAlpha(): number {
+  return readUnitInterval("CEREFOX_SEARCH_ALPHA") ?? DEFAULT_SEARCH_ALPHA;
+}
+
+/**
  * Resolve the minimum cosine-similarity floor for hybrid/semantic search
  * (vector-only matches below this are dropped; FTS matches always pass).
  * Overridable via the `CEREFOX_MIN_SEARCH_SCORE` env var (0.0–1.0). The Python
@@ -56,16 +101,11 @@ export const DEFAULT_MIN_SEARCH_SCORE_LOCAL = 0.6;
  * EF path doesn't use the host `.env` anyway).
  */
 export function getMinSearchScore(): number {
-  const raw = (globalThis as { process?: { env?: Record<string, string | undefined> } })
-    .process?.env?.CEREFOX_MIN_SEARCH_SCORE;
   const fallback =
-    (globalThis as { process?: { env?: Record<string, string | undefined> } })
-      .process?.env?.CEREFOX_EMBEDDER === "local"
+    readEnv("CEREFOX_EMBEDDER") === "local"
       ? DEFAULT_MIN_SEARCH_SCORE_LOCAL
       : DEFAULT_MIN_SEARCH_SCORE;
-  if (raw === undefined || raw === "") return fallback;
-  const n = Number.parseFloat(raw);
-  return Number.isNaN(n) || n < 0 || n > 1 ? fallback : n;
+  return readUnitInterval("CEREFOX_MIN_SEARCH_SCORE") ?? fallback;
 }
 
 /**
@@ -76,11 +116,7 @@ export function getMinSearchScore(): number {
  * (an unknown named argument fails the PostgREST function match).
  */
 export function getMinTermCoverage(): number | undefined {
-  const raw = (globalThis as { process?: { env?: Record<string, string | undefined> } })
-    .process?.env?.CEREFOX_MIN_TERM_COVERAGE;
-  if (raw === undefined || raw === "") return undefined;
-  const n = Number.parseFloat(raw);
-  return Number.isNaN(n) || n < 0 || n > 1 ? undefined : n;
+  return readUnitInterval("CEREFOX_MIN_TERM_COVERAGE");
 }
 
 export function applyByteBudget(

--- a/_shared/mcp-tools/search.ts
+++ b/_shared/mcp-tools/search.ts
@@ -19,7 +19,7 @@ import type { MCPSupabaseClient } from "./types.ts";
 
 import { getEmbedding, resolveEmbedderKind } from "../embeddings/index.ts";
 import { applyByteBudget, getMaxResponseBytes, getMinSearchScore,
-  getMinTermCoverage, logUsage } from "./_utils.ts";
+  getMinTermCoverage, getSearchAlpha, logUsage } from "./_utils.ts";
 import { lookupProjectId } from "./_projects.ts";
 import { McpInvalidParams, type ToolContext, type ToolDefinition } from "./types.ts";
 
@@ -32,7 +32,7 @@ async function handler(
   const project_name = args.project_name as string | undefined;
   const match_count = (args.match_count as number | undefined) ?? 5;
   const mode = (args.mode as string | undefined) ?? "docs";
-  const alpha = (args.alpha as number | undefined) ?? 0.7;
+  const alpha = (args.alpha as number | undefined) ?? getSearchAlpha();
   const min_score = (args.min_score as number | undefined) ?? getMinSearchScore();
   // v1.0.4: coverage gate default from CEREFOX_MIN_TERM_COVERAGE; only sent
   // when configured (see getMinTermCoverage — keeps pre-0.9.1 servers working).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,111 +1,28 @@
-# Cerefox TODO & Ideas Backlog
+# TODO — retired (v1.0.6, 2026-08-04)
 
-> **⚠ Outdated — pending a full cleanup pass.** This backlog has only been
-> partially reconciled against the code (most recently during the v0.9.3 doc
-> sweep, when the clearly-shipped entries were removed). Some remaining items
-> may already be implemented or obsolete. Verify against the current codebase
-> and `plan.md` before picking anything up.
+**This file is no longer maintained. The backlog lives in [GitHub Issues](https://github.com/fstamatelopoulos/cerefox/issues).**
 
-> Active work is tracked in `plan.md`. This file captures ideas, future enhancements,
-> and tasks that aren't yet scheduled into an iteration.
+Why: a markdown backlog drifts silently — it has no state, no owner, no
+notification, and nobody (contributors least of all) thinks to open it. Several
+entries here described bugs that had already been fixed and files that no longer
+existed. Issues are where the maintainer and contributors actually look.
 
----
+## Where things went
 
-## Known Tasks (Not Yet Scheduled)
+- **Unscheduled ideas and enhancements** → migrated to issues #140–#149, grouped
+  by area (data safety, search ranking, embedders, ingestion sources, writing-tool
+  adapters, advanced retrieval, web UI, audit/governance, infrastructure,
+  backup/sync + MCP integrations).
+- **Active and planned work** → [`plan.md`](plan.md), whose `## Current Focus`
+  block is the live status and the cross-session hand-off artifact.
+- **Design rationale** → [`specs/`](specs/) and [`research/`](research/).
+- **Release notes** → [`../CHANGELOG.md`](../CHANGELOG.md).
 
-### Data Safety
-- [ ] **Metadata versioning / recovery** — version snapshots capture content only;
-  a metadata wipe is unrecoverable (bit us in the v0.11.1 incident). Proposal with
-  options (audit-log before/after values, and/or metadata on version rows):
-  [`docs/research/metadata-versioning.md`](research/metadata-versioning.md).
+Entries dropped as obsolete during the migration: an ingestion-rollback bug
+(ingestion became atomic when it moved into the `cerefox_ingest_document` RPC),
+a `sync_docs.py` refactor (Python was removed at v1.0.0; the TS script already
+uses the Edge Function path), multi-language FTS (live as #129), and two
+tunables shipped in v1.0.6.
 
-### Search & Ranking
-- [ ] `CEREFOX_SEARCH_ALPHA` env default for the hybrid fusion weight (parity
-  with `CEREFOX_MIN_SEARCH_SCORE` / `CEREFOX_MIN_TERM_COVERAGE`; today alpha is
-  per-call only). Found in the v1.0.4 tunables-consistency audit.
-- [ ] Verify whether Supabase Edge Functions populate `process.env` from
-  Function secrets (Node-compat) — if yes, the client-side retrieval tunables
-  could be honored on the remote-MCP path too; document either way.
-- [ ] Reciprocal Rank Fusion (RRF) for hybrid search instead of linear alpha blending
-- [ ] True BM25 ranking via pg_textsearch or ParadeDB extension
-- [ ] Query embedding caching (avoid re-embedding repeated queries)
-- [ ] Search result re-ranking with cross-encoder models or LLM-based reranking (see vision doc)
-- [ ] Multi-language FTS support (beyond English tsvector config)
-
-### Embeddings
-- [ ] Vertex AI text-embedding-005 embedder (add as another cloud provider)
-- [ ] Benchmark: compare retrieval quality across OpenAI vs Fireworks embedders on real data
-- [ ] Matryoshka/PCA dimensionality reduction for models that don't output 768-dim
-
-### Ingestion
-- [ ] **Bug: rollback document insert if embedding/chunk-insert fails** -- currently if the pipeline crashes after inserting the document row but before inserting chunks, the document exists with no chunks and subsequent retries are silently skipped as duplicates. Fix: delete the document row on any exception after insert, or use a DB transaction.
-- [ ] Support ingesting from URLs (fetch page, convert to markdown)
-- [ ] EPUB to Markdown converter
-- [ ] HTML to Markdown converter (for saved web pages)
-- [ ] Watch folder mode (auto-ingest new files dropped into a directory)
-- [ ] **Refactor `sync_docs.py` to use the Edge Function path** -- currently uses the local `IngestionPipeline` (Python chunker + direct embedding API call), which is a separate implementation from the `cerefox-ingest` Edge Function (TypeScript chunker). This violates the single implementation principle. Switch to calling the `cerefox-ingest` Edge Function via HTTP (Cerefox access token auth, `CEREFOX_ACCESS_TOKEN`).
-
-### Writing Layer Adapters (input sources)
-These are "input adapters" -- Cerefox is the backend, these tools are the authoring front-end. The integration is always one-way: writing tool to Cerefox (not the reverse).
-- [ ] Obsidian vault adapter -- `cerefox sync --source obsidian --vault ~/Documents/MyVault` does a one-shot ingest of all vault files; `cerefox watch --vault` watches for changes and ingests incrementally. No Obsidian plugins needed, just plain folder access.
-- [ ] Notion export adapter (parse Notion HTML/MD export format)
-- [ ] Logseq vault adapter (Logseq stores as `.md` files with some syntax quirks)
-- [ ] Incremental re-ingestion (detect changes in a file, update only changed chunks)
-
-### Retrieval
-- [ ] Retrieval chain: search, expand, summarize (multi-step RPC)
-- [ ] Citation/source tracking in retrieved content
-- [ ] Relevance feedback loop (mark results as relevant/irrelevant to improve ranking)
-
-### Web UI
-- [ ] Pagination for document lists -- project documents page currently caps at 100 docs; add page controls or infinite-scroll for large projects
-- [ ] **"No Project Assigned" row in dashboard** -- show a row in the Projects table for documents not in any project
-- [ ] Search-as-you-type (debounced query)
-- [ ] Chunk boundary visualization in document viewer
-- [ ] Bulk operations (tag multiple docs, move to project, delete) -- deferred from 14C.3
-- [ ] Mobile-responsive layout improvements
-- [ ] Side-by-side diff view (requires table-based layout with paired rows for alignment)
-
-### Audit & Governance
-- [ ] Audit log entries for project operations (create, edit, delete) -- currently only document operations are tracked
-- [ ] Audit log FTS query integration -- FTS index exists on description column but no dedicated search endpoint
-- [ ] Automated knowledge processing via external LLM (anomaly detection, consistency checking, staleness assessment) -- see vision doc
-
-### Infrastructure
-- [ ] Row-Level Security (RLS) policies for multi-user future
-- [ ] Rate limiting on API endpoints
-- [ ] Usage statistics (docs stored, searches performed, storage used)
-- [ ] **Local Supabase dev environment** -- set up a full local Supabase stack for offline development and Edge Function testing. Moved from iteration plan to backlog.
-- [ ] **Validate Docker/local deployment** -- `Dockerfile` and `docker-compose.yml` have never been tested end-to-end. Low priority.
-- [ ] **Standalone binaries** (`cerefox`, `cerefox.exe`) per design doc §6d "Phase 2". Bundle Bun/Node runtime + JS code into a single executable per OS/arch (macOS-arm64, macOS-x86_64, Linux-x86_64, Windows-x86_64). ~70 MB per binary, ~280 MB total per release. Eliminates the Node/Bun install step for end users. **Deferred** beyond v1.0 per 2026-05-29 maintainer call (Fotis-23): the complexity (cross-compile gotchas, code-signing — $99/year Apple Developer Program for macOS, security concerns around bundling runtimes) doesn't justify the friction reduction for Cerefox's tech-savvy user base. Revisit if a real demand surfaces post-v1.0.
-
-### Backup & Sync
-- [ ] Scheduled automatic backups
-- [ ] Backup verification (compare DB state with backup)
-- [ ] Sync between local Postgres and Supabase
-
-### MCP & Agent Integration
-- [ ] Usage analytics (which tools agents call most, common query patterns)
-- [ ] **OpenClaw** integration -- track once the tool matures
-- [ ] Perplexity -- web connector confirmed broken (GoTrue OAuth conflict). Desktop app + local stdio MCP untested. Low priority: Perplexity moving away from MCP.
-
----
-
-## Ideas & Research
-
-### Automated Knowledge Processing (see vision doc)
-- Optional LLM-based judge for anomaly detection, consistency checking, knowledge enhancement
-- Automated summarization and consolidation of redundant documents
-- Knowledge graph overlay (lightweight `cerefox_edges` table for document relationships)
-- Context bundles: pre-composed packages of knowledge for specific projects or domains
-
-### UX
-- Browser extension for quick capture (clip a paragraph, ingest)
-- Mobile app for quick note capture
-- Telegram/Slack bot for quick note input
-- Voice note transcription to markdown to ingest
-
-### Performance
-- Query plan analysis for search RPCs
-- Connection pooling optimization
-- Batch embedding optimization (process multiple chunks in one model call)
+**Adding something new?** Open an issue. If it is work you are starting now,
+record it in `plan.md` instead.

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -119,16 +119,19 @@ This handles intermittent OpenAI API errors (500s) that would otherwise cause se
 
 > **Which paths read these?** Client-side tunables in this section are read
 > from *your* `.env` by the **CLI**, the **local MCP server**, and `cerefox
-> web`. The **remote MCP / Edge Function path** runs on Supabase and does not
-> see your `.env` — it uses the server defaults unless the caller passes the
-> per-call parameter (e.g. `min_score`, `min_term_coverage` on
-> `cerefox_search`). Setting them as Supabase **Function secrets** may also
-> work but is not a tested configuration.
+> web`. Since **v1.0.6** the same values are also honored on the **remote MCP /
+> Edge Function path** when set as Supabase **Function secrets**
+> (`supabase secrets set CEREFOX_MIN_SEARCH_SCORE=0.55 --project-ref <ref>`) —
+> the shared helpers read `Deno.env` as well as `process.env`. Per-call
+> parameters (`min_score`, `min_term_coverage`, `alpha` on `cerefox_search`)
+> override both. A single setting that governs every path without secrets is
+> tracked as issue #133 (DB-backed config).
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `CEREFOX_MAX_RESPONSE_BYTES` | `200000` | Maximum bytes in a single search response (local MCP path). See explanation below. |
 | `CEREFOX_MIN_SEARCH_SCORE` | `0.50` (`0.60` with the local embedder) | Minimum cosine similarity for hybrid and semantic search results (0.0–1.0). The default is embedder-aware: nomic scores unrelated text higher than OpenAI, so `CEREFOX_EMBEDDER=local` raises the floor to 0.60. In **hybrid search**, chunks that matched the FTS keyword operator (`@@`) always pass through regardless of their vector score — the threshold only filters vector-only results. In **semantic search**, all results are filtered. The pure **FTS search** mode is unaffected. Increase for stricter precision; decrease for wider recall. |
+| `CEREFOX_SEARCH_ALPHA` | `0.7` | Hybrid fusion weight (0.0–1.0): `1.0` = pure semantic, `0.0` = pure keyword. Applies to hybrid and document-mode search. Per-call override: `cerefox search --alpha`, or the `alpha` parameter on the `cerefox_search` MCP tool. |
 | `CEREFOX_MIN_TERM_COVERAGE` | *(unset — server default `0.5`)* | Confidence bar for the keyword OR-fallback (v1.0.4, schema ≥ 0.9.1): when a strict all-terms match fails and search relaxes to any-term matching, a result counts as a confident hit only if it matches at least this fraction of the query's meaningful terms; weaker matches surface as below-confidence candidates. `0` restores pre-gate behavior (any matching term passes); `1` requires every term. Per-call override: `cerefox search --min-term-coverage`. Leave unset against pre-0.9.1 servers. |
 | `CEREFOX_EMBED_MAX_INPUT_CHARS` | `20000` | Safety cap on the characters sent to the embedding model per input. The full chunk content is always stored and reconstructed untouched; only the embedding uses the (rare) truncated prefix, so an oversized chunk can never fail an ingest. |
 | `CEREFOX_MODELS_DIR` | `~/.cerefox/models` (in-container: inside the data volume) | Where the local embedder caches downloaded model weights (Cerefox Local; `CEREFOX_EMBEDDER=local`). |

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -3919,8 +3919,9 @@ correctness across the guides).
 **Still deferred (lower-value / heavier):**
 - [ ] Local live-test wiring: point the read/write suites at the local container (extract
   its in-container JWT for the test) so the same suite runs against cloud **and** local.
-- [ ] `schema-version.bundled=null` image cosmetic (doctor shows a null bundled-schema in
-  the container context). Cosmetic only.
+- [x] ~~`schema-version.bundled=null` image cosmetic~~ — **stale note, verified fixed
+  (2026-08-04)**: the image bundles `dist/server-assets/`, so `readBundledSchemaVersion()`
+  resolves in-container; Cerefox Local doctor shows `(bundled vX.Y.Z)` correctly.
 
 **Testing convention (local):** use the **single** default local container
 (`cerefox-local` / volume `cerefox_local_pgdata`) — the local analogue of the maintainer's

--- a/frontend/src/components/SearchResults.tsx
+++ b/frontend/src/components/SearchResults.tsx
@@ -25,8 +25,19 @@ function colorForProject(name: string): string {
   return `var(${PROJECT_COLORS[h % PROJECT_COLORS.length]})`;
 }
 
-const MODE_LABEL: Record<SearchMode, string> = {
+// A search has two independent axes — what is returned and how it was ranked
+// — and the controls already present them separately ("Documents"/"Chunks" +
+// a ranker). The results summary used to flatten them into one word, so
+// documents mode read "ranked by documents relevance": grammatically odd and
+// category-confused (the other three values are ranking methods). Keep both.
+const MODE_SHAPE: Record<SearchMode, string> = {
   docs: "documents",
+  hybrid: "chunks",
+  fts: "chunks",
+  semantic: "chunks",
+};
+const MODE_RANKER: Record<SearchMode, string> = {
+  docs: "hybrid", // docs mode is always hybrid-ranked, then assembled per document
   hybrid: "hybrid",
   fts: "keyword",
   semantic: "semantic",
@@ -119,9 +130,13 @@ export function SearchResults({ data, isLoading, error, hasQuery }: SearchResult
           <b className={ui.mono} style={{ color: "var(--text)" }}>
             {data.total_found}
           </b>{" "}
-          result{data.total_found !== 1 ? "s" : ""} · ranked by{" "}
+          result{data.total_found !== 1 ? "s" : ""} ·{" "}
           <span className={ui.mono} style={{ color: "var(--primary)" }}>
-            {MODE_LABEL[data.mode]}
+            {MODE_SHAPE[data.mode]}
+          </span>{" "}
+          ranked by{" "}
+          <span className={ui.mono} style={{ color: "var(--primary)" }}>
+            {MODE_RANKER[data.mode]}
           </span>{" "}
           relevance
         </span>

--- a/packages/memory/src/cli/commands/search.ts
+++ b/packages/memory/src/cli/commands/search.ts
@@ -26,7 +26,7 @@ import {
   systemError,
   userError,
 } from "../../../../../_shared/cli-core/index.ts";
-import { getMaxResponseBytes, getMinSearchScore, getMinTermCoverage } from "../../../../../_shared/mcp-tools/_utils.ts";
+import { getMaxResponseBytes, getMinSearchScore, getMinTermCoverage, getSearchAlpha } from "../../../../../_shared/mcp-tools/_utils.ts";
 import { getClient } from "../util/client.ts";
 import { embedQuery } from "../util/embed.ts";
 
@@ -79,7 +79,7 @@ async function action(
   }
 
   const matchCount = parsePositiveInt(options.matchCount, "--match-count", 5);
-  const alpha = parseFloat01(options.alpha, "--alpha", 0.7);
+  const alpha = parseFloat01(options.alpha, "--alpha", getSearchAlpha());
   const minScore = parseFloat01(options.minScore, "--min-score", getMinSearchScore());
   // v1.0.4 coverage gate: flag > CEREFOX_MIN_TERM_COVERAGE env > server
   // default (0.5). Only sent when one of the first two is set — omitting it
@@ -315,7 +315,7 @@ export function registerSearch(program: Command): void {
       "JSON containment filter; only docs whose metadata contains ALL pairs are returned.",
     )
     .option("--mode <mode>", "Search mode: docs (default), hybrid, fts.", "docs")
-    .option("--alpha <float>", "Semantic weight 0..1 (default: 0.7).", "0.7")
+    .option("--alpha <float>", "Semantic weight 0..1 (default: CEREFOX_SEARCH_ALPHA; else 0.7).")
     .option("--min-score <float>", "Minimum cosine similarity threshold (default: CEREFOX_MIN_SEARCH_SCORE; else 0.5, or 0.6 with the local embedder).")
     .option("--min-term-coverage <float>", "OR-fallback keyword matches must cover at least this fraction of the query's meaningful terms to count as confident hits (default: CEREFOX_MIN_TERM_COVERAGE; else the server default 0.5; needs schema ≥ 0.9.1).")
     .option("--max-bytes <n>", "Response size budget in bytes (default: CEREFOX_MAX_RESPONSE_BYTES or 200000).")

--- a/packages/memory/src/web/routes/discovery.ts
+++ b/packages/memory/src/web/routes/discovery.ts
@@ -16,7 +16,7 @@ import { Hono } from "hono";
 
 import { getEmbedding } from "../../../../../_shared/embeddings/index.js";
 import { fetchAllPages } from "../../../../../_shared/db-client/paginate.ts";
-import { getMinSearchScore } from "../../../../../_shared/mcp-tools/_utils.js";
+import { getMinSearchScore, getSearchAlpha } from "../../../../../_shared/mcp-tools/_utils.js";
 import type { WebContext } from "../context.ts";
 import { logWebUsage } from "../usage.ts";
 
@@ -376,7 +376,7 @@ async function runSearch(
       p_query_text: query,
       p_query_embedding: embedding,
       p_match_count: count,
-      p_alpha: 0.7,
+      p_alpha: getSearchAlpha(),
       p_use_upgrade: false,
       p_project_id: projectId,
       p_min_score: getMinSearchScore(),
@@ -395,7 +395,7 @@ async function runSearch(
     p_query_text: query,
     p_query_embedding: embedding,
     p_match_count: Math.min(count, 5),
-    p_alpha: 0.7,
+    p_alpha: getSearchAlpha(),
     p_project_id: projectId,
     p_min_score: getMinSearchScore(),
   };

--- a/src/cerefox/db/rpcs.sql
+++ b/src/cerefox/db/rpcs.sql
@@ -285,7 +285,21 @@ BEGIN
                    (combined.has_fts_match OR combined.vec_score >= p_min_score) AS passes
             FROM combined
         ),
-        any_pass AS (SELECT bool_or(fl.passes) AS ok FROM flagged fl)
+        any_pass AS (SELECT bool_or(fl.passes) AS ok FROM flagged fl),
+        -- v1.0.6: in the below-confidence fallback, rank each candidate WITHIN
+        -- its parent document so we can return one chunk per document. The cap
+        -- used to apply to chunks, so when a document owned several of the top
+        -- chunks the caller saw fewer than 3 results after document-level
+        -- de-duplication (cerefox_search_docs, CLI and web) — the count varied
+        -- with corpus shape rather than with the cap.
+        ranked AS (
+            SELECT fl.*,
+                   ROW_NUMBER() OVER (
+                       PARTITION BY ch.document_id ORDER BY fl.score DESC
+                   ) AS rank_in_doc
+            FROM flagged fl
+            JOIN cerefox_chunks ch ON ch.id = fl.id
+        )
     SELECT
         c.id            AS chunk_id,
         c.document_id,
@@ -311,11 +325,13 @@ BEGIN
         -- memory layer can produce. "Truly nothing" (no candidates at all)
         -- still returns zero rows.
         NOT ap.ok       AS below_confidence
-    FROM flagged cm
+    FROM ranked cm
     CROSS JOIN any_pass ap
     JOIN cerefox_chunks   c ON c.id = cm.id
     JOIN cerefox_documents d ON c.document_id = d.id
-    WHERE cm.passes OR NOT ap.ok
+    -- Normal results are unchanged; fallback rows are restricted to each
+    -- document's best chunk so the cap below counts documents, not chunks.
+    WHERE cm.passes OR (NOT ap.ok AND cm.rank_in_doc = 1)
     ORDER BY cm.score DESC
     LIMIT (SELECT CASE WHEN ap2.ok THEN p_match_count
                        ELSE LEAST(p_match_count, 3) END
@@ -1938,7 +1954,7 @@ SET search_path = public, pg_catalog
 AS $$
     -- Keep in lockstep with the `@version:` marker in schema.sql (cut_release.ts
     -- enforces it). Bump whenever schema.sql OR rpcs.sql changes.
-    SELECT '0.9.1'::TEXT;
+    SELECT '0.9.2'::TEXT;
 $$;
 
 -- ── cerefox_content_format_stats ─────────────────────────────────────────────

--- a/src/cerefox/db/schema.sql
+++ b/src/cerefox/db/schema.sql
@@ -5,7 +5,7 @@
 -- Requires extensions: vector (pgvector), uuid-ossp
 -- These are enabled at the top of db_deploy.py before this file is applied.
 --
--- @version: 0.9.1
+-- @version: 0.9.2
 -- The `@version` marker above is read by the schema-version-mismatch banner
 -- (see /api/v1/schema-version). Bump it whenever schema.sql OR rpcs.sql
 -- changes in a way that requires `cerefox server deploy` to be re-run —


### PR DESCRIPTION
## Summary

**Consistent result counts (schema 0.9.1 → 0.9.2).** The below-confidence fallback capped *chunks* before they were grouped into documents, so a KB where one document owned several top chunks returned fewer results than one where they were spread out — the reason a gibberish query showed 1 result in one case and 3 in another. The cap now counts documents (one chunk per document in fallback mode), so chunk-mode and document-mode agree.

**Two-axis search header.** "ranked by *documents* relevance" borrowed the result shape into a slot that otherwise names a ranking method. Now: "12 results · **documents** ranked by **hybrid** relevance" — matching what `SearchControls` already displays. (The controls were already correct: they hide the ranker in document mode and say "whole documents · hybrid-ranked".)

**`CEREFOX_SEARCH_ALPHA`** — the last retrieval tunable with no persistent setting.

**Retrieval tunables reach the remote path.** The shared env helpers now read `Deno.env` as well as `process.env`, so Supabase **Function secrets** configure the remote MCP / Edge Function path. This resolves the "verify whether EFs see Function secrets" TODO by implementing it; a single setting for every path without secrets remains #133.

**`docs/TODO.md` retired** → issues #140–#149, with obsolete entries dropped (an ingestion-rollback bug fixed when ingestion became atomic; a `sync_docs.py` refactor for a file deleted with Python). `CONTRIBUTING.md` and `CLAUDE.md` updated to point at issues.

**Also**: the plan.md note about a container `bundled=null` doctor cosmetic was stale — verified the image bundles server assets and doctor resolves it; marked resolved. #136 (web 500) triaged and commented: not reproducible here (largest project 81 docs vs the ~400 URL cliff); very likely fixed by #134 in v1.0.5, awaiting @tdebasis's confirmation on his 536-doc project. Ops item filed as #150 (disable legacy API keys).

## Test plan
- [x] New dedup test on a throwaway Postgres: fallback returns 3 rows from 3 distinct documents; chunk count == document count (the pre-fix mismatch)
- [x] Full 16-scenario recall/coverage suite re-run green on schema 0.9.2
- [x] 5 new unit tests for `getSearchAlpha` incl. the `Deno.env` fallback and precedence
- [x] `_shared` 314 pass, package build + 158 pass, frontend build + lint clean, typecheck clean
- [ ] Post-deploy: confirm the header wording and result-count consistency in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)