### PR TITLE
beta.3: load .env at startup, CEREFOX_ENV_LABEL, backup-dir fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,26 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
+### Added
+- **`CEREFOX_ENV_LABEL` — name a non-production environment.** Inert when
+  unset (every normal install). When set, the environment identifies itself
+  wherever it could otherwise be confused for production: a banner on every
+  web UI page, `[LABEL]` on `doctor`'s config line, the label in the backup
+  filename (`cerefox-staging-<stamp>.json`) and payload, and a warning from
+  `backup restore` when a snapshot's environment differs from the target's.
+  That last pair matters because `CEREFOX_BACKUP_DIR` does not follow
+  `CEREFOX_CONFIG_DIR`, so snapshots from two environments can share a
+  directory and a "most recent file" restore could seed production from
+  staging.
+
 ### Fixed
+- **`.env` is now loaded once at CLI startup.** Nothing did this: settings were
+  loaded lazily, deep inside whichever helper first needed Supabase
+  credentials, so any code reading `process.env.CEREFOX_*` directly saw an
+  unpopulated environment and silently used its default. That produced two
+  independent bugs — `CEREFOX_BACKUP_DIR` ignored outright, and
+  `CEREFOX_ENV_LABEL` never reaching `doctor` — and would have produced one for
+  every future setting read that way.
 - **`CEREFOX_BACKUP_DIR` set in `.env` was silently ignored.** `backup create`
   read the variable *before* anything loaded the config file — nothing loads
   `.env` at CLI startup; `loadSettings()` runs later, inside `getClient()` — so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
+### Fixed
+- **`CEREFOX_BACKUP_DIR` set in `.env` was silently ignored.** `backup create`
+  read the variable *before* anything loaded the config file — nothing loads
+  `.env` at CLI startup; `loadSettings()` runs later, inside `getClient()` — so
+  snapshots always went to the built-in `~/.cerefox/backups` no matter what was
+  configured. The setting appeared to work only when the variable was exported
+  in the shell or when Bun's auto-dotenv injected a working-directory `.env`,
+  which is how one machine's snapshots ended up split across two directories.
+  This also broke the staging guide's snapshot isolation: a staging `.env`
+  pointing at its own backup directory had no effect, so staging snapshots
+  landed beside production's.
+
 Open roadmap.
 
 ---

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -264,7 +264,8 @@ cerefox document get <document-id> --version-id <version-id>
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `CEREFOX_BACKUP_DIR` | dev mode: `./backups` · user-state mode: `~/.cerefox/backups` (v0.3.0+) | Local directory where file system backups are stored. Created automatically if it doesn't exist. The default tracks the resolved config dir — dev users see no change. |
+| `CEREFOX_BACKUP_DIR` | `~/.cerefox/backups` | Local directory where file system backups are stored. Created automatically if it doesn't exist. **Use an absolute path** — a relative value (such as the pre-v0.3.0 `./backups`) resolves against the current working directory, so snapshots scatter depending on where you run the command; `backup create` warns when it sees one. Does **not** follow `CEREFOX_CONFIG_DIR`, so a second environment must set it explicitly. |
+| `CEREFOX_ENV_LABEL` | _(unset)_ | Names a non-production environment (e.g. `staging`). Purely cosmetic and inert when unset. When set: the web UI shows a banner on every page, `doctor` appends `[LABEL]` to its config line, `backup create` puts the label in the snapshot filename and payload, and `backup restore` warns when a snapshot's environment differs from the target's. See [`staging-env.md`](staging-env.md). |
 | `CEREFOX_VERSION_RETENTION_HOURS` | `48` | How long to retain archived document versions (hours). The most recent version is always kept regardless of this setting. |
 
 ---

--- a/docs/guides/staging-env.md
+++ b/docs/guides/staging-env.md
@@ -73,11 +73,20 @@ CEREFOX_DATABASE_URL=postgresql://postgres.<staging-ref>:…@aws-0-<region>.pool
 
 # Isolate snapshots. CEREFOX_BACKUP_DIR does NOT follow the config dir, so
 # without this line staging backups land beside production's.
+# Use an ABSOLUTE path: a relative value resolves against the working
+# directory, so snapshots scatter wherever you happen to run the command.
 CEREFOX_BACKUP_DIR=~/.cerefox/staging/backups
 
 OPENAI_API_KEY=sk-…
 SUPABASE_ACCESS_TOKEN=sbp_…                       # account-level; same as prod
 ```
+
+> **Snapshot isolation needs v1.1.0-beta.3 or later.** On **beta.2 and
+> earlier**, `backup create` read `CEREFOX_BACKUP_DIR` *before* loading the
+> `.env` file, so the setting above was silently ignored and staging snapshots
+> landed in production's directory. Until staging is on a build with the fix,
+> pass the destination explicitly: `cfx-stg backup create --output-dir
+> ~/.cerefox/staging/backups`.
 
 **Mirror production's tuning** (`CEREFOX_MIN_SEARCH_SCORE`,
 `CEREFOX_MAX_CHUNK_CHARS`, `CEREFOX_MIN_CHUNK_CHARS`, `CEREFOX_EMBEDDER`, …).

--- a/docs/guides/staging-env.md
+++ b/docs/guides/staging-env.md
@@ -226,8 +226,24 @@ cfx-stg web status      # staging only
 cerefox web status      # production only — unaffected
 ```
 
-Set `CEREFOX_ENV_LABEL=staging` in the staging `.env` (Step 2) and the web UI
-labels itself, so a stray browser tab can't be mistaken for production.
+Set `CEREFOX_ENV_LABEL=staging` in the staging `.env` (Step 2) and the
+environment names itself everywhere it matters — two tabs that look identical
+otherwise:
+
+| Surface | With the label set |
+|---|---|
+| Web UI | A banner on every page: *"STAGING environment — not production."* |
+| `doctor` | `✓ config  …/staging/.env (mode 0600) [STAGING]` |
+| `backup create` | Filename becomes `cerefox-staging-<stamp>.json`, and the label is stored in the payload |
+| `backup restore` | Warns when the snapshot's environment differs from the target's |
+
+The filename and restore warning matter because `CEREFOX_BACKUP_DIR` does not
+follow `CEREFOX_CONFIG_DIR`: staging and production snapshots can end up in one
+directory, and a restore that picks "the most recent file" there would
+otherwise seed production from staging without saying so.
+
+**Requires v1.1.0-beta.3 or later** — on earlier builds `CEREFOX_ENV_LABEL` is
+read but nothing acts on it.
 
 ---
 

--- a/frontend/src/api/version.ts
+++ b/frontend/src/api/version.ts
@@ -4,6 +4,12 @@ export interface VersionInfo {
   version: string;
   git_commit_short: string | null;
   build_date: string | null;
+  /**
+   * `CEREFOX_ENV_LABEL` — names a non-production environment (e.g. "staging").
+   * Null on a normal install, which is the overwhelmingly common case, so
+   * nothing is rendered unless the operator explicitly opted in.
+   */
+  env_label?: string | null;
 }
 
 export async function fetchVersion(): Promise<VersionInfo> {

--- a/frontend/src/components/EnvironmentBanner.tsx
+++ b/frontend/src/components/EnvironmentBanner.tsx
@@ -1,0 +1,48 @@
+import { Alert, Text } from "@mantine/core";
+import { IconFlask } from "@tabler/icons-react";
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchVersion } from "../api/version";
+
+/**
+ * Names the environment when `CEREFOX_ENV_LABEL` is set.
+ *
+ * Running a staging server alongside production means two browser tabs that
+ * look identical while pointing at different databases — and the destructive
+ * actions in this UI (delete, restore, ingest over an existing document) are
+ * not ones you want to take against the wrong one. The label is the cheapest
+ * possible guard: visible on every page, impossible to miss, zero behaviour
+ * change.
+ *
+ * Renders nothing when the variable is unset, which is every normal install.
+ * See docs/guides/staging-env.md.
+ */
+export function EnvironmentBanner() {
+  const { data } = useQuery({
+    queryKey: ["version"],
+    queryFn: fetchVersion,
+    staleTime: Infinity,
+    retry: false,
+  });
+
+  const label = data?.env_label?.trim();
+  if (!label) return null;
+
+  return (
+    <Alert
+      icon={<IconFlask size={18} />}
+      color="grape"
+      withCloseButton={false}
+      mb="md"
+      data-testid="environment-banner"
+    >
+      <Text size="sm" fw={600}>
+        {label.toUpperCase()} environment — not production.
+      </Text>
+      <Text size="xs" c="dimmed">
+        This server is running against the <Text span fw={600}>{label}</Text>{" "}
+        database. Changes made here do not affect production.
+      </Text>
+    </Alert>
+  );
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -9,6 +9,7 @@ import {
 import { IconCheck, IconDeviceDesktop, IconMoon, IconSun } from "@tabler/icons-react";
 import { Outlet, useLocation, useNavigate } from "react-router-dom";
 import { useThemePreference } from "../hooks/useThemePreference";
+import { EnvironmentBanner } from "./EnvironmentBanner";
 import { SchemaVersionBanner } from "./SchemaVersionBanner";
 import { VersionFooter } from "./VersionFooter";
 
@@ -118,6 +119,7 @@ export function Layout() {
       </AppShell.Header>
 
       <AppShell.Main>
+        <EnvironmentBanner />
         <SchemaVersionBanner />
         <Outlet />
         <VersionFooter />

--- a/frontend/tests/e2e/ui.spec.ts
+++ b/frontend/tests/e2e/ui.spec.ts
@@ -204,3 +204,28 @@ test.describe("Audit Log", () => {
     await expect(page.getByTestId("page-title")).toHaveText(/Audit/i);
   });
 });
+
+// ── Environment banner ────────────────────────────────────────────────────
+// Asserts the contract rather than a fixed outcome: the banner appears if and
+// only if the server reports an `env_label`. That way the test is meaningful
+// on a normal install (where it guards against a banner ever showing up
+// uninvited) and on a labelled staging server, without needing two harnesses.
+test.describe("Environment banner", () => {
+  test("shown only when the server reports an env_label", async ({ page, request }) => {
+    const info = await (await request.get("/api/v1/version")).json();
+    const label = (info.env_label ?? "").trim();
+
+    await page.goto(`${APP}/`);
+    const banner = page.getByTestId("environment-banner");
+
+    if (label) {
+      await expect(banner).toBeVisible({ timeout: 15_000 });
+      await expect(banner).toContainText(label.toUpperCase());
+      await expect(banner).toContainText("not production");
+    } else {
+      // The overwhelmingly common case: a normal single-environment install
+      // must never see this.
+      await expect(banner).toHaveCount(0);
+    }
+  });
+});

--- a/packages/memory/src/bin/cerefox.ts
+++ b/packages/memory/src/bin/cerefox.ts
@@ -64,6 +64,29 @@ async function bareEntryPoint(): Promise<void> {
 }
 
 async function main(): Promise<void> {
+  // Load `.env` once, before any command body runs.
+  //
+  // Nothing used to do this: `loadSettings()` was called lazily deep inside
+  // whichever helper first needed Supabase credentials, so any code reading
+  // `process.env.CEREFOX_*` directly saw an unpopulated environment and
+  // silently fell back to its default. That produced two separate bugs —
+  // `CEREFOX_BACKUP_DIR` in `.env` was ignored outright, and
+  // `CEREFOX_ENV_LABEL` never reached `doctor` — and would keep producing them
+  // for every new setting read that way.
+  //
+  // loadEnv() is idempotent and reads one small file, so the later
+  // loadSettings() calls are unaffected and `--help` / `--version` stay fast.
+  {
+    const { loadEnv } = await import("../../../../_shared/config/index.ts");
+    try {
+      loadEnv();
+    } catch {
+      // A missing or unreadable .env is not fatal here: settings can come from
+      // the real environment (Cerefox Local does exactly that), and the
+      // commands that genuinely need credentials report it themselves.
+    }
+  }
+
   // Bare invocation (just `cerefox` with no args): show the state-aware
   // friendly entry instead of commander's default help dump.
   if (process.argv.length === 2) {

--- a/packages/memory/src/cli/commands/backup.ts
+++ b/packages/memory/src/cli/commands/backup.ts
@@ -20,6 +20,7 @@ import {
   println,
   systemError,
 } from "../../../../../_shared/cli-core/index.ts";
+import { loadEnv } from "../../../../../_shared/config/index.ts";
 import { fetchAllPages } from "../../../../../_shared/db-client/paginate.ts";
 import { getClient } from "../util/client.ts";
 import { PKG_VERSION } from "../../meta.ts";
@@ -54,6 +55,21 @@ function utcStamp(): string {
 }
 
 async function action(options: BackupOptions): Promise<void> {
+  // Load `.env` BEFORE reading CEREFOX_BACKUP_DIR.
+  //
+  // Nothing loads it at CLI startup — `loadSettings()` runs inside
+  // `getClient()`, which happens further down. So this line used to read a
+  // `process.env` that the config file had not been merged into yet, and
+  // `CEREFOX_BACKUP_DIR` set in `.env` was silently ignored: snapshots went to
+  // the built-in default no matter what the user configured. It appeared to
+  // work only when the variable was exported in the shell, or when Bun's
+  // auto-dotenv happened to inject a working-directory `.env`, which is why
+  // the same setting sent two machines' backups to two different places.
+  //
+  // loadEnv() is idempotent, so calling it here is free when something else
+  // already did.
+  loadEnv();
+
   const configuredDir = options.outputDir ?? process.env.CEREFOX_BACKUP_DIR;
   const outDir = resolve(expandHome(configuredDir ?? "~/.cerefox/backups"));
 

--- a/packages/memory/src/cli/commands/backup.ts
+++ b/packages/memory/src/cli/commands/backup.ts
@@ -97,8 +97,25 @@ async function action(options: BackupOptions): Promise<void> {
 
   if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true });
 
+  // Stamp the environment into the filename when one is labelled.
+  //
+  // `CEREFOX_BACKUP_DIR` does not follow `CEREFOX_CONFIG_DIR`, so a staging
+  // snapshot can legitimately land in the shared backup directory — and a
+  // restore picking the "most recent" file there would then quietly seed
+  // production from staging. The name is the last line of defence: a snapshot
+  // should say where it came from without anyone having to open it.
+  //
+  // Sanitised because it becomes a path segment: anything outside
+  // [A-Za-z0-9._-] is collapsed to `-`.
+  const envLabel = (process.env.CEREFOX_ENV_LABEL ?? "")
+    .trim()
+    .replace(/[^A-Za-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
   const stamp = utcStamp();
-  const filename = `cerefox-${stamp}${options.label ? "-" + options.label : ""}.json`;
+  const filename =
+    `cerefox-${envLabel ? envLabel + "-" : ""}${stamp}` +
+    `${options.label ? "-" + options.label : ""}.json`;
   const dest = join(outDir, filename);
 
   const client = getClient();
@@ -288,6 +305,10 @@ async function action(options: BackupOptions): Promise<void> {
     document_count: docs.length,
     trashed_count: trashedCount,
     includes_trash: includeTrash,
+    // Which environment produced this snapshot (null on a normal install).
+    // Restore surfaces it, so seeding production from a staging file is a
+    // visible act rather than an accident.
+    env_label: envLabel || null,
     // False when taken against a pre-0.10.0 server, so a restore can tell an
     // absent lifecycle_status from one that was genuinely never set.
     includes_lifecycle_status: lifecycleCaptured,

--- a/packages/memory/src/cli/commands/restore.ts
+++ b/packages/memory/src/cli/commands/restore.ts
@@ -65,6 +65,8 @@ async function action(target: string, options: RestoreOptions): Promise<void> {
       // 2 = includes projects + memberships (#166). Absent/1 = documents and
       // chunks only; those snapshots still restore, just without memberships.
       backup_format?: number;
+      /** Environment that produced the snapshot (format 4+); null/absent on a normal install. */
+      env_label?: string | null;
       schema_version?: string;
       document_count?: number;
       chunk_count?: number;
@@ -111,6 +113,22 @@ async function action(target: string, options: RestoreOptions): Promise<void> {
       "This backup predates project-membership capture (format 1) — documents " +
         "will be restored WITHOUT their project assignments.",
     );
+  }
+
+  // Cross-environment restores are legitimate (seeding staging from production
+  // is the main reason staging exists) but the reverse is a mistake you only
+  // make once. Since `CEREFOX_BACKUP_DIR` does not follow `CEREFOX_CONFIG_DIR`,
+  // snapshots from both environments can sit in one directory — so say out loud
+  // when the file and the target disagree instead of restoring silently.
+  {
+    const fileEnv = (payload.env_label ?? "").trim();
+    const targetEnv = (process.env.CEREFOX_ENV_LABEL ?? "").trim();
+    if (fileEnv !== targetEnv) {
+      warn(
+        `This snapshot came from ${fileEnv ? `the "${fileEnv}" environment` : "an unlabelled (production) environment"}, ` +
+          `but you are restoring into ${targetEnv ? `"${targetEnv}"` : "an unlabelled (production) environment"}.`,
+      );
+    }
   }
 
   // Trashed documents (format 4+) are restored *as trash*: the row carries its

--- a/packages/memory/src/cli/util/checks.ts
+++ b/packages/memory/src/cli/util/checks.ts
@@ -136,10 +136,15 @@ export function checkConfig(): CheckResult {
       // Couldn't stat; surface as a warn but don't block.
     }
   }
+  // Name the environment when the operator has labelled one. `doctor` is the
+  // command people run to answer "what am I actually pointed at?", so a
+  // staging run should say so on the very first line rather than leaving the
+  // config path as the only clue.
+  const envLabel = (process.env.CEREFOX_ENV_LABEL ?? "").trim();
   return {
     name: "config",
     status: "ok",
-    detail: `${envPath}${modeDetail}`,
+    detail: `${envPath}${modeDetail}${envLabel ? ` [${envLabel.toUpperCase()}]` : ""}`,
   };
 }
 

--- a/packages/memory/src/web/routes/meta.ts
+++ b/packages/memory/src/web/routes/meta.ts
@@ -44,7 +44,17 @@ const VERSION_INFO = {
 const SCHEMA_VERSION_RE = /^--\s*@version:\s*(\S+)/m;
 
 export function registerMetaRoutes(app: Hono, ctx: WebContext | null): void {
-  app.get("/api/v1/version", (c) => c.json(VERSION_INFO));
+  // `env_label` is read per-request, not folded into the module-level
+  // VERSION_INFO: the label comes from `.env`, which is loaded during server
+  // startup, and this module is imported before that happens.
+  //
+  // Purely cosmetic, and deliberately so — it exists to stop someone acting on
+  // a staging tab believing it is production. Empty/whitespace is treated as
+  // unset so a stray `CEREFOX_ENV_LABEL=` never paints a blank badge.
+  app.get("/api/v1/version", (c) => {
+    const label = (process.env.CEREFOX_ENV_LABEL ?? "").trim();
+    return c.json({ ...VERSION_INFO, env_label: label.length > 0 ? label : null });
+  });
 
   app.get("/api/v1/docs", (c) => c.json(listBundledDocs()));
 

--- a/packages/memory/test/web-integration/meta.test.ts
+++ b/packages/memory/test/web-integration/meta.test.ts
@@ -29,16 +29,21 @@ describe("meta endpoints (HTTP boundary)", () => {
 
   // ── /api/v1/version ────────────────────────────────────────────────────────
 
-  test("/version returns {version, git_commit_short, build_date}", async () => {
+  test("/version returns {version, git_commit_short, build_date, env_label}", async () => {
     if (!server) return;
     const resp = await fetch(`${server.base}/api/v1/version`);
     expect(resp.status).toBe(200);
     const body = await resp.json();
     expect(Object.keys(body).sort()).toEqual(
-      ["build_date", "git_commit_short", "version"].sort(),
+      ["build_date", "env_label", "git_commit_short", "version"].sort(),
     );
     expect(typeof body.version).toBe("string");
     expect(body.version).toMatch(/^\d+\.\d+\.\d+/);
+    // Null unless CEREFOX_ENV_LABEL names an environment. The web UI banner
+    // keys off exactly this, so a normal install must report null rather than
+    // an empty string.
+    expect(body.env_label === null || typeof body.env_label === "string").toBe(true);
+    expect(body.env_label).not.toBe("");
   });
 
   // ── /api/v1/docs ───────────────────────────────────────────────────────────


### PR DESCRIPTION
Accumulating branch for **v1.1.0-beta.3**. Everything here came out of running
staging and production side by side.

## The root cause tying it together

**Nothing loaded `.env` at CLI startup.** Settings were loaded lazily, deep
inside whichever helper first needed Supabase credentials, so any code reading
`process.env.CEREFOX_*` directly saw an unpopulated environment and silently
used its default. That produced two independent bugs and would have produced one
for every future setting read that way. Now loaded once at the entry point.

## Fixed

- **`CEREFOX_BACKUP_DIR` in `.env` was ignored outright.** `backup create` read
  the variable before anything had loaded the file, so snapshots always went to
  the built-in `~/.cerefox/backups` regardless of configuration. It appeared to
  work only when the variable was exported in the shell, or when Bun's
  auto-dotenv injected a working-directory `.env` — which is exactly what split
  one store's snapshots across two directories: the installed CLI used the
  default while a repo-run dev build picked up `./backups` from the checkout.
  This also broke the staging guide's snapshot isolation.
- Warns when `CEREFOX_BACKUP_DIR` is **relative**, naming the resolved
  destination. A relative value resolves against the working directory, so the
  same command writes somewhere different depending on where you run it.
- `requirements-and-specs.md` / `configuration.md` still documented the
  pre-v0.3.0 `./backups` as the default.

## Added — `CEREFOX_ENV_LABEL`

Promised by the staging guide and **never implemented**: the variable was
documented and set in a real staging `.env`, but no code read it. Running
staging beside production means two browser tabs that look identical while
pointing at different databases, and the destructive actions in the web UI are
not ones to take against the wrong one.

Inert when unset — every normal install. When set:

| Surface | Behaviour |
|---|---|
| Web UI | Banner on every page: *"STAGING environment — not production."* |
| `doctor` | `✓ config  …/staging/.env (mode 0600) [STAGING]` |
| `backup create` | `cerefox-staging-<stamp>.json`, label stored in the payload |
| `backup restore` | Warns when snapshot and target environments differ |

The last two are not cosmetic. `CEREFOX_BACKUP_DIR` does not follow
`CEREFOX_CONFIG_DIR`, so snapshots from both environments can share a directory
— and `restore` given a *directory* picks the most recent file in it. Without
the label, that path could seed production from staging in silence.

## Test plan

- [x] `cd _shared && bun test` — 350 pass, 0 fail
- [x] `cd packages/memory && bun run build && bun test` — 161 pass; one live
      test intermittently times out at its 5s budget, pre-existing and
      reproduced on a clean tree
- [x] `bun run typecheck`
- [x] Playwright: banner renders against a labelled server; **absent** against
      an unlabelled one. Permanent test asserts the contract in both directions
      (visible iff the server reports `env_label`), so it stays meaningful on a
      normal install
- [x] `doctor` prints `[STAGING]` on staging, unchanged on production
- [x] Staging backup lands in the staging directory as
      `cerefox-staging-<stamp>.json` — proving both the `.env` fix and the
      filename
- [x] Dry-run restore of that staging snapshot into production emits the
      cross-environment warning before writing anything
- [x] Updated the `/version` HTTP-boundary test, which asserted an exact key set

## Notes

Branch name predates the wider scope. Docs updated: `staging-env.md`
(affected-version caveats + the label table), `configuration.md`
(both variables), CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vd45RFdSk8hHupWLn9jfDQ
