### PR TITLE
Settings UI: lead with the description; fix cross-page cache staleness

### DIFF
--- a/frontend/src/api/config.ts
+++ b/frontend/src/api/config.ts
@@ -21,8 +21,14 @@ export interface ConfigEntry {
   high_impact: boolean;
   impact_note: string | null;
   /**
-   * Set when a CEREFOX_* variable on this server overrides the stored value.
-   * The DB value is then not what this server actually uses.
+   * Name of the CEREFOX_* variable that CAN override this key on a given
+   * machine, or null if the key has no local override. Always reported, so the
+   * escape hatch is discoverable before it surprises anyone.
+   */
+  env_var?: string | null;
+  /**
+   * Set when that variable IS overriding the stored value on this server —
+   * meaning the DB value is not what this server actually uses.
    */
   env_override: ConfigEnvOverride | null;
 }

--- a/frontend/src/pages/AnalyticsPage.tsx
+++ b/frontend/src/pages/AnalyticsPage.tsx
@@ -181,7 +181,7 @@ export function AnalyticsPage() {
         <Title order={2}>Analytics</Title>
         <Group gap="md">
           <Tooltip
-            label="Opt-in. Logs each read/write (operation metadata only — no content) to the usage log, powering these charts and the dashboard's agent-activity card."
+            label="Opt-in. Logs each read/write (operation metadata only — no content) to the usage log, powering these charts and the dashboard's agent-activity card. Same setting as usage_tracking_enabled on the Settings page — either place works."
             multiline
             w={300}
             withArrow

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -135,8 +135,11 @@ export function SettingsPage() {
         title="CLI equivalent"
         commands={[
           { cmd: "cerefox config list" },
-          { cmd: "cerefox config get", args: "relations_enabled" },
-          { cmd: "cerefox config set", args: "relations_enabled true" },
+          { cmd: "cerefox config get", args: "min_search_score" },
+          // Deliberately a neutral key. `relations_enabled true` would be a
+          // copy-pasteable command that switches on the one feature shipped
+          // dormant on purpose — an example should show the syntax, not nudge.
+          { cmd: "cerefox config set", args: "min_search_score 0.6" },
         ]}
       />
 
@@ -222,6 +225,13 @@ function ConfigRow({
           {/* The key is the identifier used by `cerefox config set` and the
               docs — needed, but secondary to what the setting actually does. */}
           <Code style={{ fontSize: "0.72rem" }}>{entry.key}</Code>
+
+          {!overridden && entry.env_var && (
+            <Text size="xs" c="dimmed" mt={6} data-testid={`config-overridable-${entry.key}`}>
+              Can be overridden per machine with <Code>{entry.env_var}</Code>. Not set
+              here, so the value above is what this server uses.
+            </Text>
+          )}
 
           {overridden && (
             <Alert

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -62,6 +62,9 @@ export function SettingsPage() {
     onSuccess: (_res, vars) => {
       showSuccess(`Saved ${vars.key}`);
       void queryClient.invalidateQueries({ queryKey: ["config"] });
+      // AnalyticsPage caches this key separately (["config", <key>]); without
+      // this it keeps showing the pre-toggle value.
+      void queryClient.invalidateQueries({ queryKey: ["config", vars.key] });
       setDrafts((d) => {
         const next = { ...d };
         delete next[vars.key];
@@ -201,8 +204,10 @@ function ConfigRow({
     <Card withBorder padding="sm" radius="sm" data-testid={`config-row-${entry.key}`}>
       <Group justify="space-between" align="flex-start" wrap="nowrap">
         <div style={{ flex: 1, minWidth: 0 }}>
-          <Group gap="xs">
-            <Code>{entry.key}</Code>
+          <Group gap="xs" wrap="nowrap" align="baseline">
+            <Text size="sm" fw={500}>
+              {entry.description}
+            </Text>
             {entry.value === null && (
               <Badge size="xs" variant="light" color="gray">
                 default
@@ -214,9 +219,9 @@ function ConfigRow({
               </Badge>
             )}
           </Group>
-          <Text size="sm" c="dimmed" mt={4}>
-            {entry.description}
-          </Text>
+          {/* The key is the identifier used by `cerefox config set` and the
+              docs — needed, but secondary to what the setting actually does. */}
+          <Code style={{ fontSize: "0.72rem" }}>{entry.key}</Code>
 
           {overridden && (
             <Alert

--- a/frontend/tests/e2e/ui.spec.ts
+++ b/frontend/tests/e2e/ui.spec.ts
@@ -259,6 +259,17 @@ test.describe("Settings", () => {
     if (overridden.length === 0) {
       await expect(page.getByTestId("config-row-min_search_score")).toBeVisible();
     }
+
+    // Overridable-but-not-overridden is a DIFFERENT, quieter statement: the
+    // escape hatch should be discoverable before it ever surprises anyone,
+    // without implying the shown value is wrong.
+    const overridable = (cfg.keys as Array<{ key: string; env_var?: string | null; env_override: unknown }>)
+      .filter((k) => k.env_var && k.env_override === null);
+    for (const k of overridable) {
+      await expect(page.getByTestId(`config-overridable-${k.key}`)).toBeVisible();
+      // ...and it must NOT also claim to be overridden.
+      await expect(page.getByTestId(`config-override-${k.key}`)).toHaveCount(0);
+    }
   });
 
   test("toggling a high-impact key asks for confirmation first", async ({ page, request }) => {

--- a/packages/memory/src/web/routes/config.ts
+++ b/packages/memory/src/web/routes/config.ts
@@ -73,6 +73,13 @@ export function registerConfigRoutes(app: Hono, ctx: WebContext): void {
           group: spec.group,
           high_impact: spec.highImpact ?? false,
           impact_note: spec.impactNote ?? null,
+          // Two distinct facts, deliberately separate:
+          //   env_var       — this key CAN be overridden per machine (always
+          //                   reported, so the escape hatch is discoverable
+          //                   before it ever surprises anyone).
+          //   env_override  — it IS being overridden right now, on this server,
+          //                   which means the stored value is not what runs.
+          env_var: envVar ?? null,
           env_override: envValue ? { name: envVar, value: envValue } : null,
         };
       }),


### PR DESCRIPTION
Maintainer feedback on the new Settings page.

## 1. Description first, key second

The row led with `min_search_score` and buried "Minimum cosine similarity for
vector-side results" underneath. Reversed: the sentence is what a human scans
for; the key is only needed when reaching for `cerefox config set` or the docs,
so it now sits below in small mono.

## 2. A real staleness bug, found by the duplicate-toggle question

Settings invalidated `["config"]` after a write, but `AnalyticsPage` caches
`usage_tracking_enabled` under `["config", "usage_tracking_enabled"]` — a
*different* React Query key, so it never refetched. Toggling usage tracking in
Settings and then opening Analytics showed the **pre-toggle** value until an
unrelated refetch. Both keys are now invalidated.

## 3. Keeping the toggle in both places, deliberately

`usage_tracking_enabled` stays on Analytics *and* Settings rather than being
centralised. The Analytics page is where the need is actually felt — you notice
an empty chart there, not on a settings screen — so removing it would trade a
real affordance for tidiness. The two cannot disagree: both go through the same
`cerefox_set_config` RPC, and with #2 fixed they can't even look different. The
Analytics tooltip now points at Settings.

## Test plan

- [x] Playwright — 18 pass, including the 4 Settings tests
- [x] `bun run typecheck`
- [x] Frontend build clean; SPA re-bundled into the package

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vd45RFdSk8hHupWLn9jfDQ
