### PR TITLE
Move misfiled release notes into [Unreleased]; guard released sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,46 +9,6 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
-Open roadmap.
-
----
-
-## [v1.1.0-beta.6] -- 2026-08-06
-
-### Fixed
-- **A deterministic conflict was raised under a "retryable" SQLSTATE, causing
-  unbounded retry storms** (reported by
-  [@tdebasis](https://github.com/tdebasis)). `cerefox_ingest_document` raised
-  `CEREFOX_CONFLICT` with SQLSTATE `40001` (`serialization_failure`) — the one
-  PostgreSQL class whose contract promises *"this was transient, retry and it
-  may succeed"*. PostgREST maps it to a retryable HTTP status, so retry-aware
-  infrastructure replayed the request. But an optimistic-concurrency conflict is
-  **deterministic**: the same stale token fails identically forever, so "retry
-  until it clears" meant retry until something died.
-
-  Reproduced and measured on a live project:
-
-  | | Before (`40001`) | After (`PT409`) |
-  |---|---|---|
-  | HTTP response | 504 after 125s | **409 after 636ms** |
-  | RPC executions per request | **68,825** | **1** |
-  | After the client gave up | kept running past 153,000 executions | stopped |
-
-  The contributor's project ran the loop for roughly a day — **~47 million
-  calls** — which exhausted its Disk IO budget and needed a hung connection
-  killed by hand. Conflicts now raise `PT409` (PostgREST's convention → HTTP 409
-  Conflict), which nothing retries.
-
-  Also: a **blank** `expected_content_hash` (empty or whitespace) is now treated
-  as *absent* rather than stale, raising `CEREFOX_TOKEN_REQUIRED` (400). `''` is
-  not NULL, so it slipped past the absent-token branch into the conflict branch,
-  where it could never match a real hash — a permanent failure wearing a
-  retryable code, which is the exact shape that triggered the incident.
-
-  **Requires a server redeploy** (`cerefox server deploy`) — schema 0.10.1 →
-  0.10.2, migration 0015. Client detection is unchanged: every transport matches
-  the `CEREFOX_CONFLICT:` message prefix, never the SQLSTATE.
-
 ### Documentation
 - **Relations are now documented for users.** The headline 1.1.0 feature shipped
   with no user-facing docs: `cli.md` never mentioned the `cerefox relation`
@@ -66,7 +26,6 @@ Open roadmap.
   retry-storm fix lives in `rpcs.sql` and upgrading the client alone leaves the
   database on the old behaviour.
 
-### Changed
 - **Version retention is now a property of the store, not of each client.**
   `cerefox_snapshot_version` took the retention window and cleanup flag as
   parameters, and every client filled them from its own environment — so the
@@ -122,6 +81,46 @@ Open roadmap.
   Stale `.env` lines are surfaced in two places rather than silently ignored:
   `cerefox doctor` lists them with a copy-pasteable command carrying your value
   into the store, and the **Settings** page flags the affected key directly.
+
+---
+
+## [v1.1.0-beta.6] -- 2026-08-06
+
+### Fixed
+- **A deterministic conflict was raised under a "retryable" SQLSTATE, causing
+  unbounded retry storms** (reported by
+  [@tdebasis](https://github.com/tdebasis)). `cerefox_ingest_document` raised
+  `CEREFOX_CONFLICT` with SQLSTATE `40001` (`serialization_failure`) — the one
+  PostgreSQL class whose contract promises *"this was transient, retry and it
+  may succeed"*. PostgREST maps it to a retryable HTTP status, so retry-aware
+  infrastructure replayed the request. But an optimistic-concurrency conflict is
+  **deterministic**: the same stale token fails identically forever, so "retry
+  until it clears" meant retry until something died.
+
+  Reproduced and measured on a live project:
+
+  | | Before (`40001`) | After (`PT409`) |
+  |---|---|---|
+  | HTTP response | 504 after 125s | **409 after 636ms** |
+  | RPC executions per request | **68,825** | **1** |
+  | After the client gave up | kept running past 153,000 executions | stopped |
+
+  The contributor's project ran the loop for roughly a day — **~47 million
+  calls** — which exhausted its Disk IO budget and needed a hung connection
+  killed by hand. Conflicts now raise `PT409` (PostgREST's convention → HTTP 409
+  Conflict), which nothing retries.
+
+  Also: a **blank** `expected_content_hash` (empty or whitespace) is now treated
+  as *absent* rather than stale, raising `CEREFOX_TOKEN_REQUIRED` (400). `''` is
+  not NULL, so it slipped past the absent-token branch into the conflict branch,
+  where it could never match a real hash — a permanent failure wearing a
+  retryable code, which is the exact shape that triggered the incident.
+
+  **Requires a server redeploy** (`cerefox server deploy`) — schema 0.10.1 →
+  0.10.2, migration 0015. Client detection is unchanged: every transport matches
+  the `CEREFOX_CONFLICT:` message prefix, never the SQLSTATE.
+
+### Changed
 - **Bulk-rewrite warning thresholds raised** — `migrate-format` 200 → 1,000
   documents, `reindex` 1,000 → 5,000 chunks. The thresholds were originally set
   low because a contributor's Disk IO depletion appeared to follow a large

--- a/scripts/cut_release.ts
+++ b/scripts/cut_release.ts
@@ -402,6 +402,51 @@ function parseChangelog(text: string): ChangelogParts {
  */
 const UNRELEASED_PLACEHOLDER = "Open roadmap.";
 
+/**
+ * A released CHANGELOG section must still match the tag it was cut from.
+ *
+ * Entries intended for the next release keep landing in the PREVIOUS one. The
+ * mechanism is subtle: an author (human or agent) anchors an edit on nearby
+ * entry text, then a cut promotes that text out of [Unreleased] and into the
+ * versioned section — so the next edit finds the anchor inside a released
+ * section and inserts there. [Unreleased] is left holding only the placeholder
+ * and the notes are attributed to a version that never contained them.
+ *
+ * This has happened three times (beta.3, beta.4, beta.6). The empty-[Unreleased]
+ * gate catches the symptom; this catches the cause, and says where the text went.
+ *
+ * Only the most recent released section is checked: that is where a promoted
+ * anchor lives, so it is where the misfiling always lands.
+ */
+function checkReleasedSectionUnchanged(changelogText: string): void {
+  const m = changelogText.match(/^## \[(v[^\]]+)\][^\n]*$/m);
+  if (!m) return;                       // no released sections yet
+  const tag = m[1];
+
+  const atTag = run("git", ["show", `${tag}:CHANGELOG.md`]);
+  if (atTag.status !== 0) return;       // tag or file absent — nothing to compare
+
+  const sectionOf = (text: string): string | null => {
+    const start = text.indexOf(`## [${tag}]`);
+    if (start === -1) return null;
+    const next = text.indexOf("\n## [", start + 5);
+    return next === -1 ? text.slice(start) : text.slice(start, next);
+  };
+
+  const released = sectionOf(atTag.stdout);
+  const current = sectionOf(changelogText);
+  if (released === null || current === null) return;
+  if (released.trim() === current.trim()) return;
+
+  die(
+    `The ${tag} section of CHANGELOG.md has changed since that release was cut.\n` +
+      `  A released section is history and should never move. This almost always means\n` +
+      `  notes meant for the NEXT release were inserted into the previous one — check\n` +
+      `  whether the ${tag} section contains entries that belong under [Unreleased],\n` +
+      `  and move them. Compare with:  git diff ${tag} -- CHANGELOG.md`,
+  );
+}
+
 function unreleasedHasContent(body: string): boolean {
   const stripped = body
     .replace(/^---\s*$/gm, "")  // section dividers
@@ -654,6 +699,7 @@ async function main(): Promise<void> {
   info("Parsing CHANGELOG.md…");
   const changelogText = readFileSync(CHANGELOG_FILE, "utf8");
   const parts = parseChangelog(changelogText);
+  checkReleasedSectionUnchanged(changelogText);
   if (!unreleasedHasContent(parts.unreleasedBody)) {
     die(
       "[Unreleased] section in CHANGELOG.md is empty. " +


### PR DESCRIPTION
The beta.7 cut refused with *"[Unreleased] section in CHANGELOG.md is empty"*.
The notes from #175 and #177 were not missing — they had been written into the
**released v1.1.0-beta.6 section**. 4,584 characters of them.

## Cause

I anchor CHANGELOG edits on nearby entry text. The anchor I used sat in
`[Unreleased]` when written; the beta.6 cut then **promoted that text into the
versioned section**, so every later edit found the anchor inside a released
section and inserted there. Result: notes attributed to a version that never
shipped them, and an `[Unreleased]` that looks empty.

Third occurrence (beta.3, beta.4, beta.6). The empty-`[Unreleased]` gate added in
#173 catches the symptom every time — which is why this surfaced at the cut
rather than in a published release — but it cannot say what actually went wrong.

## The guard

`checkReleasedSectionUnchanged` compares the most recent released section against
the CHANGELOG **at its own tag** and refuses the cut if it has moved. That is
where a promoted anchor lives, so it is where the misfiling always lands.

```
✗ The v1.1.0-beta.6 section of CHANGELOG.md has changed since that release was cut.
  A released section is history and should never move. This almost always means
  notes meant for the NEXT release were inserted into the previous one — check
  whether the v1.1.0-beta.6 section contains entries that belong under [Unreleased],
  and move them. Compare with:  git diff v1.1.0-beta.6 -- CHANGELOG.md
```

## The repair

The `v1.1.0-beta.6` section is restored **byte-for-byte from its tag** (verified
equal), and the 4,584 characters now sit under `[Unreleased]` — the relations
documentation from #175, and the retention + retrieval changes from #177.

## Test plan

- [x] `bun run typecheck`
- [x] `cd _shared && bun test` — 348 pass, 0 fail
- [x] Released section verified identical to `v1.1.0-beta.6:CHANGELOG.md`
- [x] Guard refuses when the pollution is reproduced, naming the section
- [x] `cut_release.ts 1.1.0-beta.7 --dry-run` proceeds to release-create on the
      corrected file
- [x] Dry runs only — no tag, release, or push created by testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vd45RFdSk8hHupWLn9jfDQ
