### PR TITLE
v1.1.0-beta.2: staging environment, backup format 4, five cross-environment fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 ## [Unreleased]
 
 ### Fixed
+- **`cerefox web` daemon state is now per-environment.** The pidfile and log
+  were written to `~/.cerefox/web.{pid,log}` regardless of
+  `CEREFOX_CONFIG_DIR`, so starting a web server in a second environment
+  overwrote the first one's bookkeeping — and a later `web stop` then targeted
+  the wrong process, killing the other environment's server. State now follows
+  an explicitly-set `CEREFOX_CONFIG_DIR`. **No change for normal installs**:
+  without the override the location is exactly as before, and the resolver is
+  deliberately keyed on the env var rather than the config-dir resolver so repo
+  dev-mode never drops `web.pid` into a working tree.
 - **Backups now capture project memberships** (#166). `backup create` never
   read the document↔project junction, so every restore silently landed
   documents with **no project assignments** — and the restore command's help

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ Open roadmap.
   one relation type outward, following chains and terminating safely on cycles.
   Search ranking is deliberately untouched in this release; relation-aware
   retrieval is the next slice.
+
+  **The feature ships dormant.** The relation tools are hidden from agents
+  until a deployment opts in with `cerefox config set relations_enabled true`
+  — a tool an agent can see is a tool an agent may use, and this design is
+  meant to evolve through experimentation before it becomes part of the
+  default surface. With the flag off, Cerefox behaves exactly as it did in
+  1.0.6: an empty table, a defaulted column, and 10 visible tools.
 - **Deployment-wide search settings** (#133; schema 0.9.2 → 0.9.3 — redeploy
   with `cerefox server deploy`). `min_search_score`, `min_term_coverage`, and
   `search_alpha` can now be set once with `cerefox config set` and every access
@@ -46,6 +53,16 @@ Open roadmap.
   before the server and a normal upgrade window would otherwise fail CI.
 
 ### Fixed
+- **UI end-to-end tests repaired** (#155). The Playwright suite had drifted to
+  8 failures and 2 silent skips out of 13 — every one a stale selector rather
+  than a broken app (polished copy, renamed headings, a form moved into a
+  modal). It now passes 13/13 in ~32 seconds instead of 3.7 minutes, and page
+  identity is asserted through stable test hooks so copy changes cannot break
+  it again.
+- **Dashboard rows are keyboard reachable** (#165). Recent documents and
+  projects navigated via a click handler on the table row, so keyboard and
+  screen-reader users could not open them at all, and cmd/middle-click and
+  "copy link" did nothing. They are real links now.
 - **`cerefox doctor` no longer reports "All checks passed" alongside warnings**
   (#152) — it contradicted the remediation printed directly above it.
 - **`cerefox-local upgrade` actually upgrades** (#153). With no argument it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,15 @@ Open roadmap.
   before the server and a normal upgrade window would otherwise fail CI.
 
 ### Fixed
+- **Backups capture the full picture** — projects, memberships (ported from
+  v1.0.7, #166) and now **relations + `lifecycle_status`** too, so the graph
+  and each document's standing survive a restore. Relations are only restored
+  when both endpoint documents landed, and a snapshot from an older Cerefox
+  still restores (with a note about what it cannot recreate).
+- **`cerefox doctor`'s content-format hint is legible.** It ended with
+  "What this means: `cerefox guides show content-format`", which read as
+  though the command were the explanation. It now says plainly that the legacy
+  format is harmless, how to convert, and what to run to read about it.
 - **UI end-to-end tests repaired** (#155). The Playwright suite had drifted to
   8 failures and 2 silent skips out of 13 — every one a stale selector rather
   than a broken app (polished copy, renamed headings, a form moved into a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 ## [Unreleased]
 
 ### Fixed
+- **`CEREFOX_CONFIG_DIR` now outranks an ambient `.env`.** Bun auto-loads `.env`
+  from the working directory, so every `bun scripts/*.ts` run inside a repo
+  clone arrived with that file's credentials already in `process.env` — and
+  `loadEnv()` only filled *unset* keys, so the named config directory was
+  silently ignored. `CEREFOX_CONFIG_DIR=…/staging bun scripts/db_migrate.ts
+  --status` reported **production**, and the same resolution path through
+  `db_deploy.ts --reset` would have wiped production while naming staging on
+  the command line. When the config dir is explicitly named, its `.env` is now
+  the authority. Unchanged when the override is unset, which is every
+  single-environment install.
+- **`db_deploy.ts --reset` now names the database it is about to drop.** The
+  confirmation prompt asked for a typed `yes` without ever saying *which*
+  project would be wiped. It now prints the target project ref, host, and the
+  config file the connection came from.
 - **`cerefox web` daemon state is now per-environment.** The pidfile and log
   were written to `~/.cerefox/web.{pid,log}` regardless of
   `CEREFOX_CONFIG_DIR`, so starting a web server in a second environment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 ## [Unreleased]
 
 ### Fixed
+- **`backup create` no longer fails against a pre-0.10.0 server.** The document
+  select named `lifecycle_status` unconditionally, so a v1.1.0 CLI pointed at a
+  v1.0.x database aborted with *"column cerefox_documents.lifecycle_status does
+  not exist"* — breaking backups at the one moment they matter most, taking a
+  snapshot of production **before** upgrading it. The column is now probed and
+  dropped from the select if the server predates it, recorded in the payload as
+  `includes_lifecycle_status: false`.
+- **Schema-status output no longer points at deleted Python scripts.**
+  `db_status` told users to "run db_deploy.py" on a version mismatch; the Python
+  implementation was removed at v1.0.0. All three messages now say
+  `cerefox server deploy`.
 - **`CEREFOX_CONFIG_DIR` now outranks an ambient `.env`.** Bun auto-loads `.env`
   from the working directory, so every `bun scripts/*.ts` run inside a repo
   clone arrived with that file's credentials already in `process.env` — and
@@ -48,6 +59,15 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
   `content-format.md` both told users to run it anyway.
 
 ### Added
+- **Backups now capture trashed documents** (backup format 4). Soft-delete is
+  not a purge — `cerefox_delete_document` only stamps `deleted_at`, and nothing
+  ever collects it (the 48h retention sweep prunes document *versions*, never
+  the trash). Snapshots silently omitted that durable state, so a restore
+  permanently lost everything in the trash. Trashed documents are now captured
+  and **restored as trash**: `deleted_at` is replayed verbatim, and since every
+  read and search RPC filters on it, nothing deleted comes back visible —
+  `cerefox document restore` still recovers it. Counted on its own line by both
+  commands; `--no-trash` opts out.
 - **`cerefox server migrate-format`** — the command that actually does the
   conversion #164 promised: re-ingests legacy documents through the normal
   pipeline so they are re-chunked, re-embedded, and stamped with the current

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
+### Fixed
+- **Backups now capture project memberships** (#166). `backup create` never
+  read the document↔project junction, so every restore silently landed
+  documents with **no project assignments** — and the restore command's help
+  text claimed the opposite. Snapshots now include projects and memberships
+  (backup format 2) and restore recreates them idempotently. Older snapshots
+  still restore, with a warning that memberships are absent. Verified with a
+  full round trip: seed → back up → wipe → restore, memberships intact.
+- **`cerefox server reindex` no longer claimed to convert legacy chunk
+  formats** (#164, reported by [@tdebasis](https://github.com/tdebasis)).
+  Reindex refreshes embeddings on existing chunk rows; it never re-chunks, so
+  it cannot advance `content_format` — verified on a 3,203-chunk store where
+  it touched every chunk and moved exactly zero. `cerefox doctor` and
+  `content-format.md` both told users to run it anyway.
+
+### Added
+- **`cerefox server migrate-format`** — the command that actually does the
+  conversion #164 promised: re-ingests legacy documents through the normal
+  pipeline so they are re-chunked, re-embedded, and stamped with the current
+  format. Opt-in (it costs embedding spend), with `--dry-run`, `--limit`, and
+  `--document-id`. Each document converts under optimistic concurrency, so an
+  edit made mid-run is skipped rather than overwritten, and documents whose
+  content is byte-identical to another document are reported as
+  un-convertible rather than failing the run.
+
 Open roadmap.
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -397,6 +397,7 @@ These live in `docs/guides/` and are written for someone who has never seen the 
 | `connect-agents.md` | MCP setup for Claude, Cursor, and generic clients |
 | `configuration.md` | All `CEREFOX_` environment variables with defaults |
 | `ops-scripts.md` | All `scripts/` — deploy, migrate, backup, restore |
+| `staging-env.md` | Running a staging environment alongside production (opt-in; `CEREFOX_CONFIG_DIR`) |
 | `operational-cost.md` | Embedding and hosting cost estimates |
 | `CONTRIBUTING.md` (repo root) | How to contribute to Cerefox |
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -139,6 +139,14 @@ pushes the branch you are on. Two guards make the dangerous mistakes loud:
   standing on main (VERSION `1.1.0-beta.1`) is refused — that would publish
   1.1.0's tree to the stable channel under a patch number, and tags here are
   immutable.
+- **Own line only.** A `release/X.Y.*` branch can only cut `X.Y.z` versions.
+  (The forward-only rule alone would not catch cutting `1.1.0-beta.2` from
+  `release/1.0.7` — that moves forward, but tags a tree with none of the 1.1.0
+  work.)
+- **`--yes` does not apply off main.** The confirmation names the branch, and a
+  maintenance cut is exactly where an unattended yes would defeat it, so `--yes`
+  is ignored (loudly) and a human must answer. Without a TTY the cut is refused
+  rather than left hanging.
 - **`--branch=<name>` (optional)** asserts which branch you believe you are on
   and fails if it disagrees. It never switches branches; omit it and the
   checked-out branch is used.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -120,6 +120,35 @@ edit `[Unreleased]` so the stable section aggregates **every** change across all
 Added / Changed / Fixed / Removed / Security. That consolidated section is the source for the
 release announcement. Leave the individual pre-release sections beneath it as granular history.
 
+## Patching an older line (maintenance branch)
+
+When main has already moved on — main carried all of 1.1.0 while 1.0.7 needed
+to ship — the patch cannot be cut from main: doing so would tag main's tree as
+a 1.0.x release. Cut from a maintenance branch instead:
+
+```bash
+git checkout -b release/1.0.7 v1.0.6     # branch from the LAST TAG of that line
+# apply the fixes, commit, push
+bun scripts/cut_release.ts 1.0.7 --npm-publish
+```
+
+`cut_release.ts` supports this: it accepts `main` or any `release/*` branch, and
+pushes the branch you are on. Two guards make the dangerous mistakes loud:
+
+- **Forward-only.** A release must increase the version. Cutting `1.0.7` while
+  standing on main (VERSION `1.1.0-beta.1`) is refused — that would publish
+  1.1.0's tree to the stable channel under a patch number, and tags here are
+  immutable.
+- **`--branch=<name>` (optional)** asserts which branch you believe you are on
+  and fails if it disagrees. It never switches branches; omit it and the
+  checked-out branch is used.
+
+**Forward-port with cherry-picks, not a branch merge.** Merging `release/1.0.7`
+into main would drag its version bump along and regress main from
+`1.1.0-beta.1` to `1.0.7`. Cherry-pick the fix commits onto main (and any live
+feature branch) instead, and leave the release branch unmerged as the record of
+that line.
+
 ## Post-release verification
 
 1. The release workflow run is green (build + test, then publish).

--- a/_shared/__tests__/env-config-dir-precedence.test.ts
+++ b/_shared/__tests__/env-config-dir-precedence.test.ts
@@ -1,0 +1,83 @@
+/**
+ * CEREFOX_CONFIG_DIR must beat an ambient .env.
+ *
+ * Bun auto-loads `.env` from the working directory, so a contributor running
+ * `bun scripts/*.ts` inside a repo clone already has that file's values in
+ * `process.env` before `loadEnv()` runs. Because loadEnv only filled *unset*
+ * keys, the named config dir was silently ignored:
+ *
+ *   CEREFOX_CONFIG_DIR=~/.cerefox/staging bun scripts/db_migrate.ts --status
+ *
+ * reported production. The same path through `db_deploy.ts --reset` would have
+ * wiped production while naming staging on the command line.
+ *
+ * These run in a subprocess on purpose: the bug only exists when the ambient
+ * environment is populated before module load, which is exactly what Bun's
+ * auto-dotenv does and what an in-process test cannot reproduce.
+ */
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const CONFIG_MOD = join(import.meta.dir, "..", "config", "index.ts");
+
+const roots: string[] = [];
+function tempDir(): string {
+  const d = mkdtempSync(join(tmpdir(), "cfx-env-"));
+  roots.push(d);
+  return d;
+}
+afterAll(() => {
+  for (const d of roots) rmSync(d, { recursive: true, force: true });
+});
+
+/** Resolve CEREFOX_SUPABASE_URL the way a real command would. */
+function resolveUrl(opts: { cwd: string; env: Record<string, string> }): string {
+  const proc = Bun.spawnSync({
+    cmd: [
+      "bun",
+      "-e",
+      `import { loadEnv } from ${JSON.stringify(CONFIG_MOD)};` +
+        `loadEnv(); console.log(process.env.CEREFOX_SUPABASE_URL ?? "");`,
+    ],
+    cwd: opts.cwd,
+    env: { PATH: process.env.PATH ?? "", HOME: process.env.HOME ?? "", ...opts.env },
+  });
+  return proc.stdout.toString().trim();
+}
+
+describe("loadEnv + CEREFOX_CONFIG_DIR precedence", () => {
+  test("the named config dir wins over an auto-loaded working-directory .env", () => {
+    const repo = tempDir();
+    writeFileSync(join(repo, ".env"), "CEREFOX_SUPABASE_URL=https://production.example\n");
+
+    const staging = tempDir();
+    writeFileSync(join(staging, ".env"), "CEREFOX_SUPABASE_URL=https://staging.example\n");
+
+    expect(resolveUrl({ cwd: repo, env: { CEREFOX_CONFIG_DIR: staging } })).toBe(
+      "https://staging.example",
+    );
+  });
+
+  test("without the override, the working-directory .env still applies", () => {
+    const repo = tempDir();
+    writeFileSync(join(repo, ".env"), "CEREFOX_SUPABASE_URL=https://production.example\n");
+
+    expect(resolveUrl({ cwd: repo, env: {} })).toBe("https://production.example");
+  });
+
+  test("the config dir does not rewrite CEREFOX_CONFIG_DIR itself", () => {
+    const staging = tempDir();
+    writeFileSync(
+      join(staging, ".env"),
+      "CEREFOX_CONFIG_DIR=/somewhere/else\nCEREFOX_SUPABASE_URL=https://staging.example\n",
+    );
+
+    // Still reads staging's file — a self-referential value cannot redirect it.
+    expect(resolveUrl({ cwd: tempDir(), env: { CEREFOX_CONFIG_DIR: staging } })).toBe(
+      "https://staging.example",
+    );
+  });
+});

--- a/_shared/__tests__/feature-flags.test.ts
+++ b/_shared/__tests__/feature-flags.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Optional-feature gating (iteration 29): document relations must be invisible
+ * until a deployment opts in. A tool an agent can SEE is a tool an agent may
+ * use, so dormancy has to mean hidden, not merely unused.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { ALL_TOOLS, assertToolEnabled, listEnabledTools } from "../mcp-tools/index.ts";
+import { resetFeatureFlagCache } from "../mcp-tools/feature-flags.ts";
+import type { MCPSupabaseClient } from "../mcp-tools/types.ts";
+
+/** Client whose cerefox_get_config returns the given value (or throws). */
+function configClient(value: string | null, opts: { fail?: boolean } = {}): MCPSupabaseClient {
+  return {
+    rpc: (name: string) => {
+      if (name !== "cerefox_get_config") return { data: null, error: null };
+      if (opts.fail) return { data: null, error: { message: "boom" } };
+      return { data: value, error: null };
+    },
+  } as unknown as MCPSupabaseClient;
+}
+
+const RELATION_TOOLS = [
+  "cerefox_set_relation",
+  "cerefox_delete_relation",
+  "cerefox_get_relations",
+  "cerefox_get_neighbors",
+];
+
+afterEach(() => resetFeatureFlagCache());
+
+describe("relation tools are hidden by default", () => {
+  test("unset config → relation tools are not listed", async () => {
+    const names = (await listEnabledTools(configClient(null))).map((t) => t.name);
+    for (const t of RELATION_TOOLS) expect(names).not.toContain(t);
+    expect(names.length).toBe(ALL_TOOLS.length - RELATION_TOOLS.length);
+  });
+
+  test("'false' → hidden", async () => {
+    const names = (await listEnabledTools(configClient("false"))).map((t) => t.name);
+    expect(names).not.toContain("cerefox_set_relation");
+  });
+
+  test("'true' → the full surface appears", async () => {
+    const names = (await listEnabledTools(configClient("true"))).map((t) => t.name);
+    for (const t of RELATION_TOOLS) expect(names).toContain(t);
+    expect(names.length).toBe(ALL_TOOLS.length);
+  });
+
+  test("value is parsed leniently but safely", async () => {
+    expect((await listEnabledTools(configClient(" TRUE "))).length).toBe(ALL_TOOLS.length);
+    resetFeatureFlagCache();
+    expect((await listEnabledTools(configClient("yes"))).length).toBe(
+      ALL_TOOLS.length - RELATION_TOOLS.length,
+    );
+  });
+
+  test("a config read failure fails CLOSED, not open", async () => {
+    const names = (await listEnabledTools(configClient(null, { fail: true }))).map((t) => t.name);
+    expect(names).not.toContain("cerefox_set_relation");
+  });
+
+  test("non-gated tools are never affected", async () => {
+    const names = (await listEnabledTools(configClient("false"))).map((t) => t.name);
+    expect(names).toContain("cerefox_search");
+    expect(names).toContain("cerefox_ingest");
+    expect(names).toContain("cerefox_get_help");
+  });
+});
+
+describe("call-path guard", () => {
+  test("calling a gated tool while disabled explains how to enable it", async () => {
+    await expect(
+      assertToolEnabled(configClient("false"), "cerefox_set_relation"),
+    ).rejects.toThrow(/relations_enabled true/);
+  });
+
+  test("enabled → the call passes the guard", async () => {
+    await expect(
+      assertToolEnabled(configClient("true"), "cerefox_set_relation"),
+    ).resolves.toBeUndefined();
+  });
+
+  test("ungated tools skip the check entirely (no config read needed)", async () => {
+    const throwing = {
+      rpc: () => {
+        throw new Error("config should not be consulted for ungated tools");
+      },
+    } as unknown as MCPSupabaseClient;
+    await expect(assertToolEnabled(throwing, "cerefox_search")).resolves.toBeUndefined();
+  });
+});

--- a/_shared/__tests__/release-guard.test.ts
+++ b/_shared/__tests__/release-guard.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Release-cut safety: a release must move the version forward.
+ *
+ * The mistake this guards against is concrete and unrecoverable: standing on
+ * `main` (VERSION 1.1.0-beta.1) and cutting "1.0.7" would tag main's tree —
+ * all of 1.1.0 — as a 1.0.x patch and publish it to the stable channel. Tags
+ * are immutable here, so there is no clean undo.
+ *
+ * Mirrors the rule in scripts/cut_release.ts::checkVersionMovesForward.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { compareSemver } from "../compatibility/index.ts";
+
+const allowed = (branchVersion: string, cutting: string) =>
+  compareSemver(cutting, branchVersion) > 0;
+
+describe("cut_release forward-only guard", () => {
+  test("refuses a patch of an older line from a branch that is ahead", () => {
+    // The exact scenario: main carries 1.1.0-beta.1, someone cuts 1.0.7.
+    expect(allowed("1.1.0-beta.1", "1.0.7")).toBe(false);
+  });
+
+  test("allows that same patch from the maintenance branch", () => {
+    // release/1.0.7, based on the v1.0.6 tag.
+    expect(allowed("1.0.6", "1.0.7")).toBe(true);
+  });
+
+  test("refuses re-cutting the version already on the branch", () => {
+    expect(allowed("1.0.6", "1.0.6")).toBe(false);
+  });
+
+  test("allows normal forward cuts, including pre-releases", () => {
+    expect(allowed("1.0.6", "1.1.0")).toBe(true);
+    expect(allowed("1.1.0-beta.1", "1.1.0-beta.2")).toBe(true);
+    expect(allowed("1.1.0-beta.2", "1.1.0")).toBe(true);
+  });
+
+  test("refuses going backwards across a pre-release boundary", () => {
+    // 1.1.0 is released; cutting 1.1.0-beta.3 afterwards would be a regression.
+    expect(allowed("1.1.0", "1.1.0-beta.3")).toBe(false);
+  });
+});

--- a/_shared/config/env.ts
+++ b/_shared/config/env.ts
@@ -52,9 +52,26 @@ export function loadEnv(opts: ResolverOptions = {}): { path: string; vars: numbe
     return { path: envPath, vars: 0 };
   }
 
+  // Normally the ambient environment wins: an exported var is an explicit
+  // override of the file. But when the caller has *named an environment* with
+  // CEREFOX_CONFIG_DIR, that directory's .env is the authority — otherwise a
+  // stray ambient value silently redirects the command at a different backend.
+  //
+  // This is not hypothetical. Bun auto-loads `.env` from the working directory,
+  // so every `bun scripts/*.ts` run inside a repo clone that has its own `.env`
+  // arrived here with production credentials already in `env`, and the config
+  // dir was ignored. `CEREFOX_CONFIG_DIR=…/staging bun scripts/db_migrate.ts
+  // --status` reported production; the same path through `db_deploy.ts --reset`
+  // would have wiped production while naming staging on the command line.
+  //
+  // CEREFOX_CONFIG_DIR itself is never overridden — it selects the file, so
+  // letting the file rewrite it would be circular.
+  const configDirNamed = (env.CEREFOX_CONFIG_DIR ?? "").trim() !== "";
+
   let count = 0;
   for (const [k, v] of Object.entries(parseDotenv(content))) {
-    if (env[k] === undefined) {
+    if (k === "CEREFOX_CONFIG_DIR") continue;
+    if (env[k] === undefined || configDirNamed) {
       env[k] = v;
       count++;
     }

--- a/_shared/db-status/index.ts
+++ b/_shared/db-status/index.ts
@@ -257,7 +257,9 @@ export function formatReport(report: DbStatusReport): string {
   lines.push(`  bundled : ${report.schemaVersion.bundled ?? "(unknown)"}`);
   lines.push(`  deployed: ${report.schemaVersion.deployed ?? "(not reported)"}`);
   if (report.schemaVersion.mismatch) {
-    lines.push("  ⚠️  bundled and deployed schema versions differ — run db_deploy.py");
+    lines.push(
+      "  ⚠️  bundled and deployed schema versions differ — run `cerefox server deploy`",
+    );
   }
 
   lines.push("");
@@ -265,10 +267,10 @@ export function formatReport(report: DbStatusReport): string {
   if (report.allOk) {
     lines.push("✓  All checks passed. Schema looks healthy.");
   } else if (anyUnknown) {
-    lines.push("?  Function checks unavailable. Run db_deploy.py to install");
-    lines.push("   the introspection helper RPC, then re-run.");
+    lines.push("?  Function checks unavailable. Run `cerefox server deploy` to");
+    lines.push("   install the introspection helper RPC, then re-run.");
   } else {
-    lines.push("✗  Some checks failed. Run db_deploy.py to fix missing objects.");
+    lines.push("✗  Some checks failed. Run `cerefox server deploy` to fix missing objects.");
   }
 
   return lines.join("\n");

--- a/_shared/mcp-tools/feature-flags.ts
+++ b/_shared/mcp-tools/feature-flags.ts
@@ -1,0 +1,68 @@
+/**
+ * Optional-feature gating for the MCP tool surface.
+ *
+ * Document relations (iteration 29) ship **dormant**: the table sits empty, the
+ * `lifecycle_status` column defaults to `'active'`, search is untouched — but
+ * the four relation tools would still appear in every agent's tool list, and an
+ * agent that sees a tool may decide to use it. For a feature we intend to
+ * evolve through experimentation, that is not "optional" enough.
+ *
+ * So exposure is gated on a deployment-wide flag (`relations_enabled` in
+ * `cerefox_config`, default **false**), read through the same RPC as every
+ * other setting. Turning it on is one command:
+ *
+ *   cerefox config set relations_enabled true
+ *
+ * Failure mode is deliberately closed: if the config read fails (older schema,
+ * transient error), the feature stays hidden rather than appearing
+ * intermittently.
+ */
+
+import type { MCPSupabaseClient } from "./types.ts";
+
+/** Tools gated behind `relations_enabled`. */
+export const RELATION_TOOL_NAMES: ReadonlySet<string> = new Set([
+  "cerefox_set_relation",
+  "cerefox_delete_relation",
+  "cerefox_get_relations",
+  "cerefox_get_neighbors",
+]);
+
+/**
+ * Cached per process. `tools/list` happens once per session, but `tools/call`
+ * checks too (a long-lived session could hold a stale list), and a round trip
+ * per call is not worth paying.
+ */
+const CACHE_TTL_MS = 60_000;
+let cached: { value: boolean; at: number } | null = null;
+
+/** Test seam: drop the cache so a flag change is picked up immediately. */
+export function resetFeatureFlagCache(): void {
+  cached = null;
+}
+
+export async function relationsEnabled(supabase: MCPSupabaseClient): Promise<boolean> {
+  if (cached && Date.now() - cached.at < CACHE_TTL_MS) return cached.value;
+  try {
+    const { data, error } = await supabase.rpc("cerefox_get_config", {
+      p_key: "relations_enabled",
+    });
+    if (error) throw new Error(error.message);
+    const value = String(data ?? "").trim().toLowerCase() === "true";
+    cached = { value, at: Date.now() };
+    return value;
+  } catch {
+    // Fail closed, and don't cache a failure — a transient error shouldn't
+    // hide the feature for a full TTL once it is genuinely enabled.
+    return false;
+  }
+}
+
+/** Message shown when a gated tool is called while the feature is off. */
+export function disabledToolMessage(name: string): string {
+  return (
+    `${name} is part of the document-relations feature, which is off by default. ` +
+    `Enable it with: cerefox config set relations_enabled true ` +
+    `(deployment-wide; every access path picks it up).`
+  );
+}

--- a/_shared/mcp-tools/index.ts
+++ b/_shared/mcp-tools/index.ts
@@ -13,6 +13,11 @@
 
 import { auditLogTool } from "./audit-log.ts";
 import {
+  disabledToolMessage,
+  relationsEnabled,
+  RELATION_TOOL_NAMES,
+} from "./feature-flags.ts";
+import {
   deleteRelationTool,
   getNeighborsTool,
   getRelationsTool,
@@ -27,7 +32,7 @@ import { listVersionsTool } from "./list-versions.ts";
 import { metadataSearchTool } from "./metadata-search.ts";
 import { searchTool } from "./search.ts";
 import { setDocumentProjectsTool } from "./set-document-projects.ts";
-import type { ToolDefinition } from "./types.ts";
+import { McpInvalidParams, type MCPSupabaseClient, type ToolDefinition } from "./types.ts";
 
 /** All Cerefox MCP tools, in canonical order (matches AGENT_QUICK_REFERENCE.md). */
 export const ALL_TOOLS: ToolDefinition[] = [
@@ -47,6 +52,31 @@ export const ALL_TOOLS: ToolDefinition[] = [
   getNeighborsTool,
   getHelpTool,
 ];
+
+/**
+ * The tools an agent should SEE, given deployment config. Optional features are
+ * hidden until enabled (see feature-flags.ts) — a tool an agent can see is a
+ * tool an agent may use, so "dormant" has to mean invisible, not just unused.
+ */
+export async function listEnabledTools(
+  supabase: MCPSupabaseClient,
+): Promise<ToolDefinition[]> {
+  const relations = await relationsEnabled(supabase);
+  return ALL_TOOLS.filter((t) => relations || !RELATION_TOOL_NAMES.has(t.name));
+}
+
+/**
+ * Guard for the call path: a session that listed tools before the flag changed
+ * (or a hand-written client) can still name a gated tool.
+ */
+export async function assertToolEnabled(
+  supabase: MCPSupabaseClient,
+  name: string,
+): Promise<void> {
+  if (!RELATION_TOOL_NAMES.has(name)) return;
+  if (await relationsEnabled(supabase)) return;
+  throw new McpInvalidParams(disabledToolMessage(name));
+}
 
 /** Build a name → definition map for fast dispatch. */
 export const TOOLS_BY_NAME: Record<string, ToolDefinition> = Object.fromEntries(

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -117,6 +117,12 @@ This handles intermittent OpenAI API errors (500s) that would otherwise cause se
 
 ## Retrieval
 
+> **Optional features.** `relations_enabled` (default `false`) controls whether
+> the document-relation tools are exposed to agents. The feature ships
+> **dormant**: the table stays empty, `lifecycle_status` defaults to `active`,
+> search is untouched, and the tools do not appear in any agent's tool list
+> until you opt in with `cerefox config set relations_enabled true`.
+
 > **Deployment-wide defaults (v1.1.0+).** `min_search_score`,
 > `min_term_coverage`, and `search_alpha` can also be set **once, in the
 > database**, and every access path obeys — CLI, local and remote MCP, Edge

--- a/docs/guides/content-format.md
+++ b/docs/guides/content-format.md
@@ -40,7 +40,14 @@ in — even after the current version has moved to format 2.
 - A document **moves to format 2 automatically the next time it is edited/saved**
   (it gets re-chunked by the new chunker).
 - If you want to convert everything now rather than on next edit, run
-  `cerefox server reindex` (re-chunks + re-embeds the whole knowledge base).
+  `cerefox server migrate-format`. It re-ingests each legacy document through
+  the normal pipeline (re-chunk + re-embed + stamp the current format), which
+  costs embedding spend — so it is opt-in, supports `--dry-run` and `--limit`,
+  and skips any document that changes mid-run rather than overwriting it.
+
+  > **Not `cerefox server reindex`.** Reindex refreshes *embeddings* on the
+  > existing chunk rows; it never re-chunks, so it cannot advance the stored
+  > format. Earlier versions of this guide said otherwise (#164).
 
 `cerefox doctor` reports how many documents still use the legacy format — purely
 informational, never a failure. A fresh install shows zero.

--- a/docs/guides/setup-supabase.md
+++ b/docs/guides/setup-supabase.md
@@ -21,7 +21,22 @@ This guide walks you from a blank Supabase project to a fully deployed Cerefox s
 1. Go to [app.supabase.com](https://app.supabase.com) and sign in
 2. Click **New project**
 3. Choose a name (e.g. `cerefox`), set a strong database password, pick a region close to you
-4. Click **Create new project** and wait ~2 minutes for it to provision
+4. Review the security options offered at creation (defaults in brackets):
+   - **Enable Data API** *[on]* — **keep it on.** The CLI, web UI, and local MCP all reach
+     Supabase through PostgREST; without it nothing works.
+   - **Automatically expose new tables** *[on]* — **turn it off.** Cerefox grants its tables
+     to `service_role` explicitly (migration `0013`), so it does not rely on implicit
+     exposure, and leaving it on means any future table is exposed to the Data API roles by
+     default. Supabase recommends disabling it too.
+   - **Enable automatic RLS** *[off]* — optional. Cerefox's schema already runs
+     `ENABLE ROW LEVEL SECURITY` on every table it creates, so this only covers tables
+     Cerefox doesn't own. Harmless either way; every Cerefox access path authenticates as
+     `service_role`, which bypasses RLS by design.
+5. Click **Create new project** and wait ~2 minutes for it to provision
+
+> **Note on the database password**: it is used *only* by `cerefox server deploy` (a direct
+> Postgres connection for DDL). Everyday CLI, web, and MCP traffic uses the secret key
+> instead. Store it in a password manager — Supabase will not show it again.
 
 ---
 
@@ -56,14 +71,24 @@ Either way: keep this key secret — it bypasses Row Level Security and grants f
 
 This is used by `cerefox server deploy` (and the contributor scripts `bun scripts/db_deploy.ts` / `bun scripts/db_migrate.ts`). See the **[Connection pooling in 2026](#connection-pooling-2026)** reference section near the end of this guide for context. The short version:
 
-1. Open **Project Settings → Database → Connection pooling** (not the "Connect" dialog — that one usually omits the Session Pooler in the new UI).
+1. From the **project overview**, click the **Copy** button beside the project URL, then
+   **Get Connected** in the dropdown. Under **Direct Connection Pooling**, choose
+   **Session pooler**. *(Verified against a project created 2026-08-05. Supabase moves this
+   regularly — it used to live under Project Settings → Database → Connection pooling, which
+   may still work.)*
 2. Copy the **Session Pooler** URI (host ends in `.pooler.supabase.com`, port `5432`).
 3. Confirm the username has the form `postgres.<project-ref>` — without that suffix you'll get "Tenant or user not found".
 4. Append `?sslmode=require` to enforce TLS explicitly.
 
+The result looks like this — note both the ref-suffixed username **and** the pooler host:
+
+```
+postgresql://postgres.abcdefghijklmnop:<password>@aws-0-<region>.pooler.supabase.com:5432/postgres?sslmode=require
+```
+
 If you only see Direct Connection and Transaction Pooler in your dashboard, take the Transaction Pooler URI and change `:6543` → `:5432`. That gives you the Session Pooler. **Do not use port 6543** — Transaction Pooler does not support DDL and the schema deploy will fail mid-schema.
 
-The Direct Connection (`db.<project-ref>.supabase.co:5432`) is IPv6-only on the free tier and unusable on most home/office networks. The dashboard now warns about this directly.
+> **Don't take the Direct connection string** (`postgresql://postgres:<password>@db.<ref>.supabase.co:5432/postgres`). It is the most prominent option in the dialog, but it is IPv6-only on the free tier, so it times out on most home and office networks. The dashboard warns about this directly.
 
 ---
 
@@ -380,7 +405,13 @@ Not yet. The Supabase docs explicitly state: *"You can still use old anon and se
 
 ## Connection pooling in 2026 <a id="connection-pooling-2026"></a>
 
-Supabase's "Connect" dialog was redesigned in 2026 and the **Session Pooler** is no longer a first-class tab in many projects. The other two surfaces (Direct Connection and Transaction Pooler) are present but neither works for Cerefox's deployment scripts. Here's the full picture.
+Supabase's "Connect" dialog has been redesigned repeatedly through 2026, and where the
+**Session Pooler** lives has moved with it. As of **2026-08-05** it is inside the Connect
+dialog: project overview → **Copy** (beside the project URL) → **Get Connected** →
+**Direct Connection Pooling** → **Session pooler**. Earlier in the year it was only under
+Project Settings → Database → Connection pooling. Check both if one comes up empty — and the
+shape of the URI is the reliable signal, not the menu path: **ref-suffixed username plus a
+`.pooler.supabase.com` host on port 5432**. Here's the full picture.
 
 ### The three Postgres connection types
 

--- a/docs/guides/staging-env.md
+++ b/docs/guides/staging-env.md
@@ -154,6 +154,14 @@ Use one of:
 `doctor` is the one to reach for; the migration list is only interesting when a
 deploy behaved unexpectedly.
 
+> **Contributor scripts and a repo `.env`.** The `bun scripts/*.ts` tools honour
+> `CEREFOX_CONFIG_DIR` — but only from the version that fixed this. Bun
+> auto-loads `.env` from the working directory, so on **v1.1.0-beta.1 and
+> earlier** a repo clone with its own `.env` silently outranked the config dir:
+> `CEREFOX_CONFIG_DIR=…/staging bun scripts/db_migrate.ts --status` reported
+> *production*. If you're on an older build, run those scripts from a directory
+> with no `.env`, and confirm the target before trusting the output.
+
 ---
 
 ## 5. Populate from a production snapshot
@@ -190,6 +198,16 @@ Two count details that look like bugs and are not:
 The daemon's pidfile and log follow `CEREFOX_CONFIG_DIR`, so staging writes to
 `~/.cerefox/staging/web.{pid,log}` and production to `~/.cerefox/web.{pid,log}`.
 Each `web stop` / `web status` acts only on its own environment.
+
+> **Requires v1.1.0-beta.2 or later.** On **beta.1 and earlier** both
+> environments shared `~/.cerefox/web.pid`, so `cfx-stg web start` refuses with
+> *"A Cerefox web daemon is already running on :8000"* — it is reading
+> production's pidfile. Until staging is on a build with the fix, start it in
+> the **foreground** instead, which never touches the pidfile:
+>
+> ```bash
+> cfx-stg web --port 8030      # no `start` subcommand; Ctrl-C to stop
+> ```
 
 Pick a different port for staging so the two can run simultaneously:
 

--- a/docs/guides/staging-env.md
+++ b/docs/guides/staging-env.md
@@ -10,9 +10,13 @@ production stays untouched.
 > want staging, you can stop reading; `cerefox …` behaves exactly as documented
 > in [`setup-supabase.md`](setup-supabase.md).
 
-**Status**: the environment split (config, database, backups) is **validated**.
-Running two *different Cerefox versions* in parallel has **known gaps** — see
-[Known limits](#known-limits) before relying on it.
+**Status**: validated end to end — config, database, backups, CLI version, and
+the web server all separate cleanly. One gap remains (agent/MCP wiring); see
+[Known limits](#known-limits).
+
+This is a **convention, not a feature**. There is no `--env` flag and no profile
+system to learn: two environment variables and a shell alias do the whole job,
+which is why none of it can destabilise a normal single-environment install.
 
 ---
 
@@ -80,15 +84,50 @@ SUPABASE_ACCESS_TOKEN=sbp_…                       # account-level; same as pro
 A staging result only means something if the knobs match; different chunk sizes
 make every comparison noise. **Do not** copy credentials — staging has its own.
 
-Add an alias so you never type the prefix:
+---
+
+## 3. Pin a Cerefox version for staging
+
+`CEREFOX_CONFIG_DIR` switches the *database*, not the *code*. The `cerefox` on
+your PATH is a single global npm install, so on its own it would point both
+environments at the same version — which defeats the main purpose of staging:
+rehearsing a **pre-release** build before production ever sees it.
+
+Give staging its own install tree. npm's `--prefix` keeps it entirely separate
+from the global one, so production's binary is never touched:
 
 ```bash
-alias cfx-stg='CEREFOX_CONFIG_DIR=~/.cerefox/staging cerefox'
+npm install -g --prefix ~/.cerefox/staging/cli @cerefox/memory@beta
 ```
+
+Then bind **both axes — version and environment — in a single alias**, so they
+can never drift apart:
+
+```bash
+alias cfx-stg='CEREFOX_CONFIG_DIR=~/.cerefox/staging ~/.cerefox/staging/cli/bin/cerefox'
+```
+
+Put it in `~/.zshrc` (or `~/.bashrc`) and reload. From here on, `cerefox` means
+production-version-on-production-data and `cfx-stg` means
+staging-version-on-staging-data. There is no combination of the two that a typo
+can produce.
+
+Verify the split before trusting it:
+
+```bash
+cerefox --version    # production, e.g. 1.0.8
+cfx-stg --version    # staging, e.g. 1.1.0-beta.2
+```
+
+To move staging to a newer pre-release later, re-run the `npm install` above;
+production is unaffected. If you'd rather not keep an install tree at all,
+`npx --package=@cerefox/memory@beta cerefox …` works too, but it re-resolves the
+package on every call and makes the version harder to pin down when something
+misbehaves.
 
 ---
 
-## 3. Deploy and verify
+## 4. Deploy and verify
 
 ```bash
 cfx-stg server deploy      # fresh database → schema + RPCs + 9 Edge Functions
@@ -103,9 +142,21 @@ on a fresh project:
   Function / remote-MCP path there.
 - `✓ content format  no documents yet` — nothing imported.
 
+**Checking database/schema state.** There is no `cerefox db status` command.
+Use one of:
+
+| Want | Command |
+|---|---|
+| Deployed schema version, reachability, drift banner | `cfx-stg doctor` |
+| What a deploy *would* do, without doing it | `cfx-stg server deploy --dry-run` |
+| Per-migration applied/pending list | `bun scripts/db_migrate.ts --status` (repo clone; contributor-only) |
+
+`doctor` is the one to reach for; the migration list is only interesting when a
+deploy behaved unexpectedly.
+
 ---
 
-## 4. Populate from a production snapshot
+## 5. Populate from a production snapshot
 
 ```bash
 cerefox backup create                       # production
@@ -113,33 +164,66 @@ cfx-stg backup restore ~/.cerefox/backups/<snapshot>.json
 ```
 
 Backups carry documents, chunks, projects, memberships and (from v1.1.0)
-relations and lifecycle status. Restore is idempotent, so a re-run is safe.
+relations and lifecycle status. Restore is idempotent — re-running it is safe
+and converges on the same state rather than duplicating anything.
 
 Restoring an **older** snapshot into a **newer** schema works — new columns take
 their defaults. The reverse is not supported.
+
+Two count details that look like bugs and are not:
+
+- **Trashed documents are not carried over.** `backup create` captures live
+  documents only (`deleted_at IS NULL`), so anything in production's trash is
+  absent from staging. Nothing in the trash is lost *in production* — it just
+  isn't part of the snapshot.
+- **A membership shortfall on pre-v1.1.0 snapshots.** Older `backup create`
+  captured the document↔project junction unfiltered, including rows belonging
+  to trashed documents. Restore drops those (their document isn't in the file),
+  so the summary reports fewer memberships than the header claims — 362 of 369
+  on the maintainer's store. From v1.1.0 the capture filters them out, and the
+  two numbers agree.
+
+---
+
+## 6. Run both web servers at once
+
+The daemon's pidfile and log follow `CEREFOX_CONFIG_DIR`, so staging writes to
+`~/.cerefox/staging/web.{pid,log}` and production to `~/.cerefox/web.{pid,log}`.
+Each `web stop` / `web status` acts only on its own environment.
+
+Pick a different port for staging so the two can run simultaneously:
+
+```bash
+cfx-stg web start --port 8010
+cfx-stg web status      # staging only
+cerefox web status      # production only — unaffected
+```
+
+Set `CEREFOX_ENV_LABEL=staging` in the staging `.env` (Step 2) and the web UI
+labels itself, so a stray browser tab can't be mistaken for production.
 
 ---
 
 ## Known limits
 
-**Two environments, one CLI version.** `CEREFOX_CONFIG_DIR` switches the
-*database*, not the *code*. The `cerefox` on your PATH is a single global npm
-install, so today both environments run the same version. To point staging at a
-pre-release build without disturbing production, install it under its own
-prefix and bind both axes in the alias:
-
-```bash
-npm install -g --prefix ~/.cerefox/staging/cli @cerefox/memory@beta
-alias cfx-stg='CEREFOX_CONFIG_DIR=~/.cerefox/staging ~/.cerefox/staging/cli/bin/cerefox'
-```
-
-The following still collide across environments and are being worked on:
-
 | Area | Problem |
 |---|---|
-| **Web daemon** | `web start` writes its PID and log to `~/.cerefox/web.{pid,log}` regardless of `CEREFOX_CONFIG_DIR`, so a staging daemon overwrites production's bookkeeping. Until that is fixed, run staging's server in the **foreground** on a different port (`cfx-stg web --port 8010`) rather than as a daemon. |
-| **Agent (MCP) config** | `configure-agent` registers the MCP server under the fixed name `cerefox`, so running it from staging **overwrites your production agent wiring**. Don't run it against staging yet. |
+| **Agent (MCP) config** | `configure-agent` registers the MCP server under the fixed name `cerefox`, so running it from staging **overwrites your production agent wiring**. Don't run it against staging yet — tracked in [#168](https://github.com/fstamatelopoulos/cerefox/issues/168). |
 | **`doctor`'s `mcp clients` line** | It inspects your global agent configs, which point at production, and reports them even in staging mode. Informative, but easy to misread as "staging is wired to my agents". |
+
+Everything else — config, database, backups, CLI version, web daemon — is
+separated and validated.
+
+### What is *not* isolated, by design
+
+Two things are shared on purpose, and both are safe:
+
+- **`SUPABASE_ACCESS_TOKEN`** is an account-level credential, not a
+  project-level one. The same value belongs in both `.env` files; the project
+  it acts on comes from the URL and database URL beside it.
+- **Your OpenAI key.** Staging embeds against the same account, so staging
+  ingestion and `migrate-format` rehearsals cost real money. That is the point —
+  it is how you measure the spend before committing production to it.
 
 ---
 

--- a/docs/guides/staging-env.md
+++ b/docs/guides/staging-env.md
@@ -1,0 +1,150 @@
+# Running a staging environment alongside production
+
+Cerefox can talk to more than one backend from a single machine. This guide sets
+up a **staging** environment — a second Supabase project you can deploy
+pre-release builds to, import production data into, and break freely — while
+production stays untouched.
+
+> **Nothing here affects a normal single-environment install.** Every mechanism
+> below is opt-in and inert unless you set `CEREFOX_CONFIG_DIR`. If you never
+> want staging, you can stop reading; `cerefox …` behaves exactly as documented
+> in [`setup-supabase.md`](setup-supabase.md).
+
+**Status**: the environment split (config, database, backups) is **validated**.
+Running two *different Cerefox versions* in parallel has **known gaps** — see
+[Known limits](#known-limits) before relying on it.
+
+---
+
+## Why bother
+
+Two things are hard to test safely against production:
+
+- **Upgrades.** A release that changes the schema will run its migrations
+  against your real data exactly once. Staging lets you rehearse that on a copy.
+- **Destructive or expensive operations.** `server migrate-format` re-embeds
+  every legacy document (real spend, rewrites chunks). Proving it on a copy
+  first turns an act of faith into a measurement.
+
+---
+
+## 1. Create the staging Supabase project
+
+Follow [`setup-supabase.md` Step 1](setup-supabase.md), with two differences:
+
+- Name it distinctly (`cerefox-staging`) — the dashboard project switcher is
+  your first defense against acting on the wrong database.
+- Pick the **same region as production** if you care about comparable timings.
+  A different region is fine functionally; just never compare *speed* across
+  the two.
+
+The creation-time security options are the same as production, and the
+"automatically expose new tables" setting is worth disabling on both — Cerefox
+grants its tables to `service_role` explicitly.
+
+---
+
+## 2. Give staging its own config directory
+
+`CEREFOX_CONFIG_DIR` overrides where Cerefox reads `.env`. Production lives at
+`~/.cerefox/.env` and is never consulted when the override is set.
+
+```bash
+mkdir -p ~/.cerefox/staging && chmod 700 ~/.cerefox/staging
+```
+
+Then either run the interactive setup against it:
+
+```bash
+CEREFOX_CONFIG_DIR=~/.cerefox/staging cerefox init
+```
+
+…or write `~/.cerefox/staging/.env` (mode 0600) directly:
+
+```bash
+CEREFOX_ENV_LABEL=staging
+CEREFOX_SUPABASE_URL=https://<staging-ref>.supabase.co
+CEREFOX_SUPABASE_KEY=sb_secret_…                 # staging project's secret key
+CEREFOX_DATABASE_URL=postgresql://postgres.<staging-ref>:…@aws-0-<region>.pooler.supabase.com:5432/postgres?sslmode=require
+
+# Isolate snapshots. CEREFOX_BACKUP_DIR does NOT follow the config dir, so
+# without this line staging backups land beside production's.
+CEREFOX_BACKUP_DIR=~/.cerefox/staging/backups
+
+OPENAI_API_KEY=sk-…
+SUPABASE_ACCESS_TOKEN=sbp_…                       # account-level; same as prod
+```
+
+**Mirror production's tuning** (`CEREFOX_MIN_SEARCH_SCORE`,
+`CEREFOX_MAX_CHUNK_CHARS`, `CEREFOX_MIN_CHUNK_CHARS`, `CEREFOX_EMBEDDER`, …).
+A staging result only means something if the knobs match; different chunk sizes
+make every comparison noise. **Do not** copy credentials — staging has its own.
+
+Add an alias so you never type the prefix:
+
+```bash
+alias cfx-stg='CEREFOX_CONFIG_DIR=~/.cerefox/staging cerefox'
+```
+
+---
+
+## 3. Deploy and verify
+
+```bash
+cfx-stg server deploy      # fresh database → schema + RPCs + 9 Edge Functions
+cfx-stg doctor
+```
+
+`doctor` should report the staging config path and URL. Two lines are expected
+on a fresh project:
+
+- `ℹ edge functions … No CEREFOX_ACCESS_TOKEN set` — staging has no Cerefox
+  access token yet. Run `cfx-stg token generate` if you plan to test the Edge
+  Function / remote-MCP path there.
+- `✓ content format  no documents yet` — nothing imported.
+
+---
+
+## 4. Populate from a production snapshot
+
+```bash
+cerefox backup create                       # production
+cfx-stg backup restore ~/.cerefox/backups/<snapshot>.json
+```
+
+Backups carry documents, chunks, projects, memberships and (from v1.1.0)
+relations and lifecycle status. Restore is idempotent, so a re-run is safe.
+
+Restoring an **older** snapshot into a **newer** schema works — new columns take
+their defaults. The reverse is not supported.
+
+---
+
+## Known limits
+
+**Two environments, one CLI version.** `CEREFOX_CONFIG_DIR` switches the
+*database*, not the *code*. The `cerefox` on your PATH is a single global npm
+install, so today both environments run the same version. To point staging at a
+pre-release build without disturbing production, install it under its own
+prefix and bind both axes in the alias:
+
+```bash
+npm install -g --prefix ~/.cerefox/staging/cli @cerefox/memory@beta
+alias cfx-stg='CEREFOX_CONFIG_DIR=~/.cerefox/staging ~/.cerefox/staging/cli/bin/cerefox'
+```
+
+The following still collide across environments and are being worked on:
+
+| Area | Problem |
+|---|---|
+| **Web daemon** | `web start` writes its PID and log to `~/.cerefox/web.{pid,log}` regardless of `CEREFOX_CONFIG_DIR`, so a staging daemon overwrites production's bookkeeping. Until that is fixed, run staging's server in the **foreground** on a different port (`cfx-stg web --port 8010`) rather than as a daemon. |
+| **Agent (MCP) config** | `configure-agent` registers the MCP server under the fixed name `cerefox`, so running it from staging **overwrites your production agent wiring**. Don't run it against staging yet. |
+| **`doctor`'s `mcp clients` line** | It inspects your global agent configs, which point at production, and reports them even in staging mode. Informative, but easy to misread as "staging is wired to my agents". |
+
+---
+
+## Housekeeping
+
+Pause the staging project in the Supabase dashboard between test rounds — a
+paused project keeps its data without consuming free-tier compute. Check your
+plan's limit on simultaneously active projects before creating the second one.

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -4007,6 +4007,38 @@ and the web UI relation panel — re-opening search ranking so soon after the
 **Release shape**: dogfooded through `1.1.0-beta.N` on both worlds per
 RELEASING.md, since Phase 1 and Phase 2 both carry real regression risk.
 
+### beta.2 workstream (branch `feat/beta2-playwright-config-ui`)
+
+Cut from main after `1.1.0-beta.1`. Not released yet — beta.1 is deliberately
+untested against production until a staging Supabase project exists (below).
+
+- ✅ **#155 UI e2e repair.** The Playwright suite had drifted to 8 failures +
+  2 *silent skips* out of 13; every failure was a stale selector, not a broken
+  app (copy polished ASCII `...`→`…`, headings renamed, project creation moved
+  into a modal, two buttons now matching "Search"). Now 13/13 in ~32s (was
+  3.7min — three failures were 60s `page.fill` timeouts). Page identity is
+  asserted via `data-testid` hooks, because the dashboard heading is a
+  time-of-day greeting that should never have been in a test.
+- ✅ **Relations ship dormant** (`relations_enabled`, default false). The
+  maintainer's stability requirement for v1: the table and column were already
+  inert, but the four tools appeared in every agent's list. Gated in both
+  transports, fail-closed, guarded on the call path too. Verified live: 10
+  tools advertised with the flag off, 14 with it on. Schema 0.10.1.
+- ✅ **#165 keyboard accessibility.** Dashboard document/project rows were
+  click-only `<tr>`s — unreachable by keyboard, no cmd/middle-click, no copy
+  link. Real links now. (This also caused the e2e suite's silent skips.)
+- ⏳ **Config web UI** — a settings surface for the `cerefox_config` keys
+  (`cerefox config set` equivalents, incl. the retrieval tunables from #133 and
+  `relations_enabled`). Next up.
+
+**Open decisions carried to the staging session:**
+- Staging Supabase project (separate project, same account) — gives an isolated
+  DB *and* finally exercises the never-validated fresh-install path (the
+  original #26 concern). Needs a config-switching story (a second config dir or
+  env-file selection) so the CLI can target staging without touching prod.
+- Relation-aware search: agreed as an **optional extension**, designed and
+  discussed before any implementation.
+
 **Update (2026-08-03): v1.0.2 SHIPPED (security/maintenance patch) + supply-chain regime.**
 Full-repo doc sanity pass + security audit (PR #112; audit addendum in
 `docs/specs/security-audit-1.0.md`): dependency refresh (19 advisories → 3

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -4027,15 +4027,53 @@ untested against production until a staging Supabase project exists (below).
 - ✅ **#165 keyboard accessibility.** Dashboard document/project rows were
   click-only `<tr>`s — unreachable by keyboard, no cmd/middle-click, no copy
   link. Real links now. (This also caused the e2e suite's silent skips.)
+- ✅ **Staging environment stood up and validated** (2026-08-05).
+  `cerefox-staging` Supabase project deployed from scratch — which finally
+  exercised the never-validated fresh-install path and confirmed the #26
+  explicit `service_role` grants work on a project with "automatically expose
+  new tables" **disabled**. Production data imported (319 docs / 17 projects).
+  The parallel-worlds story is a **convention, not a feature** (maintainer
+  decision: "simpler is better, I am the only user") — `CEREFOX_CONFIG_DIR`
+  for the database, a separate `npm --prefix` install tree for the *version*,
+  and one alias binding both axes. No `--env` flag, no profiles, so a normal
+  single-environment install is untouched. Written up in
+  `docs/guides/staging-env.md`.
+- ✅ **Five defects the staging exercise found**, all fixed here. Each was
+  invisible from a single-environment machine, which is the argument for
+  keeping staging:
+  1. **`CEREFOX_CONFIG_DIR` was silently ignored by every `bun scripts/*.ts`.**
+     Bun auto-loads `.env` from the working directory, and `loadEnv()` only
+     filled *unset* keys, so the repo's production credentials won.
+     `db_migrate.ts --status` reported production while naming staging; the
+     same path through `db_deploy.ts --reset` **would have wiped production**.
+     The named config dir is now authoritative, and `--reset` prints the target
+     project ref before asking.
+  2. **Web daemon state was global** — `web.{pid,log}` ignored the config dir,
+     so a staging `web stop` would have killed the production server.
+  3. **`backup create` aborted against any pre-0.10.0 server** (named
+     `lifecycle_status` unconditionally) — i.e. it failed at the one moment it
+     matters most, snapshotting production *before* an upgrade.
+  4. **`backup restore` was not idempotent**, contrary to its help text: it
+     deduped on `content_hash`, so a document edited between snapshots kept its
+     id, changed its hash, and collided on the primary key.
+  5. **`db_status` pointed users at `db_deploy.py`**, deleted at v1.0.0.
+- ✅ **Backup format 4 — the trash is captured.** Soft-delete is not a purge
+  and nothing ever collects it (the 48h sweep prunes *versions*), so snapshots
+  were silently lossy. Trashed documents now round-trip and are restored **as
+  trash** (`deleted_at` replayed; every read/search RPC filters it), with
+  `--no-trash` to opt out. Proven end to end: 331 captured (12 trashed) →
+  319 live + 12 trashed in staging, exact match; re-run 0/331/0.
 - ⏳ **Config web UI** — a settings surface for the `cerefox_config` keys
   (`cerefox config set` equivalents, incl. the retrieval tunables from #133 and
   `relations_enabled`). Next up.
 
-**Open decisions carried to the staging session:**
-- Staging Supabase project (separate project, same account) — gives an isolated
-  DB *and* finally exercises the never-validated fresh-install path (the
-  original #26 concern). Needs a config-switching story (a second config dir or
-  env-file selection) so the CLI can target staging without touching prod.
+**Open decisions carried forward:**
+- **#168 — `configure-agent` overwrites production MCP wiring** when run from a
+  second environment (fixed server name `cerefox`). The last un-separated axis;
+  proposal is to derive the name from `CEREFOX_ENV_LABEL`.
+- `migrate-format` on production: rehearsed on staging (3 of 214 converted
+  cleanly, content intact) but **not yet run on prod** — 214 legacy documents
+  there, real embedding spend.
 - Relation-aware search: agreed as an **optional extension**, designed and
   discussed before any implementation.
 

--- a/docs/requirements-and-specs.md
+++ b/docs/requirements-and-specs.md
@@ -431,7 +431,7 @@ All parameters use `CEREFOX_` prefix and can be set via environment variables or
 | `CEREFOX_MAX_RESPONSE_BYTES` | `200000` | Max response size for MCP/search |
 | `CEREFOX_MAX_CHUNK_CHARS` | `4000` | Max characters per chunk |
 | `CEREFOX_MIN_CHUNK_CHARS` | `100` | Min characters per chunk |
-| `CEREFOX_BACKUP_DIR` | `./backups` | Directory for file system backups |
+| `CEREFOX_BACKUP_DIR` | `~/.cerefox/backups` | Directory for file system backups. Use an absolute path — a relative value resolves against the working directory, so snapshots scatter. (`./backups` was the pre-v0.3.0 default and may linger in older `.env` files.) |
 | `CEREFOX_VECTOR_DIMENSIONS` | `768` | Embedding vector dimensions |
 | `CEREFOX_LOG_LEVEL` | `INFO` | Logging level |
 | `CEREFOX_SMALL_TO_BIG_THRESHOLD` | `20000` | Doc size (chars) above which search returns chunks + neighbors instead of full document |

--- a/frontend/src/components/ListPage.tsx
+++ b/frontend/src/components/ListPage.tsx
@@ -75,7 +75,7 @@ export function ListPage<T>({
       <div className={ui.pageHead}>
         <div>
           <p className={ui.eyebrow}>{eyebrow}</p>
-          <h1 className={ui.pageTitle}>{title}</h1>
+          <h1 className={ui.pageTitle} data-testid="page-title">{title}</h1>
           {subtitle && <p className={ui.pageSub}>{subtitle}</p>}
         </div>
         {headerRight}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -104,7 +104,7 @@ export function DashboardPage() {
       <div className={`${styles.dashHero} ${ui.rise}`}>
         <div style={{ minWidth: 0 }}>
           <p className={ui.eyebrow}>Memory layer · online</p>
-          <h1 className={ui.pageTitle}>{greeting()}, operator.</h1>
+          <h1 className={ui.pageTitle} data-testid="page-title">{greeting()}, operator.</h1>
         </div>
         <div className={styles.dashHeroActions}>
           <form
@@ -247,7 +247,7 @@ export function DashboardPage() {
                   const ChipIcon = chip.icon;
                   const pending = doc.review_status !== "approved";
                   return (
-                    <tr key={doc.id} onClick={() => navigate(`/document/${doc.id}`)}>
+                    <tr key={doc.id} data-testid="recent-doc-row" onClick={() => navigate(`/document/${doc.id}`)}>
                       <td>
                         <div className={styles.docCell}>
                           <span className={styles.docDot} style={{ background: projColor(doc) }} />

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -17,7 +17,7 @@ import {
 } from "@tabler/icons-react";
 import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 
 import { fetchUsageSummary } from "../api/analytics";
 import { CliCard } from "../components/CliCard";
@@ -252,9 +252,17 @@ export function DashboardPage() {
                         <div className={styles.docCell}>
                           <span className={styles.docDot} style={{ background: projColor(doc) }} />
                           <div className={ui.col} style={{ gap: 3, minWidth: 0 }}>
-                            <span className={`${ui.link} ${styles.docTitle}`}>
+                            {/* A real link, not just a row click (#165): keyboard
+                                users can reach it, and cmd/middle-click, "copy
+                                link", and hover preview all work again. The row
+                                click below stays as a convenience. */}
+                            <Link
+                              to={`/document/${doc.id}`}
+                              className={`${ui.link} ${styles.docTitle}`}
+                              onClick={(e) => e.stopPropagation()}
+                            >
                               {doc.title || "Untitled"}
-                            </span>
+                            </Link>
                             <div className={ui.row} style={{ gap: 6 }}>
                               {doc.project_ids
                                 .filter((pid) => projectMap.has(pid))
@@ -335,7 +343,14 @@ export function DashboardPage() {
                       <span className={styles.projDot} style={{ background: color }} />
                       <div className={ui.col} style={{ gap: 5, minWidth: 0, flex: 1 }}>
                         <div className={ui.row} style={{ justifyContent: "space-between", gap: 8 }}>
-                          <span className={styles.projName}>{p.name}</span>
+                          {/* Real link for the same reasons as the document rows (#165). */}
+                          <Link
+                            to={`/projects/${p.id}/documents`}
+                            className={styles.projName}
+                            onClick={(e) => e.stopPropagation()}
+                          >
+                            {p.name}
+                          </Link>
                           <span className={styles.projCounts}>
                             <span>{docs}</span>
                             {trash > 0 && (

--- a/frontend/src/pages/IngestPage.tsx
+++ b/frontend/src/pages/IngestPage.tsx
@@ -133,7 +133,7 @@ export function IngestPage() {
       <div className={ui.pageHead}>
         <div>
           <p className={ui.eyebrow}>Add to memory</p>
-          <h1 className={ui.pageTitle}>Ingest content</h1>
+          <h1 className={ui.pageTitle} data-testid="page-title">Ingest content</h1>
         </div>
       </div>
 

--- a/frontend/src/pages/MetadataSearchPage.tsx
+++ b/frontend/src/pages/MetadataSearchPage.tsx
@@ -70,7 +70,7 @@ export function MetadataSearchPage() {
       <div className={ui.pageHead}>
         <div>
           <p className={ui.eyebrow}>Knowledge base</p>
-          <h1 className={ui.pageTitle}>Metadata Search</h1>
+          <h1 className={ui.pageTitle} data-testid="page-title">Metadata Search</h1>
           <p className={ui.pageSub}>Find documents by their metadata keys and values.</p>
         </div>
         <CliHint cmd="cerefox metadata search" args={cliArgs} />
@@ -121,7 +121,7 @@ export function MetadataSearchPage() {
             <TextInput label="Created since" type="date" value={createdSince} onChange={(e) => setCreatedSince(e.currentTarget.value)} size="sm" />
           </Group>
 
-          <Button leftSection={<IconSearch size={16} />} onClick={handleSearch} disabled={validFilterCount === 0} loading={isPending} style={{ alignSelf: "flex-start" }}>
+          <Button data-testid="metadata-search-submit" leftSection={<IconSearch size={16} />} onClick={handleSearch} disabled={validFilterCount === 0} loading={isPending} style={{ alignSelf: "flex-start" }}>
             Search
           </Button>
         </Stack>

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -44,7 +44,7 @@ export function SearchPage() {
       <div className={ui.pageHead}>
         <div>
           <p className={ui.eyebrow}>Knowledge base</p>
-          <h1 className={ui.pageTitle}>Search memory</h1>
+          <h1 className={ui.pageTitle} data-testid="page-title">Search memory</h1>
         </div>
         <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 8 }}>
           {dash && (

--- a/frontend/tests/e2e/ui.spec.ts
+++ b/frontend/tests/e2e/ui.spec.ts
@@ -47,17 +47,16 @@ async function purgeProjectByName(name: string): Promise<void> {
 test.describe("Dashboard", () => {
   test("loads and shows stats", async ({ page }) => {
     await page.goto(APP);
-    await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible();
+    await expect(page.getByTestId("page-title")).toBeVisible();
     await expect(page.getByText("Documents", { exact: true }).first()).toBeVisible();
-    await expect(page.getByText("Recent Documents")).toBeVisible();
   });
 
   test("quick search navigates to search", async ({ page }) => {
     await page.goto(APP);
-    await page.fill('input[placeholder="Quick search..."]', "cerefox");
-    await page.click('button:has-text("Go")');
+    await page.fill('input[placeholder="Quick search…"]', "cerefox");
+    await page.getByRole("button", { name: "Search" }).first().click();
     await page.waitForURL("**/search**");
-    await expect(page.getByRole("heading", { name: "Search Knowledge Base" })).toBeVisible();
+    await expect(page.getByTestId("page-title")).toHaveText(/Search/i);
   });
 });
 
@@ -66,11 +65,11 @@ test.describe("Ingest (paste)", () => {
   test("paste ingest creates a document", async ({ page }) => {
     const title = uniqueTitle("Playwright Paste Test");
     await page.goto(`${APP}/ingest`);
-    await expect(page.getByRole("heading", { name: "Ingest Content" })).toBeVisible();
+    await expect(page.getByTestId("page-title")).toHaveText(/Ingest/i);
 
     await page.fill('input[placeholder="Document title"]', title);
     await page.fill(
-      'textarea[placeholder="Paste your Markdown content here..."]',
+      'textarea[placeholder="# Paste your Markdown here…"]',
       `# Test Document\n\nPlaywright e2e ${crypto.randomUUID()}.`,
     );
     await page.click('button[type="submit"]:has-text("Ingest")');
@@ -87,12 +86,12 @@ test.describe("Ingest (paste)", () => {
 test.describe("Search", () => {
   test("search page loads", async ({ page }) => {
     await page.goto(`${APP}/search`);
-    await expect(page.getByRole("heading", { name: "Search Knowledge Base" })).toBeVisible();
+    await expect(page.getByTestId("page-title")).toHaveText(/Search/i);
   });
 
   test("search returns results", async ({ page }) => {
     await page.goto(`${APP}/search?q=cerefox&mode=docs`);
-    await expect(page.getByText("results found")).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText(/\d+ results? ·/)).toBeVisible({ timeout: 15_000 });
   });
 });
 
@@ -101,8 +100,9 @@ test.describe("Projects", () => {
   test("project create → verify → delete", async ({ page }) => {
     const projectName = uniqueTitle("Test Project");
     await page.goto(`${APP}/projects`);
-    await expect(page.getByRole("heading", { name: "Projects", exact: true })).toBeVisible();
+    await expect(page.getByTestId("page-title")).toHaveText("Projects");
 
+    await page.getByRole("button", { name: "New project" }).click();
     await page.fill('input[placeholder="Project name"]', projectName);
     await page.fill('input[placeholder="Optional description"]', "E2E test project");
     await page.click('button[type="submit"]:has-text("Create")');
@@ -119,12 +119,12 @@ test.describe("Document detail", () => {
   test("document page loads with action buttons", async ({ page }) => {
     await page.goto(APP);
     await page.waitForTimeout(2000);
-    const docLinks = page.locator("a[href*='/document/']");
-    if ((await docLinks.count()) === 0) {
+    const docRows = page.getByTestId("recent-doc-row");
+    if ((await docRows.count()) === 0) {
       test.skip(true, "No documents in the database to test");
       return;
     }
-    await docLinks.first().click();
+    await docRows.first().click();
     await page.waitForTimeout(2000);
     await expect(page.getByRole("button", { name: "Edit" })).toBeVisible();
     await expect(page.getByRole("link", { name: "Download" })).toBeVisible();
@@ -133,14 +133,16 @@ test.describe("Document detail", () => {
   test("review status toggle visible", async ({ page }) => {
     await page.goto(APP);
     await page.waitForTimeout(2000);
-    const docLinks = page.locator("a[href*='/document/']");
-    if ((await docLinks.count()) === 0) {
+    const docRows = page.getByTestId("recent-doc-row");
+    if ((await docRows.count()) === 0) {
       test.skip(true, "No documents in the database to test");
       return;
     }
-    await docLinks.first().click();
+    await docRows.first().click();
     await page.waitForTimeout(2000);
-    await expect(page.getByText("Approved")).toBeVisible();
+    // The toggle shows the CURRENT state — either is correct; the point is that
+    // the control renders.
+    await expect(page.getByText(/^(Approved|Pending)$/)).toBeVisible();
   });
 });
 
@@ -148,9 +150,9 @@ test.describe("Document detail", () => {
 test.describe("Metadata Search", () => {
   test("page loads with filter builder", async ({ page }) => {
     await page.goto(`${APP}/metadata-search`);
-    await expect(page.getByRole("heading", { name: "Metadata Search" })).toBeVisible();
+    await expect(page.getByTestId("page-title")).toHaveText(/Metadata/i);
     await expect(page.getByText("Metadata Filters")).toBeVisible();
-    await expect(page.getByRole("main").getByRole("button", { name: "Search" })).toBeVisible();
+    await expect(page.getByTestId("metadata-search-submit")).toBeVisible();
   });
 
   test("returns results or empty message", async ({ page }) => {
@@ -167,7 +169,7 @@ test.describe("Metadata Search", () => {
       await option.click();
     }
     await page.locator('input[placeholder="Value"]').first().fill("e2e-test-suite");
-    await page.getByRole("main").getByRole("button", { name: "Search" }).click();
+    await page.getByTestId("metadata-search-submit").click();
     await page.waitForTimeout(5000);
 
     await expect(
@@ -199,6 +201,6 @@ test.describe("Analytics", () => {
 test.describe("Audit Log", () => {
   test("page loads", async ({ page }) => {
     await page.goto(`${APP}/audit-log`);
-    await expect(page.getByRole("heading", { name: "Audit Log" })).toBeVisible();
+    await expect(page.getByTestId("page-title")).toHaveText(/Audit/i);
   });
 });

--- a/packages/memory/src/cli/commands/backup.ts
+++ b/packages/memory/src/cli/commands/backup.ts
@@ -144,6 +144,23 @@ async function action(options: BackupOptions): Promise<void> {
     // Older server without the relations table — nothing to capture.
   }
 
+  // Drop memberships whose document is not in this snapshot. Backups capture
+  // live documents only, but the junction carries rows for soft-deleted ones
+  // too — 7 of 369 on the maintainer's store. Restore already ignores them, so
+  // this is about the file being internally consistent: every membership in a
+  // snapshot should point at a document the snapshot contains.
+  {
+    const captured = new Set(docs.map((d) => d.id as string));
+    const before = memberships.length;
+    memberships = memberships.filter((m) => captured.has(m.document_id as string));
+    const dropped = before - memberships.length;
+    if (dropped > 0) {
+      println(
+        c.dim(`  (skipped ${dropped} membership(s) belonging to trashed documents)`),
+      );
+    }
+  }
+
   // For each doc, pull its chunks.
   let chunkTotal = 0;
   const enriched: Array<Record<string, unknown>> = [];

--- a/packages/memory/src/cli/commands/backup.ts
+++ b/packages/memory/src/cli/commands/backup.ts
@@ -82,7 +82,10 @@ async function action(options: BackupOptions): Promise<void> {
         .from("cerefox_documents")
         .select(
           "id, title, content_hash, source, metadata, total_chars, chunk_count, " +
-            "review_status, created_at, updated_at, deleted_at",
+            // lifecycle_status (iteration 29) must be listed explicitly: this
+            // select is an allow-list, which is how the previous columns went
+            // missing in the first place (#166).
+            "review_status, lifecycle_status, created_at, updated_at, deleted_at",
         )
         .is("deleted_at", null)
         .order("created_at", { ascending: true })
@@ -122,6 +125,23 @@ async function action(options: BackupOptions): Promise<void> {
     throw systemError(
       `Project/membership fetch failed: ${err instanceof Error ? err.message : String(err)}`,
     );
+  }
+
+  // Document relations (iteration 29). Absent on pre-0.10.0 servers, so a
+  // missing table is not an error — it just means this store has no graph.
+  let relations: Array<Record<string, unknown>> = [];
+  try {
+    relations = await fetchAllPages<Record<string, unknown>>((from, to) =>
+      client.raw
+        .from("cerefox_document_relations")
+        .select("source_id, target_id, rel_type, metadata, author, author_type, created_at")
+        .order("source_id", { ascending: true })
+        .order("target_id", { ascending: true })
+        .order("rel_type", { ascending: true })
+        .range(from, to),
+    );
+  } catch {
+    // Older server without the relations table — nothing to capture.
   }
 
   // For each doc, pull its chunks.
@@ -164,14 +184,17 @@ async function action(options: BackupOptions): Promise<void> {
   const payload = {
     created_at: new Date().toISOString(),
     cerefox_version: PKG_VERSION,
-    backup_format: 2,
+    // 3 = adds relations + lifecycle_status (iteration 29).
+    backup_format: 3,
     schema_version: schemaVersion,
     document_count: docs.length,
     chunk_count: chunkTotal,
     project_count: projects.length,
     membership_count: memberships.length,
+    relation_count: relations.length,
     projects,
     memberships,
+    relations,
     documents: enriched,
   };
 
@@ -182,7 +205,8 @@ async function action(options: BackupOptions): Promise<void> {
   println(
     c.dim(
       `  documents: ${docs.length} · chunks: ${chunkTotal} · ` +
-        `projects: ${projects.length} · memberships: ${memberships.length}`,
+        `projects: ${projects.length} · memberships: ${memberships.length}` +
+          (relations.length > 0 ? ` · relations: ${relations.length}` : ""),
     ),
   );
 

--- a/packages/memory/src/cli/commands/backup.ts
+++ b/packages/memory/src/cli/commands/backup.ts
@@ -22,6 +22,7 @@ import {
 } from "../../../../../_shared/cli-core/index.ts";
 import { fetchAllPages } from "../../../../../_shared/db-client/paginate.ts";
 import { getClient } from "../util/client.ts";
+import { PKG_VERSION } from "../../meta.ts";
 
 interface BackupOptions {
   outputDir?: string;
@@ -63,6 +64,15 @@ async function action(options: BackupOptions): Promise<void> {
 
   const client = getClient();
 
+  // Stamped into the payload so a restore (possibly on a different Cerefox
+  // version) can tell which schema produced it.
+  let schemaVersion = "unknown";
+  try {
+    schemaVersion = (await client.rpc<string>("cerefox_schema_version", {})) ?? "unknown";
+  } catch {
+    // Non-fatal: an older server without the RPC still backs up fine.
+  }
+
   // Pull all non-deleted documents. Paginated: an unbounded select caps at
   // the PostgREST row limit (1000) and silently truncates the backup (#131).
   let docs: Array<Record<string, unknown>>;
@@ -82,6 +92,35 @@ async function action(options: BackupOptions): Promise<void> {
   } catch (err) {
     throw systemError(
       `Document fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  // Projects + memberships (#166). These were never captured, so every
+  // restore silently landed documents with no project assignments — and the
+  // restore command's help text claimed the opposite. Both tables are small
+  // (tens of projects, one row per membership) but paginated anyway: the
+  // membership count tracks the document count, which is unbounded.
+  let projects: Array<Record<string, unknown>> = [];
+  let memberships: Array<Record<string, unknown>> = [];
+  try {
+    projects = await fetchAllPages<Record<string, unknown>>((from, to) =>
+      client.raw
+        .from("cerefox_projects")
+        .select("id, name, description, created_at, updated_at")
+        .order("id", { ascending: true })
+        .range(from, to),
+    );
+    memberships = await fetchAllPages<Record<string, unknown>>((from, to) =>
+      client.raw
+        .from("cerefox_document_projects")
+        .select("document_id, project_id")
+        .order("document_id", { ascending: true })
+        .order("project_id", { ascending: true })
+        .range(from, to),
+    );
+  } catch (err) {
+    throw systemError(
+      `Project/membership fetch failed: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
 
@@ -119,11 +158,20 @@ async function action(options: BackupOptions): Promise<void> {
   }
   if (process.stdout.isTTY) process.stderr.write("\n");
 
+  // backup_format 2 (#166) adds projects + memberships. Restore accepts
+  // format 1 (documents + chunks only) unchanged, so older snapshots keep
+  // working — they simply have no memberships to recreate.
   const payload = {
     created_at: new Date().toISOString(),
-    cerefox_version: process.env.npm_package_version ?? "unknown",
+    cerefox_version: PKG_VERSION,
+    backup_format: 2,
+    schema_version: schemaVersion,
     document_count: docs.length,
     chunk_count: chunkTotal,
+    project_count: projects.length,
+    membership_count: memberships.length,
+    projects,
+    memberships,
     documents: enriched,
   };
 
@@ -131,7 +179,12 @@ async function action(options: BackupOptions): Promise<void> {
 
   println("");
   println(c.green("✓ ") + `Backup written: ${dest}`);
-  println(c.dim(`  documents: ${docs.length} · chunks: ${chunkTotal}`));
+  println(
+    c.dim(
+      `  documents: ${docs.length} · chunks: ${chunkTotal} · ` +
+        `projects: ${projects.length} · memberships: ${memberships.length}`,
+    ),
+  );
 
   if (options.git) {
     println(c.yellow("⚠ ") + "--git commit is not implemented; the snapshot was written without a git checkpoint.");

--- a/packages/memory/src/cli/commands/backup.ts
+++ b/packages/memory/src/cli/commands/backup.ts
@@ -29,6 +29,7 @@ interface BackupOptions {
   includeVersions?: boolean;
   label?: string;
   git?: boolean;
+  trash?: boolean;
 }
 
 function expandHome(path: string): string {
@@ -73,30 +74,70 @@ async function action(options: BackupOptions): Promise<void> {
     // Non-fatal: an older server without the RPC still backs up fine.
   }
 
-  // Pull all non-deleted documents. Paginated: an unbounded select caps at
-  // the PostgREST row limit (1000) and silently truncates the backup (#131).
-  let docs: Array<Record<string, unknown>>;
-  try {
-    docs = await fetchAllPages<Record<string, unknown>>((from, to) =>
-      client.raw
-        .from("cerefox_documents")
-        .select(
-          "id, title, content_hash, source, metadata, total_chars, chunk_count, " +
-            // lifecycle_status (iteration 29) must be listed explicitly: this
-            // select is an allow-list, which is how the previous columns went
-            // missing in the first place (#166).
-            "review_status, lifecycle_status, created_at, updated_at, deleted_at",
-        )
-        .is("deleted_at", null)
+  // Trashed documents are captured by default (backup format 4).
+  //
+  // Soft-delete is not a purge: `cerefox_delete_document` only stamps
+  // `deleted_at`, and nothing ever collects it — the 48h retention sweep prunes
+  // document *versions*, never the trash. So the trash is durable state that
+  // survives indefinitely until someone runs an explicit purge, and a snapshot
+  // that omitted it was quietly the one lossy part of "back up everything".
+  //
+  // Restore replays `deleted_at` verbatim, so trashed documents come back
+  // trashed, never resurrected. That is what makes this safe to default on:
+  // every read and search RPC filters `deleted_at IS NULL`, so restored trash
+  // is as invisible as it was on the source, and `document restore` still
+  // recovers it. `--no-trash` opts out for anyone who deletes at volume.
+  const includeTrash = options.trash !== false;
+
+  // The column allow-list is explicit on purpose: a `select("*")` is how the
+  // membership columns went missing unnoticed in the first place (#166).
+  //
+  // `lifecycle_status` arrived with schema 0.10.0, but a newer CLI is routinely
+  // pointed at an older server — backing up production before upgrading it is
+  // the single most important time this command has to work. Naming the column
+  // unconditionally made `backup create` fail outright against any 0.9.x
+  // database ("column cerefox_documents.lifecycle_status does not exist"), so
+  // the fallback below drops it and re-runs. Restore already tolerates its
+  // absence.
+  const BASE_COLUMNS =
+    "id, title, content_hash, source, metadata, total_chars, chunk_count, " +
+    "review_status, created_at, updated_at, deleted_at";
+
+  const fetchDocs = (columns: string): Promise<Array<Record<string, unknown>>> =>
+    fetchAllPages<Record<string, unknown>>((from, to) => {
+      // Paginated: an unbounded select caps at the PostgREST row limit (1000)
+      // and silently truncates the backup (#131).
+      const q = client.raw.from("cerefox_documents").select(columns);
+      return (includeTrash ? q : q.is("deleted_at", null))
         .order("created_at", { ascending: true })
         .order("id", { ascending: true })
-        .range(from, to),
-    );
+        .range(from, to);
+    });
+
+  let docs: Array<Record<string, unknown>>;
+  let lifecycleCaptured = true;
+  try {
+    docs = await fetchDocs(`${BASE_COLUMNS}, lifecycle_status`);
   } catch (err) {
-    throw systemError(
-      `Document fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+    const message = err instanceof Error ? err.message : String(err);
+    if (!/lifecycle_status/.test(message)) {
+      throw systemError(`Document fetch failed: ${message}`);
+    }
+    lifecycleCaptured = false;
+    try {
+      docs = await fetchDocs(BASE_COLUMNS);
+    } catch (retryErr) {
+      throw systemError(
+        `Document fetch failed: ${retryErr instanceof Error ? retryErr.message : String(retryErr)}`,
+      );
+    }
+    println(
+      c.dim("  (server predates lifecycle_status — captured without it)"),
     );
   }
+
+  const trashedCount = docs.filter((d) => d.deleted_at != null).length;
+
 
   // Projects + memberships (#166). These were never captured, so every
   // restore silently landed documents with no project assignments — and the
@@ -144,9 +185,10 @@ async function action(options: BackupOptions): Promise<void> {
     // Older server without the relations table — nothing to capture.
   }
 
-  // Drop memberships whose document is not in this snapshot. Backups capture
-  // live documents only, but the junction carries rows for soft-deleted ones
-  // too — 7 of 369 on the maintainer's store. Restore already ignores them, so
+  // Drop memberships whose document is not in this snapshot. With trash
+  // captured (format 4) this is usually a no-op, but it still matters under
+  // `--no-trash`, and it guards the general case of a junction row outliving
+  // its document. Restore already ignores such rows, so
   // this is about the file being internally consistent: every membership in a
   // snapshot should point at a document the snapshot contains.
   {
@@ -202,9 +244,15 @@ async function action(options: BackupOptions): Promise<void> {
     created_at: new Date().toISOString(),
     cerefox_version: PKG_VERSION,
     // 3 = adds relations + lifecycle_status (iteration 29).
-    backup_format: 3,
+    // 4 = trashed documents are captured (with deleted_at preserved).
+    backup_format: 4,
     schema_version: schemaVersion,
     document_count: docs.length,
+    trashed_count: trashedCount,
+    includes_trash: includeTrash,
+    // False when taken against a pre-0.10.0 server, so a restore can tell an
+    // absent lifecycle_status from one that was genuinely never set.
+    includes_lifecycle_status: lifecycleCaptured,
     chunk_count: chunkTotal,
     project_count: projects.length,
     membership_count: memberships.length,
@@ -226,6 +274,18 @@ async function action(options: BackupOptions): Promise<void> {
           (relations.length > 0 ? ` · relations: ${relations.length}` : ""),
     ),
   );
+  // Counted on its own line: the trash is included in document_count, and a
+  // silent inclusion is exactly the kind of surprise this feature exists to
+  // remove. Say so either way.
+  if (!includeTrash) {
+    println(c.dim("  trashed documents: excluded (--no-trash)"));
+  } else if (trashedCount > 0) {
+    println(
+      c.dim(
+        `  of which trashed: ${trashedCount} (restored as trash, not resurrected)`,
+      ),
+    );
+  }
 
   if (options.git) {
     println(c.yellow("⚠ ") + "--git commit is not implemented; the snapshot was written without a git checkpoint.");
@@ -244,5 +304,9 @@ export function registerBackup(program: Command): void {
     .option("-l, --label <label>", "Optional suffix added to the filename.")
     .option("--include-versions", "Include archived versions in the snapshot. (v0.5: ignored — current chunks only.)")
     .option("--git", "Commit the snapshot to the output dir as a git checkpoint. (v0.5: ignored.)")
+    .option(
+      "--no-trash",
+      "Exclude soft-deleted documents. Default: they are captured and restored as trash.",
+    )
     .action(action);
 }

--- a/packages/memory/src/cli/commands/backup.ts
+++ b/packages/memory/src/cli/commands/backup.ts
@@ -54,9 +54,31 @@ function utcStamp(): string {
 }
 
 async function action(options: BackupOptions): Promise<void> {
-  const outDir = resolve(
-    expandHome(options.outputDir ?? process.env.CEREFOX_BACKUP_DIR ?? "~/.cerefox/backups"),
-  );
+  const configuredDir = options.outputDir ?? process.env.CEREFOX_BACKUP_DIR;
+  const outDir = resolve(expandHome(configuredDir ?? "~/.cerefox/backups"));
+
+  // A *relative* CEREFOX_BACKUP_DIR resolves against the working directory, so
+  // the same command writes to a different place depending on where it is run
+  // from — and the snapshots quietly scatter. `./backups` was the pre-v0.3.0
+  // default and still sits in `.env` files created back then, which is how one
+  // store ended up with backups split between `~/.cerefox/backups` and a repo
+  // checkout. Harmless individually, dangerous in aggregate: you believe you
+  // have backups and cannot find them. Say so rather than silently complying.
+  if (
+    configuredDir !== undefined &&
+    !configuredDir.startsWith("/") &&
+    !configuredDir.startsWith("~")
+  ) {
+    println(
+      c.yellow("⚠ ") +
+        `Backup directory "${configuredDir}" is relative — it resolves against the ` +
+        "current working directory, so backups land in different places depending " +
+        "on where you run this from.",
+    );
+    println(c.dim(`  Writing to: ${outDir}`));
+    println(c.dim("  Set an absolute path (e.g. ~/.cerefox/backups) to keep them together."));
+  }
+
   if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true });
 
   const stamp = utcStamp();

--- a/packages/memory/src/cli/commands/config-list.ts
+++ b/packages/memory/src/cli/commands/config-list.ts
@@ -41,6 +41,11 @@ const CONFIG_KEYS: ReadonlyArray<{ key: string; description: string }> = [
       "0–1 — fraction of a query's meaningful terms a keyword OR-fallback match must cover to count as confident. Default 0.5.",
   },
   {
+    key: "relations_enabled",
+    description:
+      "'true'/'false' — expose the document-relation tools to agents. Off by default; the feature is dormant until enabled (iteration 29).",
+  },
+  {
     key: "search_alpha",
     description:
       "0–1 — hybrid fusion weight: 1 = pure semantic, 0 = pure keyword. Default 0.7.",

--- a/packages/memory/src/cli/commands/migrate-format.ts
+++ b/packages/memory/src/cli/commands/migrate-format.ts
@@ -1,0 +1,212 @@
+/**
+ * `cerefox server migrate-format` — convert legacy-format documents to the
+ * current chunk-reconstruction format.
+ *
+ * Why this exists (#164): `cerefox doctor` reports how many documents still
+ * use `content_format = 1`, and both the guide and doctor used to point at
+ * `server reindex` to clear it. Reindex cannot: it patches `embedding_primary`
+ * and `embedder_primary` on existing chunk rows and never re-chunks, so the
+ * stored format never advances. Verified on a 3,203-chunk store: reindex
+ * touched every chunk and moved exactly zero of them.
+ *
+ * The only write path that stamps the current format is real ingestion, so
+ * that is what this command drives: read each legacy document's reconstructed
+ * content, then re-ingest it through the normal pipeline (re-chunk, re-embed,
+ * stamp format 2) as an update in place.
+ *
+ * Cost and safety:
+ *   - This RE-EMBEDS every converted document, so it costs real embedding
+ *     spend. It is opt-in, never automatic, and `--dry-run` reports the work
+ *     without doing it.
+ *   - Each document is converted under optimistic concurrency using the hash
+ *     read moments earlier. If something edits a document mid-run, that
+ *     document is skipped and reported rather than overwritten — a conversion
+ *     must never clobber a concurrent human edit.
+ *   - Legacy format is not broken. Documents that stay on format 1 reconstruct
+ *     exactly as they always have; converting is housekeeping, not a repair.
+ */
+
+import type { Command } from "commander";
+
+import {
+  c,
+  parsePositiveInt,
+  println,
+  printTable,
+  resolveAuthor,
+  resolveAuthorType,
+  systemError,
+} from "../../../../../_shared/cli-core/index.ts";
+import { loadSettings } from "../../../../../_shared/config/index.ts";
+import { fetchAllPages } from "../../../../../_shared/db-client/paginate.ts";
+import { IngestionPipeline } from "../../ingestion/pipeline.ts";
+import { getClient } from "../util/client.ts";
+
+/** The format written by the current chunker (see docs/guides/content-format.md). */
+const CURRENT_FORMAT = 2;
+
+interface MigrateOptions {
+  dryRun?: boolean;
+  limit?: string;
+  documentId?: string;
+  author?: string;
+}
+
+async function action(options: MigrateOptions): Promise<void> {
+  const settings = loadSettings();
+  const client = getClient();
+  const supabase = client.raw;
+
+  // Documents holding at least one current chunk below the target format.
+  // Paginated: the chunk table is the largest in the store (#131).
+  let legacyChunkRows: Array<{ document_id: string }>;
+  try {
+    legacyChunkRows = await fetchAllPages<{ document_id: string }>((from, to) => {
+      let q = supabase
+        .from("cerefox_chunks")
+        .select("document_id")
+        .is("version_id", null)
+        .lt("content_format", CURRENT_FORMAT);
+      if (options.documentId) q = q.eq("document_id", options.documentId);
+      return q.order("document_id", { ascending: true }).range(from, to);
+    }, 1000);
+  } catch (err) {
+    throw systemError(
+      `Could not list legacy chunks: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  const docIds = [...new Set(legacyChunkRows.map((r) => r.document_id))];
+  const limit = options.limit ? parsePositiveInt(options.limit, "--limit", docIds.length) : docIds.length;
+  const targets = docIds.slice(0, limit);
+
+  if (targets.length === 0) {
+    println(c.green("✓ Nothing to migrate — every document already uses the current format."));
+    return;
+  }
+
+  println(
+    c.bold(
+      `${docIds.length} document(s) on the legacy format` +
+        (targets.length < docIds.length ? `; converting ${targets.length} (--limit)` : ""),
+    ),
+  );
+  if (options.dryRun) {
+    println(c.yellow("⚠  --dry-run: nothing was written."));
+    println(c.dim("   Each document would be re-chunked and RE-EMBEDDED (embedding spend)."));
+    return;
+  }
+  println(c.dim("Each document is re-chunked and re-embedded — this costs embedding spend."));
+  println("");
+
+  const author = resolveAuthor(options.author);
+  const authorType = resolveAuthorType(undefined);
+  const pipeline = new IngestionPipeline({
+    supabase,
+    openAiApiKey: settings.openaiApiKey,
+  });
+
+  let converted = 0;
+  let skipped = 0;
+  // Documents whose content is byte-identical to another document: the
+  // ingestion pipeline refuses those by design (content-hash dedup), so they
+  // cannot be converted by re-ingesting. That is a data-hygiene finding, not a
+  // migration failure — surface them instead of failing the run.
+  const duplicates: Array<{ document: string; reason: string }> = [];
+  const failures: Array<{ document: string; reason: string }> = [];
+
+  for (let i = 0; i < targets.length; i++) {
+    const id = targets[i];
+    if (process.stdout.isTTY) {
+      process.stderr.write(`\r  Converting ${i + 1}/${targets.length}…`);
+    }
+
+    // Reconstructed content + the concurrency token, from the same RPC every
+    // other reader uses — so we convert exactly what a reader would see.
+    // Column names are the RPC's own (doc_title / full_content), not the
+    // table's — an easy mismatch to assume wrong, so it is spelled out here.
+    let doc: { doc_title: string; full_content: string; content_hash: string } | null = null;
+    try {
+      const rows = await client.rpc<
+        Array<{ doc_title: string; full_content: string; content_hash: string }>
+      >("cerefox_get_document", { p_document_id: id, p_version_id: null });
+      doc = rows?.[0] ?? null;
+    } catch (err) {
+      failures.push({ document: id, reason: `read: ${err instanceof Error ? err.message : String(err)}` });
+      continue;
+    }
+    if (!doc) {
+      failures.push({ document: id, reason: "read: document not found" });
+      continue;
+    }
+
+    try {
+      await pipeline.ingestText({
+        text: doc.full_content,
+        title: doc.doc_title,
+        documentId: id,
+        source: "migrate-format",
+        author,
+        authorType,
+        // Compare-and-swap against what we just read: a concurrent edit makes
+        // this document skip rather than lose that edit.
+        expectedContentHash: doc.content_hash,
+      });
+      converted++;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (/conflict/i.test(message)) {
+        skipped++;
+      } else if (/identical content already exists/i.test(message)) {
+        duplicates.push({ document: `${doc.doc_title} (${id})`, reason: message });
+      } else {
+        failures.push({ document: `${doc.doc_title} (${id})`, reason: message });
+      }
+    }
+  }
+  if (process.stdout.isTTY) process.stderr.write("\n");
+
+  println("");
+  println(
+    c.bold(
+      `Converted ${converted} · skipped ${skipped} (changed mid-run) · failed ${failures.length}`,
+    ),
+  );
+  if (targets.length < docIds.length) {
+    println(c.dim(`  ${docIds.length - targets.length} document(s) still pending — re-run to continue.`));
+  }
+  if (duplicates.length > 0) {
+    println("");
+    println(
+      c.yellow(
+        `⚠ ${duplicates.length} document(s) could not be converted because their content is ` +
+          "byte-identical to another document.",
+      ),
+    );
+    println(
+      c.dim(
+        "  Re-ingesting them would collide with the content-hash dedup check. They keep working " +
+          "on the legacy format; de-duplicate them if you want them converted.",
+      ),
+    );
+    printTable(duplicates.map((d) => ({ document: d.document })));
+  }
+  if (failures.length > 0) {
+    println("");
+    printTable(failures);
+    throw systemError(`${failures.length} document(s) failed to convert.`);
+  }
+}
+
+export function registerMigrateFormat(program: Command): void {
+  program
+    .command("migrate-format")
+    .description(
+      "Convert legacy-format documents to the current chunk format (re-chunks + re-embeds).",
+    )
+    .option("--dry-run", "Report how many documents would be converted; write nothing.")
+    .option("-l, --limit <n>", "Convert at most N documents (re-run to continue).")
+    .option("--document-id <uuid>", "Convert a single document.")
+    .option("--author <name>", "Recorded in the audit log for each conversion.")
+    .action(action);
+}

--- a/packages/memory/src/cli/commands/restore.ts
+++ b/packages/memory/src/cli/commands/restore.ts
@@ -75,6 +75,8 @@ async function action(target: string, options: RestoreOptions): Promise<void> {
         id: string;
         title: string;
         content_hash: string;
+        /** Non-null on soft-deleted documents; replayed verbatim (format 4+). */
+        deleted_at?: string | null;
         chunks: Array<Record<string, unknown>>;
         [k: string]: unknown;
       }>;
@@ -110,6 +112,20 @@ async function action(target: string, options: RestoreOptions): Promise<void> {
         "will be restored WITHOUT their project assignments.",
     );
   }
+
+  // Trashed documents (format 4+) are restored *as trash*: the row carries its
+  // original `deleted_at`, and every read/search RPC filters on that column, so
+  // nothing the operator deleted comes back visible. Announced up front so a
+  // restore never quietly reinstates deleted content.
+  const trashedInFile = payload.documents.filter((d) => d.deleted_at != null).length;
+  if (trashedInFile > 0) {
+    println(
+      c.dim(
+        `  trashed documents in file: ${trashedInFile} — restored as trash ` +
+          "(still deleted; recover with `cerefox document restore`)",
+      ),
+    );
+  }
   println("");
 
   const client = getClient();
@@ -120,11 +136,26 @@ async function action(target: string, options: RestoreOptions): Promise<void> {
   const errorDetails: Array<{ title: string; error: string }> = [];
 
   for (const doc of payload.documents) {
-    // Skip if a doc with the same content_hash already exists.
+    // Skip if this document is already present — by id *or* by content hash.
+    //
+    // Matching on content_hash alone was not enough to make restore
+    // re-runnable, which is the property its help text promises. A document
+    // edited between two snapshots keeps its id but changes its hash, so the
+    // hash probe missed it and the insert then died on the primary key:
+    //   duplicate key value violates unique constraint "cerefox_documents_pkey"
+    // Three documents hit exactly that restoring a fresh production snapshot
+    // over a slightly older copy.
+    //
+    // Skipping (rather than overwriting) keeps restore additive and
+    // non-destructive: re-running it can never replace content in the target
+    // with an older revision. Recovering a *specific* superseded document is a
+    // deliberate act — restore that snapshot into an empty store, or use
+    // `document version` — not something a bulk re-run should do silently.
     const { data: existing } = await client.raw
       .from("cerefox_documents")
       .select("id")
-      .eq("content_hash", doc.content_hash)
+      .or(`id.eq.${doc.id},content_hash.eq.${doc.content_hash}`)
+      .limit(1)
       .maybeSingle();
 
     if (existing) {
@@ -258,6 +289,9 @@ async function action(target: string, options: RestoreOptions): Promise<void> {
           (relationsRestored > 0 ? ` · relations: ${relationsRestored}` : ""),
       ),
     );
+  }
+  if (trashedInFile > 0) {
+    println(c.dim(`  ${trashedInFile} of those are trashed and stay trashed.`));
   }
 
   if (errors > 0) {

--- a/packages/memory/src/cli/commands/restore.ts
+++ b/packages/memory/src/cli/commands/restore.ts
@@ -22,6 +22,7 @@ import {
   printTable,
   systemError,
   userError,
+  warn,
 } from "../../../../../_shared/cli-core/index.ts";
 import { getClient } from "../util/client.ts";
 
@@ -61,8 +62,14 @@ async function action(target: string, options: RestoreOptions): Promise<void> {
   try {
     payload = JSON.parse(readFileSync(file, "utf8")) as {
       cerefox_version?: string;
+      // 2 = includes projects + memberships (#166). Absent/1 = documents and
+      // chunks only; those snapshots still restore, just without memberships.
+      backup_format?: number;
+      schema_version?: string;
       document_count?: number;
       chunk_count?: number;
+      projects?: Array<{ id: string; name: string; description?: string | null }>;
+      memberships?: Array<{ document_id: string; project_id: string }>;
       documents: Array<{
         id: string;
         title: string;
@@ -80,12 +87,28 @@ async function action(target: string, options: RestoreOptions): Promise<void> {
   }
 
   println(c.bold(`Restoring from ${file}`));
+  const hasMemberships = Array.isArray(payload.memberships);
   println(
     c.dim(
       `  cerefox_version: ${payload.cerefox_version ?? "?"} · ` +
+        `schema: ${payload.schema_version ?? "?"} · ` +
         `documents in file: ${payload.documents.length} · chunks in file: ${payload.chunk_count ?? "?"}`,
     ),
   );
+  // Say plainly what will and will not be recreated — the previous silence
+  // here is what let membership loss go unnoticed (#166).
+  if (hasMemberships) {
+    println(
+      c.dim(
+        `  projects: ${payload.projects?.length ?? 0} · memberships: ${payload.memberships?.length ?? 0}`,
+      ),
+    );
+  } else {
+    warn(
+      "This backup predates project-membership capture (format 1) — documents " +
+        "will be restored WITHOUT their project assignments.",
+    );
+  }
   println("");
 
   const client = getClient();
@@ -140,11 +163,68 @@ async function action(target: string, options: RestoreOptions): Promise<void> {
     restored++;
   }
 
+  // ── Projects + memberships (#166) ────────────────────────────────────────
+  // After documents exist, so foreign keys resolve. Both steps are idempotent
+  // (upsert / ignore-duplicates) because restore is safe to re-run, and both
+  // are skipped for format-1 snapshots that carry neither.
+  let projectsRestored = 0;
+  let membershipsRestored = 0;
+  if (!options.dryRun && hasMemberships) {
+    const projects = payload.projects ?? [];
+    if (projects.length > 0) {
+      // Keep existing rows authoritative: a project that already exists keeps
+      // its current name/description rather than being overwritten.
+      const { error: projErr } = await client.raw
+        .from("cerefox_projects")
+        .upsert(projects, { onConflict: "id", ignoreDuplicates: true });
+      if (projErr) {
+        errors++;
+        errorDetails.push({ title: "(projects)", error: projErr.message });
+      } else {
+        projectsRestored = projects.length;
+      }
+    }
+
+    // Only memberships whose document actually landed — a skipped duplicate or
+    // a failed insert must not leave a dangling edge.
+    const presentDocIds = new Set<string>();
+    {
+      const ids = (payload.documents ?? []).map((d) => d.id);
+      for (let i = 0; i < ids.length; i += 200) {
+        const { data } = await client.raw
+          .from("cerefox_documents")
+          .select("id")
+          .in("id", ids.slice(i, i + 200));
+        for (const row of (data ?? []) as Array<{ id: string }>) presentDocIds.add(row.id);
+      }
+    }
+    const links = (payload.memberships ?? []).filter((m) => presentDocIds.has(m.document_id));
+    for (let i = 0; i < links.length; i += 500) {
+      const { error: linkErr } = await client.raw
+        .from("cerefox_document_projects")
+        .upsert(links.slice(i, i + 500), {
+          onConflict: "document_id,project_id",
+          ignoreDuplicates: true,
+        });
+      if (linkErr) {
+        errors++;
+        errorDetails.push({ title: "(memberships)", error: linkErr.message });
+        break;
+      }
+      membershipsRestored += links.slice(i, i + 500).length;
+    }
+  }
+
   println("");
   println(
     (options.dryRun ? c.yellow("(dry-run) ") : "") +
       c.bold(`Summary: ${restored} restored · ${skipped} skipped · ${errors} errors`),
   );
+  if (hasMemberships && !options.dryRun) {
+    println(
+      c.dim(`  projects: ${projectsRestored} · memberships: ${membershipsRestored}`),
+    );
+  }
 
   if (errors > 0) {
     println("");
@@ -161,7 +241,7 @@ export function registerRestore(program: Command): void {
     .option("--dry-run", "Print what would be restored without writing.")
     .option(
       "-p, --project-name <name>",
-      "Reserved for future use; currently ignored (project memberships ride along with each doc's metadata).",
+      "Reserved for future use; currently ignored. Project memberships are restored from the backup itself (format 2+).",
     )
     .action(action);
 }

--- a/packages/memory/src/cli/commands/restore.ts
+++ b/packages/memory/src/cli/commands/restore.ts
@@ -70,6 +70,7 @@ async function action(target: string, options: RestoreOptions): Promise<void> {
       chunk_count?: number;
       projects?: Array<{ id: string; name: string; description?: string | null }>;
       memberships?: Array<{ document_id: string; project_id: string }>;
+      relations?: Array<{ source_id: string; target_id: string; rel_type: string }>;
       documents: Array<{
         id: string;
         title: string;
@@ -169,6 +170,7 @@ async function action(target: string, options: RestoreOptions): Promise<void> {
   // are skipped for format-1 snapshots that carry neither.
   let projectsRestored = 0;
   let membershipsRestored = 0;
+  let relationsRestored = 0;
   if (!options.dryRun && hasMemberships) {
     const projects = payload.projects ?? [];
     if (projects.length > 0) {
@@ -213,6 +215,35 @@ async function action(target: string, options: RestoreOptions): Promise<void> {
       }
       membershipsRestored += links.slice(i, i + 500).length;
     }
+
+    // Relations (iteration 29). Only edges whose BOTH endpoints landed — a
+    // half-present edge would violate the foreign keys, and silently dropping
+    // the other half would be worse than not restoring it.
+    const relations = (payload.relations ?? []).filter(
+      (r) => presentDocIds.has(r.source_id) && presentDocIds.has(r.target_id),
+    );
+    if (relations.length > 0) {
+      for (let i = 0; i < relations.length; i += 500) {
+        const { error: relErr } = await client.raw
+          .from("cerefox_document_relations")
+          .upsert(relations.slice(i, i + 500), {
+            onConflict: "source_id,target_id,rel_type",
+            ignoreDuplicates: true,
+          });
+        if (relErr) {
+          // A pre-0.10.0 target has no relations table: report once and move
+          // on rather than failing a restore that is otherwise complete.
+          errorDetails.push({ title: "(relations)", error: relErr.message });
+          errors++;
+          break;
+        }
+        relationsRestored += relations.slice(i, i + 500).length;
+      }
+      const dropped = (payload.relations?.length ?? 0) - relations.length;
+      if (dropped > 0) {
+        warn(`${dropped} relation(s) skipped — one or both documents were not restored.`);
+      }
+    }
   }
 
   println("");
@@ -222,7 +253,10 @@ async function action(target: string, options: RestoreOptions): Promise<void> {
   );
   if (hasMemberships && !options.dryRun) {
     println(
-      c.dim(`  projects: ${projectsRestored} · memberships: ${membershipsRestored}`),
+      c.dim(
+        `  projects: ${projectsRestored} · memberships: ${membershipsRestored}` +
+          (relationsRestored > 0 ? ` · relations: ${relationsRestored}` : ""),
+      ),
     );
   }
 

--- a/packages/memory/src/cli/program.ts
+++ b/packages/memory/src/cli/program.ts
@@ -58,6 +58,7 @@ import { registerMcp } from "./commands/mcp.ts";
 import { registerEmbedderWarmup } from "./commands/embedder-warmup.ts";
 import { registerMetadataSearch } from "./commands/metadata-search.ts";
 import { registerReindex } from "./commands/reindex.ts";
+import { registerMigrateFormat } from "./commands/migrate-format.ts";
 import { registerRestore } from "./commands/restore.ts";
 import { registerSearch } from "./commands/search.ts";
 import { registerSelfUpdate } from "./commands/self-update.ts";
@@ -245,6 +246,7 @@ export function buildProgram(): Command {
   const server = program.command("server").description("Server side: deploy, reindex.");
   moveInto(server, registerDeployServer, "deploy");
   moveInto(server, registerReindex, "reindex");
+  registerMigrateFormat(server); // #164: reindex re-embeds; this re-chunks
 
   // v0.9.1: the bundled documentation — renamed from flat `docs` (disambiguates
   // from the `document` resource) + merged with `sync-self-docs` as `ingest`.

--- a/packages/memory/src/cli/util/checks.ts
+++ b/packages/memory/src/cli/util/checks.ts
@@ -436,7 +436,7 @@ export async function checkContentFormat(): Promise<CheckResult> {
       name: CONTENT_FORMAT_CHECK_NAME,
       status: "skipped", // informational (ℹ), never a gate
       detail: `${legacy} of ${total} document(s) use the legacy reconstruction format (format 1).`,
-      hint: "They auto-convert on next edit; run `cerefox server migrate-format` to convert all now (re-embeds; `--dry-run` first). What this means: `cerefox guides show content-format`.",
+      hint: "Harmless — they auto-convert on next edit. To convert them all now: `cerefox server migrate-format` (re-embeds, so try `--dry-run` first). To read what chunk formats are: `cerefox guides show content-format`.",
     };
   } catch (err) {
     return {

--- a/packages/memory/src/cli/util/checks.ts
+++ b/packages/memory/src/cli/util/checks.ts
@@ -436,7 +436,7 @@ export async function checkContentFormat(): Promise<CheckResult> {
       name: CONTENT_FORMAT_CHECK_NAME,
       status: "skipped", // informational (ℹ), never a gate
       detail: `${legacy} of ${total} document(s) use the legacy reconstruction format (format 1).`,
-      hint: "They auto-convert on next edit; run `cerefox server reindex` to convert all now. What this means: `cerefox guides show content-format`.",
+      hint: "They auto-convert on next edit; run `cerefox server migrate-format` to convert all now (re-embeds; `--dry-run` first). What this means: `cerefox guides show content-format`.",
     };
   } catch (err) {
     return {

--- a/packages/memory/src/server.ts
+++ b/packages/memory/src/server.ts
@@ -28,6 +28,8 @@ import { loadSettings } from "../../../_shared/config/index.ts";
 import { resolveServerAssets } from "../../../_shared/server-assets/index.ts";
 import {
   ALL_TOOLS,
+  assertToolEnabled,
+  listEnabledTools,
   McpInvalidParams,
   TOOLS_BY_NAME,
   type ToolContext,
@@ -82,7 +84,8 @@ export function buildServer(): ServerHandle {
   );
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
-    tools: ALL_TOOLS.map((t) => ({
+    // Optional features stay invisible until enabled deployment-wide.
+    tools: (await listEnabledTools(supabase)).map((t) => ({
       name: t.name,
       description: t.description,
       inputSchema: t.inputSchema as Record<string, unknown>,
@@ -97,6 +100,7 @@ export function buildServer(): ServerHandle {
       throw new McpInvalidParams(`Unknown tool: ${name}`);
     }
     try {
+      await assertToolEnabled(supabase, name);
       const text = await tool.handler(supabase, args, ctx);
       return { content: [{ type: "text", text }] };
     } catch (err) {

--- a/packages/memory/src/web/daemon.ts
+++ b/packages/memory/src/web/daemon.ts
@@ -28,7 +28,27 @@ import {
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-const STATE_DIR = join(homedir(), ".cerefox");
+/**
+ * Where the pidfile and log live.
+ *
+ * Normally `~/.cerefox`. When `CEREFOX_CONFIG_DIR` is set — the parallel-
+ * environment escape hatch (docs/guides/staging-env.md) — the daemon's
+ * bookkeeping follows it, so a staging server does not overwrite production's
+ * pidfile and leave `web stop` aiming at the wrong process.
+ *
+ * Deliberately keyed on the env var rather than `resolveConfigDir()`: that
+ * resolver also returns the CWD in repo dev-mode, which would drop `web.pid`
+ * and `web.log` into a working tree. Only an explicit override relocates state.
+ */
+export function resolveStateDir(override = process.env.CEREFOX_CONFIG_DIR, home = homedir()): string {
+  override = (override ?? "").trim();
+  if (!override) return join(home, ".cerefox");
+  return override === "~" || override.startsWith("~/")
+    ? join(home, override.slice(2))
+    : override;
+}
+
+const STATE_DIR = resolveStateDir();
 const PID_FILE = join(STATE_DIR, "web.pid");
 const LOG_FILE = join(STATE_DIR, "web.log");
 

--- a/packages/memory/test/daemon-state-dir.test.ts
+++ b/packages/memory/test/daemon-state-dir.test.ts
@@ -1,0 +1,41 @@
+/**
+ * The web daemon's pidfile/log location.
+ *
+ * This matters beyond tidiness: before the state dir followed
+ * `CEREFOX_CONFIG_DIR`, a staging `cerefox web start` wrote its pid over
+ * production's, so a later `cerefox web stop` aimed at the wrong process and
+ * killed the production server. See docs/guides/staging-env.md.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+
+import { resolveStateDir } from "../src/web/daemon.ts";
+
+const HOME = "/home/tester";
+
+describe("resolveStateDir", () => {
+  test("defaults to ~/.cerefox when no override is set", () => {
+    expect(resolveStateDir(undefined, HOME)).toBe(join(HOME, ".cerefox"));
+  });
+
+  test("treats an empty or whitespace override as unset", () => {
+    expect(resolveStateDir("", HOME)).toBe(join(HOME, ".cerefox"));
+    expect(resolveStateDir("   ", HOME)).toBe(join(HOME, ".cerefox"));
+  });
+
+  test("follows an explicit CEREFOX_CONFIG_DIR", () => {
+    expect(resolveStateDir("/opt/cerefox/staging", HOME)).toBe("/opt/cerefox/staging");
+  });
+
+  test("expands a leading tilde", () => {
+    expect(resolveStateDir("~/.cerefox/staging", HOME)).toBe(join(HOME, ".cerefox/staging"));
+    expect(resolveStateDir("~", HOME)).toBe(HOME);
+  });
+
+  test("staging and production never share a state dir", () => {
+    const prod = resolveStateDir(undefined, HOME);
+    const staging = resolveStateDir("~/.cerefox/staging", HOME);
+    expect(staging).not.toBe(prod);
+  });
+});

--- a/packages/memory/test/stdio-smoke.test.ts
+++ b/packages/memory/test/stdio-smoke.test.ts
@@ -51,7 +51,7 @@ describe("stdio MCP server smoke", () => {
     }
   });
 
-  test("tools/list returns 14 tools over stdio", async () => {
+  test("tools/list returns 10 tools over stdio (relations gated off by default)", async () => {
     if (!existsSync(BIN)) {
       throw new Error(`run \`bun run build\` first`);
     }
@@ -152,7 +152,7 @@ describe("stdio MCP server smoke", () => {
       result?: { tools?: Array<{ name: string }> };
     };
     expect(Array.isArray(tools.result?.tools)).toBe(true);
-    expect(tools.result?.tools?.length).toBe(14);
+    expect(tools.result?.tools?.length).toBe(10);
     const names = tools.result?.tools?.map((t) => t.name).sort();
     expect(names).toEqual(
       [

--- a/scripts/cut_release.ts
+++ b/scripts/cut_release.ts
@@ -36,6 +36,8 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join, relative } from "node:path";
 import { exit } from "node:process";
 
+import { compareSemver } from "../_shared/compatibility/index.ts";
+
 // ── paths ────────────────────────────────────────────────────────────────
 
 const REPO_ROOT = join(import.meta.dir, "..");
@@ -263,20 +265,50 @@ function checkCleanTree(): void {
   }
 }
 
-function checkBranch(): void {
+/**
+ * Releases come from `main`, or from a `release/*` maintenance branch when a
+ * patch must ship for an older line while main has already moved on (1.0.7 was
+ * cut from `release/1.0.7` off the v1.0.6 tag, because main already carried
+ * all of 1.1.0). Returns the branch so the push/sync steps target the right
+ * one — pushing `main` from a release branch would strand the version bump.
+ */
+function checkBranch(): string {
   const branch = runOrDie("git", ["rev-parse", "--abbrev-ref", "HEAD"]);
-  if (branch !== "main") {
-    die(`Must be on 'main' branch, currently on '${branch}'.`);
+  if (branch !== "main" && !branch.startsWith("release/")) {
+    die(
+      `Must be on 'main' or a 'release/*' maintenance branch, currently on '${branch}'.`,
+    );
   }
+  return branch;
 }
 
-function checkUpToDateWithOrigin(): void {
-  runOrDie("git", ["fetch", "origin", "main", "--quiet"]);
+/**
+ * The mistake this exists to prevent: standing on a branch that is AHEAD of the
+ * version you are cutting. Cutting 1.0.7 while on main (VERSION 1.1.0-beta.1)
+ * would tag main's tree — all of 1.1.0 — as a 1.0.x patch, published to the
+ * stable channel. The tag is immutable, so there is no clean recovery.
+ */
+function checkVersionMovesForward(currentVersion: string, newVersion: string, branch: string): void {
+  if (compareSemver(newVersion, currentVersion) > 0) return;
+  die(
+    `Refusing to cut ${newVersion}: this branch ('${branch}') is at ${currentVersion}.\n` +
+      `    A release must move the version forward. If you meant to patch an older line, cut\n` +
+      `    from a 'release/*' branch based on that line's tag — not from a branch that is ahead.`,
+  );
+}
+
+function checkUpToDateWithOrigin(branch: string): void {
+  // A brand-new release branch may not exist on origin yet; that is fine —
+  // the push below creates it.
+  const hasRemote =
+    run("git", ["ls-remote", "--exit-code", "--heads", "origin", branch]).status === 0;
+  if (!hasRemote) return;
+  runOrDie("git", ["fetch", "origin", branch, "--quiet"]);
   const local = runOrDie("git", ["rev-parse", "HEAD"]);
-  const remote = runOrDie("git", ["rev-parse", "origin/main"]);
+  const remote = runOrDie("git", ["rev-parse", `origin/${branch}`]);
   if (local !== remote) {
     die(
-      `Local main is not in sync with origin/main.\n` +
+      `Local ${branch} is not in sync with origin/${branch}.\n` +
         `  local : ${local}\n` +
         `  origin: ${remote}\n` +
         `Run 'git pull --ff-only' (or push your local commits) and retry.`,
@@ -547,10 +579,12 @@ async function main(): Promise<void> {
 
   // 1. Preflight: working tree, branch, sync, tag
   info("Preflight checks…");
+  let releaseBranch = "main";
   if (!args.dryRun) {
     checkCleanTree();
-    checkBranch();
-    checkUpToDateWithOrigin();
+    releaseBranch = checkBranch();
+    checkVersionMovesForward(currentVersion, newVersion, releaseBranch);
+    checkUpToDateWithOrigin(releaseBranch);
     checkTagDoesNotExist(newVersion);
   } else {
     info("  (dry-run: skipping git state checks)");
@@ -708,7 +742,7 @@ async function main(): Promise<void> {
   // 5. Push + GitHub Release (already confirmed before any mutation, above)
 
   if (args.dryRun) {
-    info(`DRY-RUN: would 'git push origin main'`);
+    info(`DRY-RUN: would 'git push origin <current branch>'`);
     info(`DRY-RUN: would 'git push origin ${tag}'`);
     info(`DRY-RUN: would 'gh release create ${tag} --title ${tag} --notes-file <release-notes>'`);
     info(`DRY-RUN: would upload install.sh + docker/local/install-local.sh as Release assets`);
@@ -728,7 +762,9 @@ async function main(): Promise<void> {
   }
 
   info("Pushing main and tag to origin…");
-  runOrDie("git", ["push", "origin", "main"]);
+  // The branch we are actually on — pushing "main" from a release branch would
+  // strand the version bump and CHANGELOG on an unpushed local commit.
+  runOrDie("git", ["push", "origin", releaseBranch]);
   runOrDie("git", ["push", "origin", tag]);
   ok(`Pushed ${tag} to origin.`);
 

--- a/scripts/cut_release.ts
+++ b/scripts/cut_release.ts
@@ -678,7 +678,27 @@ async function main(): Promise<void> {
   // immediately re-runnable. (Through v0.9.0 the script mutated + committed +
   // tagged FIRST and prompted last; a declined prompt left a local commit +
   // tag that tripped the `checkTagDoesNotExist` preflight on the next run.)
-  if (!args.dryRun && !args.yes) {
+  // `--yes` is honoured only on main. A maintenance-branch cut is the case
+  // where the banner exists to be READ — that is exactly where an unattended
+  // "yes" would defeat it, and where the mistakes are unrecoverable (immutable
+  // tags on the wrong line). Ignore it there, loudly.
+  const branchNeedsEyes = releaseBranch !== "main";
+  const skipPrompt = args.yes && !branchNeedsEyes;
+  if (!args.dryRun && args.yes && branchNeedsEyes) {
+    warn(
+      `Ignoring --yes: this cut is from '${releaseBranch}', not main. ` +
+        "Release-line mistakes here cannot be undone (tags are immutable), so " +
+        "the confirmation below must be answered by a human.",
+    );
+    if (!process.stdin.isTTY) {
+      die(
+        `Refusing to cut from '${releaseBranch}' without an interactive terminal.\n` +
+          `    --yes does not apply to maintenance branches, and there is no TTY to confirm on.\n` +
+          `    Run this cut from an interactive shell.`,
+      );
+    }
+  }
+  if (!args.dryRun && !skipPrompt) {
     console.log("");
     {
       const extras = [

--- a/scripts/cut_release.ts
+++ b/scripts/cut_release.ts
@@ -834,7 +834,7 @@ async function main(): Promise<void> {
     return;
   }
 
-  info("Pushing main and tag to origin…");
+  info(`Pushing ${releaseBranch} and tag to origin…`);
   // The branch we are actually on — pushing "main" from a release branch would
   // strand the version bump and CHANGELOG on an unpushed local commit.
   runOrDie("git", ["push", "origin", releaseBranch]);

--- a/scripts/cut_release.ts
+++ b/scripts/cut_release.ts
@@ -299,6 +299,27 @@ function checkBranch(expected?: string): string {
  * would tag main's tree — all of 1.1.0 — as a 1.0.x patch, published to the
  * stable channel. The tag is immutable, so there is no clean recovery.
  */
+/**
+ * A maintenance branch may only cut versions on its own line.
+ *
+ * The forward-only check below does NOT catch this direction: standing on
+ * `release/1.0.7` (VERSION 1.0.6) and cutting `1.1.0-beta.2` moves the version
+ * forward, so it would be allowed — and would tag a branch that contains none
+ * of the 1.1.0 work as a 1.1.0 pre-release. This is the structural guard for
+ * that; unlike `--branch`, it needs no discipline from the caller.
+ */
+function checkVersionMatchesBranchLine(newVersion: string, branch: string): void {
+  if (!branch.startsWith("release/")) return; // main may cut any line
+  const branchLine = branch.slice("release/".length).split(".").slice(0, 2).join(".");
+  const versionLine = newVersion.split(".").slice(0, 2).join(".");
+  if (branchLine === versionLine) return;
+  die(
+    `Refusing to cut ${newVersion} from '${branch}': that branch is the ${branchLine}.x line.\n` +
+      `    A maintenance branch can only release its own line. Cut ${versionLine}.x from main\n` +
+      `    (or from the release/${versionLine}.x branch for that line).`,
+  );
+}
+
 function checkVersionMovesForward(currentVersion: string, newVersion: string, branch: string): void {
   if (compareSemver(newVersion, currentVersion) > 0) return;
   die(
@@ -598,6 +619,7 @@ async function main(): Promise<void> {
   if (!args.dryRun) {
     checkCleanTree();
     releaseBranch = checkBranch(args.branch);
+    checkVersionMatchesBranchLine(newVersion, releaseBranch);
     checkVersionMovesForward(currentVersion, newVersion, releaseBranch);
     checkUpToDateWithOrigin(releaseBranch);
     checkTagDoesNotExist(newVersion);
@@ -674,6 +696,22 @@ async function main(): Promise<void> {
         `moves — any later fix ships as a NEW patch version, not a re-tag. ` +
         `(The "force-move tags only on objective failure" rule; see CONTRIBUTING.md.)`,
     );
+    // The branch is the single most consequential fact here and was previously
+    // absent from the prompt — you could confirm a cut without ever being told
+    // where it came from.
+    const bannerLines = [
+      `You are about to cut ${tag} from branch '${releaseBranch}'`,
+      `  ${currentVersion}  →  ${newVersion}`,
+    ];
+    const width = Math.max(...bannerLines.map((l) => l.length)) + 2;
+    console.log("");
+    console.log(ansi.yellow(`┌${"─".repeat(width)}┐`));
+    for (const line of bannerLines) {
+      console.log(ansi.yellow("│ ") + line.padEnd(width - 2) + ansi.yellow(" │"));
+    }
+    console.log(ansi.yellow(`└${"─".repeat(width)}┘`));
+    console.log("");
+
     const yes = await confirm("Proceed?");
     if (!yes) {
       warn("Aborted before any changes — working tree untouched, nothing committed/tagged/pushed. Re-run when ready.");

--- a/scripts/cut_release.ts
+++ b/scripts/cut_release.ts
@@ -272,11 +272,22 @@ function checkCleanTree(): void {
  * all of 1.1.0). Returns the branch so the push/sync steps target the right
  * one — pushing `main` from a release branch would strand the version bump.
  */
-function checkBranch(): string {
+function checkBranch(expected?: string): string {
   const branch = runOrDie("git", ["rev-parse", "--abbrev-ref", "HEAD"]);
   if (branch !== "main" && !branch.startsWith("release/")) {
     die(
       `Must be on 'main' or a 'release/*' maintenance branch, currently on '${branch}'.`,
+    );
+  }
+  // `--branch` ASSERTS intent; it never selects. A flag that could pick a
+  // different branch than the working tree would resurrect the bug this
+  // function exists to prevent: pushing one branch while tagging another's
+  // commit, stranding the version bump. Omitting it is fine — the branch you
+  // are standing on is the branch that is cut.
+  if (expected && expected !== branch) {
+    die(
+      `--branch ${expected} does not match the checked-out branch '${branch}'.\n` +
+        `    Check out ${expected} and retry (this flag states intent; it cannot switch branches).`,
     );
   }
   return branch;
@@ -468,6 +479,8 @@ interface Args {
   yes: boolean;
   npmPublish: boolean;
   dockerPublish: boolean;
+  /** Optional assertion: the branch you believe you are cutting from. */
+  branch?: string;
 }
 
 function parseArgs(argv: string[]): Args {
@@ -478,9 +491,11 @@ function parseArgs(argv: string[]): Args {
     yes: false,
     npmPublish: false,
     dockerPublish: false,
+    branch: undefined,
   };
   for (const a of argv) {
-    if (a === "--dry-run") out.dryRun = true;
+    if (a.startsWith("--branch=")) out.branch = a.slice("--branch=".length);
+    else if (a === "--dry-run") out.dryRun = true;
     else if (a === "--check") out.check = true;
     else if (a === "--yes" || a === "-y") out.yes = true;
     else if (a === "--npm-publish") out.npmPublish = true;
@@ -582,7 +597,7 @@ async function main(): Promise<void> {
   let releaseBranch = "main";
   if (!args.dryRun) {
     checkCleanTree();
-    releaseBranch = checkBranch();
+    releaseBranch = checkBranch(args.branch);
     checkVersionMovesForward(currentVersion, newVersion, releaseBranch);
     checkUpToDateWithOrigin(releaseBranch);
     checkTagDoesNotExist(newVersion);

--- a/scripts/db_deploy.ts
+++ b/scripts/db_deploy.ts
@@ -21,7 +21,7 @@
 import { existsSync } from "node:fs";
 import { createInterface } from "node:readline/promises";
 
-import { loadEnv } from "../_shared/config/index.js";
+import { loadEnv, resolveEnvFile } from "../_shared/config/index.js";
 import { resolveServerAssets } from "../_shared/server-assets/index.js";
 import { runDbDeploy } from "../_shared/db-deploy/index.js";
 import {
@@ -71,10 +71,30 @@ function parseArgs(argv: string[]): Args {
   return out;
 }
 
-async function confirmReset(): Promise<boolean> {
+/**
+ * Name the target before wiping it. A destructive prompt that doesn't say
+ * *which* database it will drop can only be answered on faith — and the
+ * environment this resolves from has been wrong before (a working-directory
+ * `.env` silently outranking CEREFOX_CONFIG_DIR). Printing the project ref
+ * makes a wrong-database reset visible at the one moment it can still be
+ * stopped.
+ */
+async function confirmReset(dbUrl: string): Promise<boolean> {
+  let target = "(unparseable connection string)";
+  try {
+    const u = new URL(dbUrl);
+    // Supabase encodes the project ref in the pooler username (postgres.<ref>).
+    const ref = u.username.includes(".") ? u.username.split(".").slice(1).join(".") : null;
+    target = ref ? `${ref} — ${u.host}` : u.host;
+  } catch {
+    /* fall through to the placeholder */
+  }
+
   const rl = createInterface({ input: process.stdin, output: process.stdout });
   const answer = await rl.question(
-    "\n⚠️  --reset will DROP all Cerefox tables. All data will be lost. " +
+    `\n⚠️  --reset will DROP all Cerefox tables. All data will be lost.\n` +
+      `   Target database: ${target}\n` +
+      `   Config: ${resolveEnvFile()}\n` +
       "Type 'yes' to continue: ",
   );
   rl.close();
@@ -108,7 +128,7 @@ async function main(): Promise<void> {
   }
 
   if (args.reset && !args.dryRun) {
-    const ok = await confirmReset();
+    const ok = await confirmReset(dbUrl);
     if (!ok) {
       println("Aborted.");
       process.exit(EXIT_OK);

--- a/src/cerefox/db/migrations/0014_document_relations.sql
+++ b/src/cerefox/db/migrations/0014_document_relations.sql
@@ -57,3 +57,8 @@ ALTER TABLE cerefox_audit_log ADD CONSTRAINT cerefox_audit_log_operation_check C
                   'status-change', 'archive', 'unarchive', 'restore',
                   'relation-set', 'relation-delete')
 );
+
+-- Relations ship dormant: the MCP tools stay hidden until a deployment opts in.
+INSERT INTO cerefox_config (key, value)
+VALUES ('relations_enabled', 'false')
+ON CONFLICT (key) DO NOTHING;

--- a/src/cerefox/db/rpcs.sql
+++ b/src/cerefox/db/rpcs.sql
@@ -2037,7 +2037,9 @@ DECLARE
     -- because they all resolve through these RPCs.
     v_allowed TEXT[] := ARRAY[
         'usage_tracking_enabled', 'require_requestor_identity', 'requestor_identity_format',
-        'min_search_score', 'min_term_coverage', 'search_alpha'
+        'min_search_score', 'min_term_coverage', 'search_alpha',
+        -- Optional features, off by default (iteration 29).
+        'relations_enabled'
     ];
 BEGIN
     IF NOT (p_key = ANY(v_allowed)) THEN
@@ -2232,7 +2234,7 @@ SET search_path = public, pg_catalog
 AS $$
     -- Keep in lockstep with the `@version:` marker in schema.sql (cut_release.ts
     -- enforces it). Bump whenever schema.sql OR rpcs.sql changes.
-    SELECT '0.10.0'::TEXT;
+    SELECT '0.10.1'::TEXT;
 $$;
 
 -- ── cerefox_content_format_stats ─────────────────────────────────────────────

--- a/src/cerefox/db/schema.sql
+++ b/src/cerefox/db/schema.sql
@@ -5,7 +5,7 @@
 -- Requires extensions: vector (pgvector), uuid-ossp
 -- These are enabled at the top of db_deploy.py before this file is applied.
 --
--- @version: 0.10.0
+-- @version: 0.10.1
 -- The `@version` marker above is read by the schema-version-mismatch banner
 -- (see /api/v1/schema-version). Bump it whenever schema.sql OR rpcs.sql
 -- changes in a way that requires `cerefox server deploy` to be re-run —
@@ -367,6 +367,11 @@ VALUES ('require_requestor_identity', 'false')
 ON CONFLICT (key) DO NOTHING;
 INSERT INTO cerefox_config (key, value)
 VALUES ('requestor_identity_format', '^[a-zA-Z0-9_:.\- ]+$')
+ON CONFLICT (key) DO NOTHING;
+-- Document relations ship dormant: the tools stay hidden from agents until a
+-- deployment opts in (iteration 29).
+INSERT INTO cerefox_config (key, value)
+VALUES ('relations_enabled', 'false')
 ON CONFLICT (key) DO NOTHING;
 
 

--- a/supabase/functions/cerefox-mcp/index.ts
+++ b/supabase/functions/cerefox-mcp/index.ts
@@ -34,12 +34,15 @@ import {
   unauthorizedChallenge,
 } from "./oauth.ts";
 import type { AuthResult, McpAuthenticator } from "../../../_shared/mcp-auth/index.ts";
+import type { MCPSupabaseClient } from "../../../_shared/mcp-tools/types.ts";
 import { checkAccessToken, parseAccessTokens } from "../../../_shared/ef-auth/index.ts";
 import {
   ALL_TOOLS,
   McpInvalidParams,
   TOOLS_BY_NAME,
   type ToolContext,
+  assertToolEnabled,
+  listEnabledTools,
 } from "../../../_shared/mcp-tools/index.ts";
 import {
   type AggregatedVersions,
@@ -57,11 +60,16 @@ const SERVER_VERSION = "0.4.0";
 
 // ── Tool list (derived from _shared/mcp-tools/) ─────────────────────────────
 
-const TOOLS = ALL_TOOLS.map((t) => ({
-  name: t.name,
-  description: t.description,
-  inputSchema: t.inputSchema,
-}));
+// Built per request rather than at module load: the tool surface depends on
+// deployment config (optional features are hidden until enabled), and an
+// isolate can outlive a config change.
+async function buildToolList(supabase: MCPSupabaseClient) {
+  return (await listEnabledTools(supabase)).map((t) => ({
+    name: t.name,
+    description: t.description,
+    inputSchema: t.inputSchema,
+  }));
+}
 
 // ── Method handlers ──────────────────────────────────────────────────────────
 
@@ -77,8 +85,8 @@ function handleInitialize(id: unknown): Response {
   });
 }
 
-function handleToolsList(id: unknown): Response {
-  return jsonResponse({ jsonrpc: "2.0", id, result: { tools: TOOLS } });
+async function handleToolsList(id: unknown, supabase: MCPSupabaseClient): Promise<Response> {
+  return jsonResponse({ jsonrpc: "2.0", id, result: { tools: await buildToolList(supabase) } });
 }
 
 async function handleToolsCall(
@@ -104,6 +112,14 @@ async function handleToolsCall(
 
   // deno-lint-ignore no-explicit-any
   const supabase: any = makeSupabaseClient();
+
+  // Optional features: a session that listed tools before the flag changed can
+  // still name a gated tool.
+  try {
+    await assertToolEnabled(supabase, toolName);
+  } catch (err) {
+    return errorResponse(id, -32602, err instanceof Error ? err.message : String(err));
+  }
 
   try {
     const { data: requireConfig } = await supabase.rpc("cerefox_get_config", {
@@ -336,7 +352,8 @@ Deno.serve(async (req: Request): Promise<Response> => {
     case "ping":
       return jsonResponse({ jsonrpc: "2.0", id, result: {} });
     case "tools/list":
-      return handleToolsList(id);
+      // deno-lint-ignore no-explicit-any
+      return await handleToolsList(id, makeSupabaseClient() as any);
     case "tools/call":
       return await handleToolsCall(
         id,


### PR DESCRIPTION
## Summary

Prepares **v1.1.0-beta.2**. Two features, five defects — every one of the
defects was found by standing up a real staging environment and driving
production data through it, and none were visible from a single-environment
machine.

### Features

- **Relations ship dormant** (`relations_enabled`, default false, fail-closed in
  both transports). The v1 stability requirement: 10 tools advertised with the
  flag off, 14 with it on. Schema 0.10.1.
- **Backup format 4 — trashed documents are captured.** Soft-delete is not a
  purge: `cerefox_delete_document` only stamps `deleted_at`, and nothing ever
  collects it (the 48h retention sweep prunes document *versions*). Snapshots
  were therefore silently lossy. Trash now round-trips and is restored **as
  trash** — `deleted_at` is replayed verbatim, and since every read and search
  RPC filters on it, nothing deleted comes back visible. `--no-trash` opts out.
- **#155 UI e2e repair** (13/13 in ~32s, was 8 failures + 2 silent skips) and
  **#165 keyboard accessibility** (dashboard rows are real links).

### Fixes

- **`CEREFOX_CONFIG_DIR` was silently ignored by every `bun scripts/*.ts`.**
  Bun auto-loads `.env` from the working directory and `loadEnv()` only filled
  *unset* keys, so a repo clone's production credentials won. `db_migrate.ts
  --status` reported production while naming staging on the command line — and
  the same resolution path through `db_deploy.ts --reset` would have **dropped
  every table in production**. The named config dir is now authoritative;
  `--reset` also prints the target project ref, host, and config file.
- **Web daemon state was global.** `web.{pid,log}` ignored the config dir, so a
  staging `web stop` would have killed the production server.
- **`backup create` aborted against any pre-0.10.0 server** — it named
  `lifecycle_status` unconditionally, so a v1.1.0 CLI could not snapshot a
  v1.0.x database: failure at the one moment backups matter most, capturing
  production *before* upgrading it.
- **`backup restore` was not idempotent**, contrary to its help text. It
  deduped on `content_hash` alone, so a document edited between snapshots kept
  its id, changed its hash, slipped the check, and died on the primary key.
  Now matches on id OR hash, and skips rather than overwrites so a re-run can
  never replace target content with an older revision.
- **`db_status` told users to run `db_deploy.py`**, deleted at v1.0.0.
- Warns when `CEREFOX_BACKUP_DIR` is relative — it resolves against the working
  directory, which had quietly split one store's snapshots across two places.

### Docs

`docs/guides/staging-env.md` (new) documents the parallel-environment
**convention**: `CEREFOX_CONFIG_DIR` for the database, a separate
`npm --prefix` install tree for the version, one alias binding both. No `--env`
flag and no profile system — a normal single-environment install is untouched.
`docs/plan.md` records the session; #168 filed for the last un-separated axis
(`configure-agent` overwriting production MCP wiring).

## Test plan

- [x] `cd _shared && bun test` — 350 pass, 0 fail
- [x] `cd packages/memory && bun run build && bun test` — 161 pass, 0 fail
- [x] `bun run typecheck`
- [x] Fresh Supabase deploy on a new project — validates the #26 explicit
      `service_role` grants with "automatically expose new tables" disabled
- [x] Production → staging round trip: 331 documents captured (12 trashed),
      restored to 319 live + 12 trashed, an exact match with the source
- [x] Idempotency re-run: 0 restored · 331 skipped · 0 errors
- [x] `migrate-format` on staging: 3 of 214 converted, 0 failed, content intact
- [x] Daemon isolation verified live — staging reports stopped while production
      reports its running daemon
- [ ] Cut `1.1.0-beta.2` from `main` after merge, then upgrade staging and
      re-verify the web daemon and trash round trip on the published build

## Release intent

Per `RELEASING.md`: CHANGELOG `[Unreleased]` populated; schema bumped 0.10.0 →
0.10.1 in **both** literals (`schema.sql` marker + `cerefox_schema_version()`);
compat matrix minimums reviewed and deliberately **not** raised (relations are
gated and degrade gracefully, and backup now tolerates older servers); no
primitive Edge Function changed, so the GPT Actions OpenAPI block is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vd45RFdSk8hHupWLn9jfDQ
