### PR TITLE
Release-script correctness: pre-release flag, empty-notes gate, CHANGELOG back-fill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,8 +119,6 @@ Open roadmap.
   pointing at its own backup directory had no effect, so staging snapshots
   landed beside production's.
 
-Open roadmap.
-
 ---
 
 ## [v1.1.0-beta.2] -- 2026-08-06
@@ -192,8 +190,6 @@ Open roadmap.
   edit made mid-run is skipped rather than overwritten, and documents whose
   content is byte-identical to another document are reported as
   un-convertible rather than failing the run.
-
-Open roadmap.
 
 ---
 
@@ -273,7 +269,68 @@ Open roadmap.
   9 → 10, `commander` 12 → 14. Commander 15 was deliberately skipped: it
   requires Node ≥ 22.12, which is a support-policy decision tracked in #154.
 
-Open roadmap.
+---
+
+## [v1.0.8] -- 2026-08-06
+
+> Back-filled. This release was cut from the `release/1.0.7` maintenance branch
+> and shipped **without release notes** — its GitHub Release body reads only
+> "Open roadmap.", because the cut script's emptiness check was satisfied by its
+> own placeholder. The entry below was reconstructed from the commits in
+> `v1.0.7..v1.0.8`; the gate was fixed afterwards so this cannot recur.
+
+### Fixed
+- **The false `reindex` claim from #164 survived in a second file.** The 1.0.7
+  doc pass corrected `content-format.md` and `doctor`, but `migration-1.0.md`
+  still told users to run `cerefox server reindex` to convert legacy chunk
+  formats. That one mattered more than a repo typo: guides ship **inside the npm
+  package**, so `cerefox guides show migration-1.0` served the wrong instruction
+  to anyone upgrading. Now points at `server migrate-format`.
+  (Note: `migrate-format` itself did not work until v1.1.0-beta.4 — see that
+  entry.)
+- **`cut_release.ts` push log named the wrong branch.** Cosmetic, but the line
+  is read during a release to confirm what is being pushed.
+
+### Changed
+- `docs/guides/cli.md` documents what a backup actually contains (documents,
+  chunks, projects, memberships) and the `server migrate-format` command.
+
+---
+
+## [v1.0.7] -- 2026-08-06
+
+> Back-filled from the `release/1.0.7` maintenance branch, where this release
+> was cut. The code shipped to `main` via cherry-pick; only these notes were
+> missing.
+
+### Fixed
+- **Backups now capture project memberships** (#166). `backup create` never
+  read the document↔project junction, so every restore silently landed
+  documents with **no project assignments** — and the restore command's help
+  text claimed the opposite. Snapshots now include projects and memberships
+  (backup format 2) and restore recreates them idempotently. Older snapshots
+  still restore, with a warning that memberships are absent. Verified with a
+  full round trip: seed → back up → wipe → restore, memberships intact.
+  **Applies to Cerefox Local too** — this is CLI-side logic, so a self-hosted
+  instance on ≤1.0.6 produces snapshots that restore without memberships.
+- **`cerefox server reindex` no longer claimed to convert legacy chunk
+  formats** (#164, reported by [@tdebasis](https://github.com/tdebasis)).
+  Reindex refreshes embeddings on existing chunk rows; it never re-chunks, so
+  it cannot advance `content_format` — verified on a 3,203-chunk store where
+  it touched every chunk and moved exactly zero. `cerefox doctor` and
+  `content-format.md` both told users to run it anyway.
+
+### Added
+- **`cerefox server migrate-format`** — the command that actually does the
+  conversion #164 promised: re-ingests legacy documents through the normal
+  pipeline so they are re-chunked, re-embedded, and stamped with the current
+  format. Opt-in (it costs embedding spend), with `--dry-run`, `--limit`, and
+  `--document-id`. Each document converts under optimistic concurrency, so an
+  edit made mid-run is skipped rather than overwritten, and documents whose
+  content is byte-identical to another document are reported as
+  un-convertible rather than failing the run.
+  **This command did not work as shipped** — it reported success while
+  converting nothing. Fixed in v1.1.0-beta.4.
 
 ---
 
@@ -307,8 +364,6 @@ Open roadmap.
   by atomic ingestion, a script deleted with Python) were dropped. The file
   remains as a pointer.
 
-Open roadmap.
-
 ---
 
 ## [v1.0.5] -- 2026-08-05
@@ -338,8 +393,6 @@ Open roadmap.
   verifies its result against the server's own row count when the caller
   requests one, and a repo-wide test fails CI on new unbounded PostgREST
   selects (bound them, count server-side, or allowlist with a reason).
-
-Open roadmap.
 
 ---
 
@@ -613,8 +666,6 @@ update GPT Actions / remote-MCP clients to the token → revoke the legacy anon 
   unrelated text higher, so the OpenAI-calibrated 0.5 let weak matches through
   on Cerefox Local. `CEREFOX_MIN_SEARCH_SCORE` / `--min-score` still override.
 
-Open roadmap.
-
 ---
 
 ## [v1.0.0-rc.3] -- 2026-07-12
@@ -626,8 +677,6 @@ Open roadmap.
   Postgres, PostgREST, and the web server. Sub-batching keeps peak memory flat,
   fixing `server reindex` and large-document ingest on small VMs.
   `setup-local.md` now documents the ≥ 4 GB VM recommendation.
-
-Open roadmap.
 
 ---
 
@@ -652,8 +701,6 @@ Open roadmap.
   RPCs over a newer schema until the next correct boot).
 
 
-Open roadmap.
-
 ---
 
 ## [v1.0.0-rc.1] -- 2026-07-11
@@ -670,8 +717,6 @@ Feature freeze for 1.0.0 (release-candidate line): fixes only from here to stabl
 - **`cerefox-local init` asks for the embedder first** — choosing `[2] Local`
   now skips the OpenAI-key prompt entirely (the local embedder needs no key;
   an existing key is kept silently).
-
-Open roadmap.
 
 ---
 
@@ -829,8 +874,6 @@ Open roadmap.
   identically in the TS and Python chunkers. Affected documents re-chunk cleanly on their
   next write; no schema change. (See `docs/specs/…` / the chunker regression tests, which
   now assert `reconstruct(chunks) === original`.)
-
-Open roadmap.
 
 ---
 

--- a/scripts/cut_release.ts
+++ b/scripts/cut_release.ts
@@ -429,12 +429,21 @@ function buildNewChangelog(parts: ChangelogParts, version: string): {
 } {
   const date = today();
   const newUnreleasedSection = `## [Unreleased]\n\n${UNRELEASED_PLACEHOLDER}\n\n---\n\n`;
-  const promoted = `## [v${version}] -- ${date}\n${parts.unreleasedBody}`;
+
+  // Drop the placeholder before promoting. Notes are usually added ABOVE the
+  // existing "Open roadmap." line rather than replacing it, so without this the
+  // placeholder rides along into the released section — and from there into the
+  // GitHub Release body. Ten historical sections carry that stray line.
+  const body = parts.unreleasedBody.replace(
+    new RegExp(`^${UNRELEASED_PLACEHOLDER.replace(".", "\\.")}\\s*$\\n?`, "m"),
+    "",
+  );
+  const promoted = `## [v${version}] -- ${date}\n${body}`;
   const newText = parts.preamble + newUnreleasedSection + promoted + parts.rest;
 
   // Release notes shown on GitHub Release: skip the heading line, trim
   // surrounding blank lines and the trailing horizontal rule (`---`).
-  const releaseNotes = parts.unreleasedBody
+  const releaseNotes = body
     .replace(/\n---\s*\n?$/, "\n")
     .trim();
 

--- a/scripts/cut_release.ts
+++ b/scripts/cut_release.ts
@@ -395,10 +395,23 @@ function parseChangelog(text: string): ChangelogParts {
   };
 }
 
+/**
+ * The placeholder this script writes into a fresh `[Unreleased]` after a cut.
+ * Kept as a constant so the emptiness check below and `buildNewChangelog`
+ * cannot drift apart.
+ */
+const UNRELEASED_PLACEHOLDER = "Open roadmap.";
+
 function unreleasedHasContent(body: string): boolean {
   const stripped = body
     .replace(/^---\s*$/gm, "")  // section dividers
     .trim();
+  // The placeholder is not content. Without this the check was defeated by the
+  // script's OWN output: every cut leaves `[Unreleased]` reading "Open
+  // roadmap.", which is non-empty, so a subsequent cut with nothing new to say
+  // sailed through. That is how v1.0.8 shipped with a GitHub Release whose
+  // entire body reads "Open roadmap." and no CHANGELOG section describing it.
+  if (stripped === UNRELEASED_PLACEHOLDER) return false;
   return stripped.length > 0;
 }
 
@@ -415,7 +428,7 @@ function buildNewChangelog(parts: ChangelogParts, version: string): {
   releaseNotes: string;
 } {
   const date = today();
-  const newUnreleasedSection = `## [Unreleased]\n\nOpen roadmap.\n\n---\n\n`;
+  const newUnreleasedSection = `## [Unreleased]\n\n${UNRELEASED_PLACEHOLDER}\n\n---\n\n`;
   const promoted = `## [v${version}] -- ${date}\n${parts.unreleasedBody}`;
   const newText = parts.preamble + newUnreleasedSection + promoted + parts.rest;
 

--- a/scripts/cut_release.ts
+++ b/scripts/cut_release.ts
@@ -817,7 +817,10 @@ async function main(): Promise<void> {
   if (args.dryRun) {
     info(`DRY-RUN: would 'git push origin <current branch>'`);
     info(`DRY-RUN: would 'git push origin ${tag}'`);
-    info(`DRY-RUN: would 'gh release create ${tag} --title ${tag} --notes-file <release-notes>'`);
+    info(
+      `DRY-RUN: would 'gh release create ${tag} --title ${tag} --notes-file <release-notes>` +
+        `${newVersion.includes("-") ? " --prerelease" : ""}'`,
+    );
     info(`DRY-RUN: would upload install.sh + docker/local/install-local.sh as Release assets`);
     if (args.dockerPublish) {
       const publishLatest = !newVersion.includes("-");
@@ -844,6 +847,14 @@ async function main(): Promise<void> {
   info("Creating GitHub Release…");
   const tmpNotesFile = join(REPO_ROOT, `.release-notes-${tag}.tmp`);
   writeFileSync(tmpNotesFile, releaseNotes + "\n", "utf8");
+  // Mark pre-releases as such on GitHub. Without this every beta/rc was created
+  // as a normal release, so the repo's Releases page presented the newest beta
+  // as "Latest" — a visitor landing there saw a pre-release offered as the
+  // current version. The npm side was always correct (pre-releases publish under
+  // their channel dist-tag, never `latest`), which is exactly why this went
+  // unnoticed: nothing broke, it just misrepresented the release on the one
+  // page people browse. Same suffix test the Docker `:latest` decision uses.
+  const isPrerelease = newVersion.includes("-");
   try {
     runOrDie("gh", [
       "release",
@@ -853,6 +864,7 @@ async function main(): Promise<void> {
       tag,
       "--notes-file",
       tmpNotesFile,
+      ...(isPrerelease ? ["--prerelease"] : []),
     ]);
   } finally {
     run("rm", ["-f", tmpNotesFile]);


### PR DESCRIPTION
Three defects in the release path, all found while investigating why the
Releases page showed a beta as "Latest".

## 1. Pre-releases weren't flagged

`gh release create` was called without `--prerelease`, so every beta and rc was
created as a normal release and GitHub presented the newest beta as **Latest**.

That was not only cosmetic: `releases/latest/download/install.sh` is the
documented install command (`README.md`, `install.sh`, `install-local.sh`), and
it resolves through `/releases/latest`. Until the five published betas were
re-flagged, that URL served the **beta's** installer to anyone running the
README command. Now resolves to `v1.0.8`.

Uses the same `newVersion.includes("-")` test the Docker `:latest` decision
already uses, so the two cannot disagree.

## 2. The empty-notes gate was defeated by its own output

`cut_release.ts` refuses to cut when `[Unreleased]` is empty — but every cut
leaves the placeholder `Open roadmap.` behind, which the script writes itself.
Non-empty string, gate satisfied.

That is how **v1.0.8 shipped with no release notes**: its GitHub Release body
reads, in full, "Open roadmap.". The placeholder is now a shared constant and is
treated as empty.

## 3. The placeholder leaked into released sections

Notes are typically added *above* the existing placeholder rather than replacing
it, so it rode along into the promoted section and into the GitHub Release body.
**Ten** historical sections carried the stray line. Removed, and the promotion
now strips it — verified with the placeholder above, below, alone, and absent.

## Plus: CHANGELOG back-fill

`main` had no v1.0.7 or v1.0.8 sections — both were cut from the
`release/1.0.7` maintenance branch and only the code was cherry-picked. A reader
of `main` went from v1.0.6 straight to the 1.1.0 betas.

This matters for the upcoming 1.1.0 stable, which must consolidate every change
since the last stable: #166 and `migrate-format` were invisible from `main`.

v1.0.7 is restored verbatim, with a note that the membership fix **applies to
Cerefox Local too** (CLI-side logic — a self-hosted instance on ≤1.0.6 produces
snapshots that restore without project assignments). v1.0.8 is reconstructed
from `v1.0.7..v1.0.8` and labelled as back-filled. Both cross-reference that
`migrate-format` did not actually work until v1.1.0-beta.4.

## Test plan

- [x] `bun run typecheck`
- [x] `cut_release.ts 1.1.0-beta.6 --dry-run` → `--prerelease` present
- [x] `cut_release.ts 1.1.1 --dry-run` → flag absent
- [x] Placeholder-only `[Unreleased]` → refused with "add release notes"
- [x] Real content → passes and reaches release-create
- [x] Placeholder stripping verified in all four positions
- [x] Dry runs only; no tags, releases or pushes created by testing
- [x] CHANGELOG structure spot-checked at section boundaries after cleanup

## Note

`main`'s `[Unreleased]` is currently placeholder-only, so **the 1.1.0 cut will
now be blocked until the consolidated notes are written** — which is the correct
behaviour per RELEASING.md, and previously would have produced an empty release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vd45RFdSk8hHupWLn9jfDQ
