### PR TITLE
Settings page: the web face of cerefox config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,28 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
-Open roadmap.
+### Added
+- **Settings page in the web UI** — the browser face of `cerefox config
+  get/set`. Every `cerefox_config` key with its description, current value and
+  default, grouped into Retrieval / Governance / Features. Keys that change what
+  *other software* sees require an explicit confirmation naming the consequence
+  rather than a bare toggle: turning on `relations_enabled` adds four tools to
+  every connected agent's list, and `require_requestor_identity` starts
+  rejecting agents that don't identify themselves. Verified end to end —
+  flipping the switch in the browser moved the advertised MCP tool list from 10
+  to 14 and back.
+
+  A `CEREFOX_*` variable set on the server is shown **read-only** as an
+  override, because it beats the stored value on that machine; without this the
+  page would report success while the server kept using a different number. It
+  is deliberately **not** an `.env` editor — that file holds the service-role
+  key, OpenAI key and database password, and the server only reads it at boot.
+
+  The key catalog now lives in `_shared/config-catalog/`, so `cerefox config
+  list` and the page cannot disagree about what a key means or defaults to.
+  Value validation lives there too: the RPC allow-lists the *key* but stores the
+  value as opaque text, so `min_search_score = 5` was previously accepted and
+  silently suppressed every search result. Bad values now get a 400.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,13 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
   value as opaque text, so `min_search_score = 5` was previously accepted and
   silently suppressed every search result. Bad values now get a 400.
 
+### Changed
+- **`migrate-format`'s bulk-write warning now triggers at 200 documents**
+  (was 500). Converting ~200 documents already means on the order of a thousand
+  chunk inserts plus version rows — comparable write volume to the reindex that
+  depleted a contributor's Disk IO Budget. The command is rare and opt-in, so
+  erring quiet helped nobody.
+
 ---
 
 ## [v1.1.0-beta.4] -- 2026-08-06

--- a/_shared/config-catalog/index.ts
+++ b/_shared/config-catalog/index.ts
@@ -1,0 +1,161 @@
+/**
+ * The `cerefox_config` key catalog — one description of the runtime settings,
+ * shared by every surface that presents them.
+ *
+ * These keys are DB-backed, not environment variables: setting one governs
+ * EVERY access path (CLI, local + remote MCP, Edge Functions, web) because all
+ * of them resolve through the same RPCs. That is the point of the table, and
+ * it is also why the catalog lives here rather than being restated per client
+ * — `cerefox config list` and the web settings page must not be able to
+ * disagree about what a key means or what it defaults to.
+ *
+ * The authoritative allow-list is `v_allowed` in `cerefox_set_config`
+ * (`src/cerefox/db/rpcs.sql`). This catalog must stay in step with it; a key
+ * here that the RPC rejects surfaces as a write error, and a key there but not
+ * here is simply invisible to the UI.
+ */
+
+export type ConfigValueKind = "boolean" | "number" | "string";
+
+export interface ConfigKeySpec {
+  key: string;
+  /** One line, plain enough for a settings screen. */
+  description: string;
+  kind: ConfigValueKind;
+  /** Value used when the row is absent, as stored (always a string). */
+  defaultValue: string;
+  /** Numeric bounds, for input validation. */
+  min?: number;
+  max?: number;
+  /** Grouping for display. */
+  group: "Governance" | "Retrieval" | "Features";
+  /**
+   * True when flipping this key changes what other software sees — not just
+   * how this install behaves. Surfaces get an explicit confirmation step
+   * rather than a bare toggle.
+   */
+  highImpact?: boolean;
+  /** Shown alongside a high-impact key to explain the consequence. */
+  impactNote?: string;
+}
+
+export const CONFIG_CATALOG: ReadonlyArray<ConfigKeySpec> = [
+  {
+    key: "usage_tracking_enabled",
+    description: "Log reads and writes to cerefox_usage_log.",
+    kind: "boolean",
+    defaultValue: "false",
+    group: "Governance",
+  },
+  {
+    key: "require_requestor_identity",
+    description: "Require a requestor/author on MCP tool calls.",
+    kind: "boolean",
+    defaultValue: "false",
+    group: "Governance",
+    highImpact: true,
+    impactNote:
+      "Agents that do not send a requestor will start getting errors. Confirm your MCP clients identify themselves before enabling.",
+  },
+  {
+    key: "requestor_identity_format",
+    description:
+      "Regex the requestor/author must match. Only enforced while “require requestor identity” is on.",
+    kind: "string",
+    defaultValue: "",
+    group: "Governance",
+  },
+  {
+    key: "min_search_score",
+    description:
+      "Minimum cosine similarity for vector-side results. Use 0.6 with the local embedder.",
+    kind: "number",
+    defaultValue: "0.5",
+    min: 0,
+    max: 1,
+    group: "Retrieval",
+  },
+  {
+    key: "min_term_coverage",
+    description:
+      "Fraction of a query's meaningful terms a keyword OR-fallback match must cover to count as confident.",
+    kind: "number",
+    defaultValue: "0.5",
+    min: 0,
+    max: 1,
+    group: "Retrieval",
+  },
+  {
+    key: "search_alpha",
+    description: "Hybrid fusion weight: 1 = pure semantic, 0 = pure keyword.",
+    kind: "number",
+    defaultValue: "0.7",
+    min: 0,
+    max: 1,
+    group: "Retrieval",
+  },
+  {
+    key: "relations_enabled",
+    description:
+      "Expose the four document-relation tools to agents. The feature is dormant until enabled.",
+    kind: "boolean",
+    defaultValue: "false",
+    group: "Features",
+    highImpact: true,
+    impactNote:
+      "This adds four tools (set/delete/get relations, get neighbours) to every connected agent's tool list — local MCP, remote MCP, and Edge Functions alike. Relations data and schema are always present; this switch only controls whether agents can see and use the tools. Turning it back off hides them again without deleting anything.",
+  },
+];
+
+export function configKeySpec(key: string): ConfigKeySpec | undefined {
+  return CONFIG_CATALOG.find((k) => k.key === key);
+}
+
+/** The catalog's keys, in display order. */
+export const CONFIG_KEYS: ReadonlyArray<string> = CONFIG_CATALOG.map((k) => k.key);
+
+/**
+ * Validate a value for a key before it reaches the RPC. Returns null when the
+ * value is acceptable, or a human-readable reason when it is not.
+ *
+ * The RPC is the authority on *which keys* exist; this is about the *value*,
+ * which the RPC stores as opaque text. Without it a typo like `min_search_score
+ * = 5` is accepted silently and quietly suppresses every search result.
+ */
+export function validateConfigValue(key: string, value: string): string | null {
+  const spec = configKeySpec(key);
+  if (!spec) return `Unknown config key: ${key}`;
+
+  if (spec.kind === "boolean") {
+    return value === "true" || value === "false"
+      ? null
+      : `${key} must be "true" or "false" (got ${JSON.stringify(value)}).`;
+  }
+
+  if (spec.kind === "number") {
+    const n = Number(value);
+    if (!Number.isFinite(n)) {
+      return `${key} must be a number (got ${JSON.stringify(value)}).`;
+    }
+    if (spec.min !== undefined && n < spec.min) {
+      return `${key} must be ≥ ${spec.min} (got ${n}).`;
+    }
+    if (spec.max !== undefined && n > spec.max) {
+      return `${key} must be ≤ ${spec.max} (got ${n}).`;
+    }
+    return null;
+  }
+
+  // Free-text keys that are regexes must actually compile, or the enforcement
+  // path they feed throws on every call instead of rejecting one request.
+  if (key === "requestor_identity_format" && value.length > 0) {
+    try {
+      new RegExp(value);
+    } catch (err) {
+      return `${key} must be a valid regular expression: ${
+        err instanceof Error ? err.message : String(err)
+      }`;
+    }
+  }
+  return null;
+}

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -367,8 +367,12 @@ enable it.
 
 ### How it works
 
-A `cerefox_config` table in Postgres stores runtime configuration as key-value pairs. The only
-key currently in use is `usage_tracking_enabled`. Every usage logging call goes through the
+A `cerefox_config` table in Postgres stores runtime configuration as key-value
+pairs. The allow-list lives in the `cerefox_set_config` RPC; run `cerefox config
+list` (or open **Settings** in the web UI) for the current set — today that is
+usage tracking, the two requestor-identity keys, three retrieval tunables, and
+`relations_enabled`. Usage logging is the illustrative case below: every logging
+call goes through the
 `cerefox_log_usage` RPC, which checks this config value first:
 
 - If `usage_tracking_enabled` is `"true"` -- the RPC inserts a row into `cerefox_usage_log`
@@ -398,7 +402,30 @@ cerefox config set usage_tracking_enabled false
 cerefox config get usage_tracking_enabled
 ```
 
-The canonical path is the CLI (`cerefox config set <key> <value>` / `cerefox config get <key>`) above; it works regardless of whether the web server is running. The web UI's JSON API exposes the same config under `/api/v1/config/<key>` if you need programmatic access while `cerefox web` is running.
+**Via the web UI:** `cerefox web` → **Settings**. Every runtime key is listed
+with its description, current value and default, grouped into Retrieval,
+Governance and Features.
+
+Two things the page does deliberately:
+
+- **Keys that change what agents see require confirmation.** Turning on
+  `relations_enabled` adds four tools to every connected agent's tool list, and
+  `require_requestor_identity` starts rejecting agents that don't identify
+  themselves. Neither is a bare toggle — you get a dialog naming the
+  consequence first.
+- **Local overrides are shown, read-only.** If the server has
+  `CEREFOX_MIN_SEARCH_SCORE` (or the `..._TERM_COVERAGE` / `..._SEARCH_ALPHA`
+  equivalents) in its environment, that value beats the stored one *on that
+  machine*, and the row says so. Without this the page would report a value the
+  server isn't using. The page never edits `.env` — that file holds your
+  service-role key, OpenAI key and database password, and the server only reads
+  it at boot.
+
+The CLI (`cerefox config set <key> <value>` / `cerefox config get <key>`) remains
+the canonical path and works whether or not the web server is running. Both go
+through the same `cerefox_set_config` RPC, so they cannot disagree.
+`/api/v1/config` (list) and `/api/v1/config/<key>` (read/write) expose the same
+data for programmatic access while `cerefox web` runs.
 
 ### What gets logged
 

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -4063,9 +4063,20 @@ untested against production until a staging Supabase project exists (below).
   trash** (`deleted_at` replayed; every read/search RPC filters it), with
   `--no-trash` to opt out. Proven end to end: 331 captured (12 trashed) →
   319 live + 12 trashed in staging, exact match; re-run 0/331/0.
-- ⏳ **Config web UI** — a settings surface for the `cerefox_config` keys
-  (`cerefox config set` equivalents, incl. the retrieval tunables from #133 and
-  `relations_enabled`). Next up.
+- ✅ **Config web UI** (beta.4) — a **Settings** page for the `cerefox_config`
+  keys, grouped Retrieval / Governance / Features. The key catalog moved to
+  `_shared/config-catalog/` so `cerefox config list` and the page cannot
+  disagree about a key's meaning or default, and value validation lives there
+  too (the RPC allow-lists the *key* but stores the value as opaque text, so
+  `min_search_score = 5` used to be accepted and silently suppress every
+  result). Two deliberate behaviours: keys that change what agents see
+  (`relations_enabled`, `require_requestor_identity`) require a confirmation
+  naming the consequence, never a bare toggle; and a `CEREFOX_*` variable set on
+  the server is shown read-only as an override, because it beats the stored
+  value on that machine and a page that hid it would report success while the
+  server used a different number. **Not** an `.env` editor — that file holds the
+  service-role key, OpenAI key and DB password. Verified end to end: flipping
+  `relations_enabled` in the browser moved the MCP tool list 10 → 14 → 10.
 
 ### beta.3 / beta.4 — the staging environment starts paying for itself
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import { ProjectsPage } from "./pages/ProjectsPage";
 import { AnalyticsPage } from "./pages/AnalyticsPage";
 import { MetadataSearchPage } from "./pages/MetadataSearchPage";
 import { SearchPage } from "./pages/SearchPage";
+import { SettingsPage } from "./pages/SettingsPage";
 import { TrashPage } from "./pages/TrashPage";
 
 export function App() {
@@ -29,6 +30,7 @@ export function App() {
         <Route path="/audit-log" element={<AuditLogPage />} />
         <Route path="/trash" element={<TrashPage />} />
         <Route path="/analytics" element={<AnalyticsPage />} />
+        <Route path="/settings" element={<SettingsPage />} />
         <Route path="/help" element={<HelpPage />} />
         <Route path="/help/*" element={<HelpPage />} />
       </Route>

--- a/frontend/src/api/config.ts
+++ b/frontend/src/api/config.ts
@@ -1,0 +1,43 @@
+import { apiFetch } from "./client";
+
+export interface ConfigEnvOverride {
+  name: string;
+  value: string;
+}
+
+export interface ConfigEntry {
+  key: string;
+  /** Stored value, or null when the row is absent (the default applies). */
+  value: string | null;
+  /** What takes effect: the stored value, else the default. */
+  effective: string;
+  description: string;
+  kind: "boolean" | "number" | "string";
+  default: string;
+  min: number | null;
+  max: number | null;
+  group: string;
+  /** Flipping this changes what other software sees; confirm before writing. */
+  high_impact: boolean;
+  impact_note: string | null;
+  /**
+   * Set when a CEREFOX_* variable on this server overrides the stored value.
+   * The DB value is then not what this server actually uses.
+   */
+  env_override: ConfigEnvOverride | null;
+}
+
+export async function fetchConfig(): Promise<{ keys: ConfigEntry[] }> {
+  return apiFetch<{ keys: ConfigEntry[] }>("/config");
+}
+
+export async function setConfigValue(
+  key: string,
+  value: string,
+): Promise<{ key: string; value: string }> {
+  return apiFetch<{ key: string; value: string }>(`/config/${encodeURIComponent(key)}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ value }),
+  });
+}

--- a/frontend/src/api/config.ts
+++ b/frontend/src/api/config.ts
@@ -27,8 +27,14 @@ export interface ConfigEntry {
   env_override: ConfigEnvOverride | null;
 }
 
-export async function fetchConfig(): Promise<{ keys: ConfigEntry[] }> {
-  return apiFetch<{ keys: ConfigEntry[] }>("/config");
+export interface ConfigListResponse {
+  keys: ConfigEntry[];
+  /** Path to the .env this server read, so the UI can point at it. */
+  config_file: string | null;
+}
+
+export async function fetchConfig(): Promise<ConfigListResponse> {
+  return apiFetch<ConfigListResponse>("/config");
 }
 
 export async function setConfigValue(

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -22,6 +22,7 @@ const NAV_ITEMS = [
   { label: "Audit Log", path: "/audit-log" },
   { label: "Trash", path: "/trash" },
   { label: "Analytics", path: "/analytics" },
+  { label: "Settings", path: "/settings" },
   { label: "Help", path: "/help" },
 ];
 

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -120,6 +120,7 @@ export function SettingsPage() {
                   onDraft={(v) => setDrafts((d) => ({ ...d, [entry.key]: v }))}
                   onSave={(v) => save(entry, v)}
                   saving={mutation.isPending}
+                  configFile={data?.config_file ?? null}
                 />
               ))}
             </Stack>
@@ -183,12 +184,14 @@ function ConfigRow({
   onDraft,
   onSave,
   saving,
+  configFile,
 }: {
   entry: ConfigEntry;
   draft: string | undefined;
   onDraft: (v: string) => void;
   onSave: (v: string) => void;
   saving: boolean;
+  configFile: string | null;
 }) {
   const current = draft ?? entry.effective;
   const dirty = draft !== undefined && draft !== entry.effective;
@@ -227,6 +230,18 @@ function ConfigRow({
                 Overridden on this server by <Code>{entry.env_override?.name}</Code> ={" "}
                 <Code>{entry.env_override?.value}</Code>. The stored value below still
                 applies to clients that do not set that variable.
+              </Text>
+              <Text size="xs" mt={6}>
+                To change it, edit{" "}
+                {configFile ? <Code>{configFile}</Code> : <Code>your .env</Code>} on this
+                machine and restart the server — it is read once at startup. Cerefox never
+                writes that file from the browser:{" "}
+                <Text span fw={600}>
+                  it also holds your Supabase secret key, OpenAI API key and database
+                  password
+                </Text>
+                , so treat it like a password store — keep it at mode 0600 and out of
+                version control.
               </Text>
             </Alert>
           )}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,0 +1,280 @@
+import {
+  Alert,
+  Badge,
+  Button,
+  Card,
+  Code,
+  Group,
+  Modal,
+  NumberInput,
+  Stack,
+  Switch,
+  Text,
+  TextInput,
+  Title,
+} from "@mantine/core";
+import { IconAlertTriangle, IconInfoCircle } from "@tabler/icons-react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+
+import { fetchConfig, setConfigValue, type ConfigEntry } from "../api/config";
+import { CliCard } from "../components/CliCard";
+import { showError, showSuccess } from "../utils/notifications";
+
+/**
+ * Runtime settings — the web face of `cerefox config get/set`.
+ *
+ * These live in the `cerefox_config` table, not in `.env`, which is what makes
+ * them worth a UI: one write governs every access path (CLI, local and remote
+ * MCP, Edge Functions, this app) because they all resolve through the same
+ * RPCs.
+ *
+ * Deliberately NOT an `.env` editor. That file holds the service-role key, the
+ * OpenAI key and the database password; a web endpoint that writes it would be
+ * a credential-exposure surface, and the server only reads it at boot anyway.
+ * Local overrides are shown read-only, because a `CEREFOX_*` variable beats the
+ * stored value on the machine that has it — a settings page that hid that would
+ * report success while the server kept using a different number.
+ */
+
+const GROUP_ORDER = ["Retrieval", "Governance", "Features"] as const;
+
+const GROUP_BLURB: Record<string, string> = {
+  Retrieval: "How search ranks and filters results.",
+  Governance: "Attribution and audit requirements for agent calls.",
+  Features: "Optional capabilities, off until you turn them on.",
+};
+
+export function SettingsPage() {
+  const queryClient = useQueryClient();
+  const { data, isLoading } = useQuery({ queryKey: ["config"], queryFn: fetchConfig });
+
+  // Pending high-impact change awaiting explicit confirmation.
+  const [confirming, setConfirming] = useState<{ entry: ConfigEntry; value: string } | null>(
+    null,
+  );
+  // Local edit buffer for text/number fields, so typing doesn't fire a write
+  // per keystroke.
+  const [drafts, setDrafts] = useState<Record<string, string>>({});
+
+  const mutation = useMutation({
+    mutationFn: ({ key, value }: { key: string; value: string }) => setConfigValue(key, value),
+    onSuccess: (_res, vars) => {
+      showSuccess(`Saved ${vars.key}`);
+      void queryClient.invalidateQueries({ queryKey: ["config"] });
+      setDrafts((d) => {
+        const next = { ...d };
+        delete next[vars.key];
+        return next;
+      });
+    },
+    onError: (err: unknown) => {
+      showError(err instanceof Error ? err.message : String(err));
+    },
+  });
+
+  function save(entry: ConfigEntry, value: string) {
+    // High-impact keys change what *other* software sees — agents gaining or
+    // losing tools, calls starting to fail. Those get a confirmation naming the
+    // consequence, never a bare toggle.
+    if (entry.high_impact) {
+      setConfirming({ entry, value });
+      return;
+    }
+    mutation.mutate({ key: entry.key, value });
+  }
+
+  if (isLoading) return <Text>Loading settings…</Text>;
+
+  const entries = data?.keys ?? [];
+
+  return (
+    <Stack gap="lg">
+      <div>
+        <Title order={2} data-testid="page-title">
+          Settings
+        </Title>
+        <Text c="dimmed" size="sm">
+          Runtime configuration stored in the database. A change here applies to every
+          access path — this app, the CLI, and every connected agent.
+        </Text>
+      </div>
+
+      {GROUP_ORDER.map((group) => {
+        const inGroup = entries.filter((e) => e.group === group);
+        if (inGroup.length === 0) return null;
+        return (
+          <Card key={group} withBorder padding="md" data-testid={`config-group-${group}`}>
+            <Stack gap="xs">
+              <div>
+                <Title order={4}>{group}</Title>
+                <Text size="xs" c="dimmed">
+                  {GROUP_BLURB[group]}
+                </Text>
+              </div>
+              {inGroup.map((entry) => (
+                <ConfigRow
+                  key={entry.key}
+                  entry={entry}
+                  draft={drafts[entry.key]}
+                  onDraft={(v) => setDrafts((d) => ({ ...d, [entry.key]: v }))}
+                  onSave={(v) => save(entry, v)}
+                  saving={mutation.isPending}
+                />
+              ))}
+            </Stack>
+          </Card>
+        );
+      })}
+
+      <CliCard
+        title="CLI equivalent"
+        commands={[
+          { cmd: "cerefox config list" },
+          { cmd: "cerefox config get", args: "relations_enabled" },
+          { cmd: "cerefox config set", args: "relations_enabled true" },
+        ]}
+      />
+
+      <Modal
+        opened={confirming !== null}
+        onClose={() => setConfirming(null)}
+        title="Confirm this change"
+        data-testid="config-confirm-modal"
+      >
+        {confirming && (
+          <Stack gap="sm" data-testid="config-confirm-body">
+            <Text size="sm">
+              Set <Code>{confirming.entry.key}</Code> to <Code>{confirming.value}</Code>?
+            </Text>
+            {confirming.entry.impact_note && (
+              <Alert icon={<IconAlertTriangle size={16} />} color="yellow">
+                <Text size="sm">{confirming.entry.impact_note}</Text>
+              </Alert>
+            )}
+            <Group justify="flex-end">
+              <Button variant="default" onClick={() => setConfirming(null)}>
+                Cancel
+              </Button>
+              <Button
+                data-testid="config-confirm-apply"
+                loading={mutation.isPending}
+                onClick={() => {
+                  mutation.mutate({
+                    key: confirming.entry.key,
+                    value: confirming.value,
+                  });
+                  setConfirming(null);
+                }}
+              >
+                Apply
+              </Button>
+            </Group>
+          </Stack>
+        )}
+      </Modal>
+    </Stack>
+  );
+}
+
+function ConfigRow({
+  entry,
+  draft,
+  onDraft,
+  onSave,
+  saving,
+}: {
+  entry: ConfigEntry;
+  draft: string | undefined;
+  onDraft: (v: string) => void;
+  onSave: (v: string) => void;
+  saving: boolean;
+}) {
+  const current = draft ?? entry.effective;
+  const dirty = draft !== undefined && draft !== entry.effective;
+  const overridden = entry.env_override !== null;
+
+  return (
+    <Card withBorder padding="sm" radius="sm" data-testid={`config-row-${entry.key}`}>
+      <Group justify="space-between" align="flex-start" wrap="nowrap">
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <Group gap="xs">
+            <Code>{entry.key}</Code>
+            {entry.value === null && (
+              <Badge size="xs" variant="light" color="gray">
+                default
+              </Badge>
+            )}
+            {entry.high_impact && (
+              <Badge size="xs" variant="light" color="yellow">
+                affects agents
+              </Badge>
+            )}
+          </Group>
+          <Text size="sm" c="dimmed" mt={4}>
+            {entry.description}
+          </Text>
+
+          {overridden && (
+            <Alert
+              icon={<IconInfoCircle size={14} />}
+              color="blue"
+              mt="xs"
+              p="xs"
+              data-testid={`config-override-${entry.key}`}
+            >
+              <Text size="xs">
+                Overridden on this server by <Code>{entry.env_override?.name}</Code> ={" "}
+                <Code>{entry.env_override?.value}</Code>. The stored value below still
+                applies to clients that do not set that variable.
+              </Text>
+            </Alert>
+          )}
+        </div>
+
+        <div style={{ minWidth: 190 }}>
+          {entry.kind === "boolean" ? (
+            <Switch
+              checked={current === "true"}
+              disabled={saving}
+              onChange={(e) => onSave(e.currentTarget.checked ? "true" : "false")}
+              label={current === "true" ? "On" : "Off"}
+            />
+          ) : entry.kind === "number" ? (
+            <Group gap="xs" wrap="nowrap">
+              <NumberInput
+                value={current === "" ? "" : Number(current)}
+                min={entry.min ?? undefined}
+                max={entry.max ?? undefined}
+                step={0.05}
+                decimalScale={3}
+                size="xs"
+                style={{ width: 100 }}
+                onChange={(v) => onDraft(String(v))}
+              />
+              <Button size="xs" disabled={!dirty || saving} onClick={() => onSave(current)}>
+                Save
+              </Button>
+            </Group>
+          ) : (
+            <Group gap="xs" wrap="nowrap">
+              <TextInput
+                value={current}
+                size="xs"
+                style={{ width: 120 }}
+                placeholder={entry.default || "(unset)"}
+                onChange={(e) => onDraft(e.currentTarget.value)}
+              />
+              <Button size="xs" disabled={!dirty || saving} onClick={() => onSave(current)}>
+                Save
+              </Button>
+            </Group>
+          )}
+          <Text size="xs" c="dimmed" ta="right" mt={4}>
+            default: {entry.default || "(empty)"}
+          </Text>
+        </div>
+      </Group>
+    </Card>
+  );
+}

--- a/frontend/tests/e2e/ui.spec.ts
+++ b/frontend/tests/e2e/ui.spec.ts
@@ -249,7 +249,12 @@ test.describe("Settings", () => {
     for (const k of overridden) {
       // The whole point of the badge: the stored value is NOT what this server
       // uses, and the page must not imply otherwise.
-      await expect(page.getByTestId(`config-override-${k.key}`)).toBeVisible();
+      const badge = page.getByTestId(`config-override-${k.key}`);
+      await expect(badge).toBeVisible();
+      // ...and it must say how to change it, plus why the UI will not: that
+      // file also holds the Supabase secret key and the database password.
+      await expect(badge).toContainText("restart the server");
+      await expect(badge).toContainText("database password");
     }
     if (overridden.length === 0) {
       await expect(page.getByTestId("config-row-min_search_score")).toBeVisible();

--- a/frontend/tests/e2e/ui.spec.ts
+++ b/frontend/tests/e2e/ui.spec.ts
@@ -229,3 +229,68 @@ test.describe("Environment banner", () => {
     }
   });
 });
+
+// ── Settings ──────────────────────────────────────────────────────────────
+test.describe("Settings", () => {
+  test("page loads and lists config groups", async ({ page }) => {
+    await page.goto(`${APP}/settings`);
+    await expect(page.getByTestId("page-title")).toHaveText(/Settings/i);
+    await expect(page.getByTestId("config-row-relations_enabled")).toBeVisible();
+    await expect(page.getByTestId("config-row-min_search_score")).toBeVisible();
+  });
+
+  test("a locally-overridden key says so", async ({ page, request }) => {
+    const cfg = await (await request.get("/api/v1/config")).json();
+    const overridden = (cfg.keys as Array<{ key: string; env_override: unknown }>).filter(
+      (k) => k.env_override !== null,
+    );
+
+    await page.goto(`${APP}/settings`);
+    for (const k of overridden) {
+      // The whole point of the badge: the stored value is NOT what this server
+      // uses, and the page must not imply otherwise.
+      await expect(page.getByTestId(`config-override-${k.key}`)).toBeVisible();
+    }
+    if (overridden.length === 0) {
+      await expect(page.getByTestId("config-row-min_search_score")).toBeVisible();
+    }
+  });
+
+  test("toggling a high-impact key asks for confirmation first", async ({ page, request }) => {
+    const before = await (await request.get("/api/v1/config")).json();
+    const relations = (before.keys as Array<{ key: string; effective: string }>).find(
+      (k) => k.key === "relations_enabled",
+    );
+
+    await page.goto(`${APP}/settings`);
+    const row = page.getByTestId("config-row-relations_enabled");
+    // Click the track, not the input: Mantine's switch input is visually
+    // hidden and does not receive the click.
+    await row.locator(".mantine-Switch-track").click();
+
+    // Nothing is written until the consequence has been read and accepted:
+    // this switch decides whether four tools appear in every agent's list.
+    // Assert on the modal BODY — `data-testid` on <Modal> lands on Mantine's
+    // positioning root, which reports as hidden even while open.
+    const modal = page.getByTestId("config-confirm-body");
+    await expect(modal).toBeVisible();
+    await expect(modal).toContainText("agent");
+
+    await modal.getByRole("button", { name: "Cancel" }).click();
+    await expect(modal).toBeHidden();
+
+    const after = await (await request.get("/api/v1/config")).json();
+    const relationsAfter = (after.keys as Array<{ key: string; effective: string }>).find(
+      (k) => k.key === "relations_enabled",
+    );
+    expect(relationsAfter?.effective).toBe(relations?.effective);
+  });
+
+  test("rejects an out-of-range value", async ({ request }) => {
+    const resp = await request.put("/api/v1/config/min_search_score", {
+      data: { value: "5" },
+    });
+    expect(resp.status()).toBe(400);
+    expect(await resp.text()).toContain("min_search_score");
+  });
+});

--- a/packages/memory/src/cli/commands/migrate-format.ts
+++ b/packages/memory/src/cli/commands/migrate-format.ts
@@ -125,12 +125,16 @@ async function action(options: MigrateOptions): Promise<void> {
     );
   }
   // Heaviest write path in the CLI: per document this re-chunks, archives the
-  // previous chunks as a version snapshot, and inserts new rows.
+  // previous chunks as a version snapshot, and inserts new rows — so the
+  // threshold is deliberately lower than reindex's. ~200 documents is already
+  // on the order of a thousand chunk inserts plus version rows, comparable to
+  // the reindex that depleted a contributor's Disk IO Budget. The warning is
+  // cheap and this command is rare and opt-in; erring quiet helps nobody.
   warnLargeBulkWrite({
     count: targets.length,
-    threshold: 500,
+    threshold: 200,
     unit: "document",
-    batchHint: "run it in batches with --limit 200",
+    batchHint: "run it in batches with --limit 100",
   });
 
   if (options.dryRun) {

--- a/packages/memory/src/web/routes/config.ts
+++ b/packages/memory/src/web/routes/config.ts
@@ -15,6 +15,7 @@ import {
   CONFIG_CATALOG,
   validateConfigValue,
 } from "../../../../../_shared/config-catalog/index.ts";
+import { resolveEnvFile } from "../../../../../_shared/config/index.ts";
 import type { WebContext } from "../context.ts";
 
 function unwrapScalarRpc(data: unknown): string | null {
@@ -73,7 +74,17 @@ export function registerConfigRoutes(app: Hono, ctx: WebContext): void {
         };
       }),
     );
-    return c.json({ keys: entries });
+    // Where the operator would go to change an override. Shown so the page can
+    // point at the file instead of pretending overrides are unchangeable — the
+    // UI will not edit it (it holds the service-role key, the OpenAI key and
+    // the database password), but the human owns that file.
+    let configFile: string | null = null;
+    try {
+      configFile = resolveEnvFile();
+    } catch {
+      // Unresolvable config dir — the page just omits the path.
+    }
+    return c.json({ keys: entries, config_file: configFile });
   });
 
   app.get("/api/v1/config/:key", async (c) => {

--- a/packages/memory/src/web/routes/config.ts
+++ b/packages/memory/src/web/routes/config.ts
@@ -9,6 +9,9 @@
  * RPCs — allowlist validation lives in the RPC, not here.
  */
 
+import { homedir } from "node:os";
+import { sep } from "node:path";
+
 import { Hono } from "hono";
 
 import {
@@ -80,7 +83,13 @@ export function registerConfigRoutes(app: Hono, ctx: WebContext): void {
     // the database password), but the human owns that file.
     let configFile: string | null = null;
     try {
-      configFile = resolveEnvFile();
+      const abs = resolveEnvFile();
+      // Contract the home prefix: `~/.cerefox/.env` is still valid in a shell,
+      // is shorter to read, and keeps the operator's username out of any
+      // screenshot of this page. Paths outside home are shown in full.
+      const home = homedir();
+      configFile =
+        abs === home || abs.startsWith(home + sep) ? `~${abs.slice(home.length)}` : abs;
     } catch {
       // Unresolvable config dir — the page just omits the path.
     }

--- a/packages/memory/src/web/routes/config.ts
+++ b/packages/memory/src/web/routes/config.ts
@@ -11,6 +11,10 @@
 
 import { Hono } from "hono";
 
+import {
+  CONFIG_CATALOG,
+  validateConfigValue,
+} from "../../../../../_shared/config-catalog/index.ts";
 import type { WebContext } from "../context.ts";
 
 function unwrapScalarRpc(data: unknown): string | null {
@@ -22,7 +26,56 @@ function unwrapScalarRpc(data: unknown): string | null {
   return null;
 }
 
+/**
+ * Environment variables that override a DB config key on whatever machine
+ * reads them. `cerefox_config` is the cross-cutting default; a `CEREFOX_*` var
+ * is passed as an explicit RPC argument, and the RPC COALESCEs the argument
+ * first — so the env var wins locally.
+ *
+ * The settings UI has to say this out loud. Otherwise it shows `0.5`, reports
+ * success on save, and the server keeps searching at `0.7` — a page that lies
+ * about the system it configures is worse than no page.
+ */
+const ENV_OVERRIDES: Record<string, string> = {
+  min_search_score: "CEREFOX_MIN_SEARCH_SCORE",
+  min_term_coverage: "CEREFOX_MIN_TERM_COVERAGE",
+  search_alpha: "CEREFOX_SEARCH_ALPHA",
+};
+
 export function registerConfigRoutes(app: Hono, ctx: WebContext): void {
+  // List every catalog key with its stored value. The per-key GET below stays
+  // for direct/API consumers; the UI needs one round trip, not seven.
+  app.get("/api/v1/config", async (c) => {
+    const entries = await Promise.all(
+      CONFIG_CATALOG.map(async (spec) => {
+        const { data, error } = await ctx.supabase.rpc("cerefox_get_config", {
+          p_key: spec.key,
+        });
+        const stored = error ? null : unwrapScalarRpc(data);
+        const envVar = ENV_OVERRIDES[spec.key];
+        // Report the override only when it is actually set *on this server*.
+        // Another machine running its own MCP server may differ, which the UI
+        // says rather than pretending this is the whole picture.
+        const envValue = envVar ? (process.env[envVar] ?? "").trim() : "";
+        return {
+          key: spec.key,
+          value: stored,
+          effective: stored ?? spec.defaultValue,
+          description: spec.description,
+          kind: spec.kind,
+          default: spec.defaultValue,
+          min: spec.min ?? null,
+          max: spec.max ?? null,
+          group: spec.group,
+          high_impact: spec.highImpact ?? false,
+          impact_note: spec.impactNote ?? null,
+          env_override: envValue ? { name: envVar, value: envValue } : null,
+        };
+      }),
+    );
+    return c.json({ keys: entries });
+  });
+
   app.get("/api/v1/config/:key", async (c) => {
     const key = c.req.param("key");
     const { data, error } = await ctx.supabase.rpc("cerefox_get_config", {
@@ -41,6 +94,12 @@ export function registerConfigRoutes(app: Hono, ctx: WebContext): void {
       return c.json({ detail: "Invalid JSON body" }, 400);
     }
     const value = typeof body.value === "string" ? body.value : String(body.value ?? "");
+    // The RPC allow-lists the *key* but stores the value as opaque text, so
+    // `min_search_score = 5` would be accepted and then silently suppress every
+    // search result. Reject bad values at the boundary with a 400.
+    const invalid = validateConfigValue(key, value);
+    if (invalid) return c.json({ detail: invalid }, 400);
+
     const { error } = await ctx.supabase.rpc("cerefox_set_config", {
       p_key: key,
       p_value: value,


### PR DESCRIPTION
## Summary

`cerefox_config` governs **every** access path — CLI, local and remote MCP, Edge
Functions, this app — because they all resolve through the same RPCs. Until now
the only way to change it was the CLI. This adds the browser equivalent: a
**Settings** page listing every key with its description, current value and
default, grouped Retrieval / Governance / Features.

Closes the `⏳ Config web UI` item carried since beta.2.

## Three decisions worth reviewing

**Keys that change what other software sees are not bare toggles.** Turning on
`relations_enabled` adds four tools to every connected agent's tool list;
`require_requestor_identity` starts rejecting agents that don't identify
themselves. Both open a confirmation naming the consequence first.

**Local overrides are shown, read-only.** A `CEREFOX_*` variable is passed as an
explicit RPC argument and the RPC COALESCEs the argument first — so it beats the
stored value on the machine that has it. Concretely: the maintainer's staging
`.env` sets `CEREFOX_MIN_SEARCH_SCORE=0.70` while the table says `0.5`. Without
the badge the page would display 0.5, report a successful save, and the server
would keep searching at 0.70.

**It is not an `.env` editor.** That file holds the service-role key, the OpenAI
key and the database password. An endpoint that writes it would be a
credential-exposure surface, and the server only reads it at boot anyway.

## Also fixed

The key catalog moves to `_shared/config-catalog/`, so `cerefox config list` and
the page cannot disagree about a key's meaning or default — the same
single-implementation rule the RPCs follow.

Value validation lives there too. The RPC allow-lists the **key** but stores the
**value** as opaque text, so `min_search_score = 5` was accepted and then
silently suppressed every search result. Bad values now return 400.

## Test plan

- [x] `cd _shared && bun test` — 350 pass, 0 fail
- [x] `cd packages/memory && bun test` — 164 pass, 0 fail
- [x] Playwright — 18 pass, including 4 new Settings tests: page renders,
      override badge appears for every locally-overridden key, the confirmation
      gate blocks a high-impact write (asserting the value does **not** change on
      cancel), and an out-of-range value is rejected
- [x] `bun run typecheck`
- [x] End-to-end on staging: flipping `relations_enabled` in the browser moved
      the advertised MCP tool list **10 → 14 → 10**, and the write was visible to
      `cerefox config get` — one source of truth, two surfaces
- [x] Validation live: `min_search_score=5` → 400, `relations_enabled=yes` → 400
- [x] Staging left as found (`relations_enabled=false`)

## Notes

Targets **beta.5** — beta.4 was cut while this was in progress, so the CHANGELOG
entry sits in `[Unreleased]`.

Docs: `configuration.md` gains a Settings section and its "the only key
currently in use is `usage_tracking_enabled`" line is corrected (there are
seven); `plan.md` records the item as done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vd45RFdSk8hHupWLn9jfDQ
