### PR TITLE
1.1.1: explain why the web daemon refused; Settings/doctor parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,14 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
-Open roadmap.
+### Fixed
+- `cerefox web start` now prints the reason when the daemon refuses to boot
+  (e.g. a schema below the client's minimum) instead of "not responding yet …
+  check the log". The log already said it precisely; you had to go find it.
+- The Settings page distinguishes a retired `.env` line that **matches** the
+  stored value (inert, safe to delete) from one that **differs** (your tuning is
+  silently not in effect). It previously said "delete that line" in both cases.
+  `doctor` already made this distinction; the web UI did not.
 
 ---
 

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -198,6 +198,19 @@ function ConfigRow({
   saving: boolean;
 }) {
   const current = draft ?? entry.effective;
+  // Mirrors `doctor`'s logic (v1.1.0): a leftover .env line whose value is
+  // already in the store is inert trivia; one that DIFFERS means the operator's
+  // tuning is silently not in effect, which is the case worth shouting about.
+  // Numeric compare so 0.7 and 0.70 are the same value, not a false alarm.
+  const retiredMatchesStored = (() => {
+    const envValue = entry.retired_env_set?.value;
+    if (envValue === undefined) return false;
+    const a = Number(envValue);
+    const b = Number(entry.effective);
+    return Number.isFinite(a) && Number.isFinite(b)
+      ? a === b
+      : envValue.trim() === entry.effective.trim();
+  })();
   const dirty = draft !== undefined && draft !== entry.effective;
 
   return (
@@ -226,7 +239,7 @@ function ConfigRow({
           {entry.retired_env_set && (
             <Alert
               icon={<IconAlertTriangle size={14} />}
-              color="yellow"
+              color={retiredMatchesStored ? "gray" : "yellow"}
               mt="xs"
               p="xs"
               data-testid={`config-retired-env-${entry.key}`}
@@ -238,8 +251,19 @@ function ConfigRow({
                   no longer read
                 </Text>
                 . This setting moved into the database in v1.1.0 so one value governs
-                every client. The value shown here is what actually runs — delete that
-                line from your <Code>.env</Code>; nothing reads it.
+                every client.{" "}
+                {retiredMatchesStored ? (
+                  <>
+                    The stored value already matches, so nothing changes: delete that line
+                    from your <Code>.env</Code>.
+                  </>
+                ) : (
+                  <Text span fw={600}>
+                    Your .env asked for {entry.retired_env_set.value}, but{" "}
+                    {entry.effective} is what actually runs. Set it here if you want the
+                    old value back, then delete the line from your .env.
+                  </Text>
+                )}
               </Text>
             </Alert>
           )}

--- a/frontend/tests/e2e/ui.spec.ts
+++ b/frontend/tests/e2e/ui.spec.ts
@@ -252,6 +252,12 @@ test.describe("Settings", () => {
       const warn = page.getByTestId(`config-retired-env-${k.key}`);
       await expect(warn).toBeVisible();
       await expect(warn).toContainText("no longer read");
+      // It must distinguish "already carried over" (inert leftover) from "your
+      // tuning is NOT in effect" — the second is the only one that needs action,
+      // and saying "just delete the line" there would be actively wrong.
+      const entry = k as unknown as { effective: string; retired_env_set: { value: string } };
+      const same = Number(entry.retired_env_set.value) === Number(entry.effective);
+      await expect(warn).toContainText(same ? "already matches" : "is what actually runs");
     }
     // Whether or not any are set, the page itself must render.
     await expect(page.getByTestId("config-row-min_search_score")).toBeVisible();

--- a/packages/memory/src/cli/commands/web.ts
+++ b/packages/memory/src/cli/commands/web.ts
@@ -15,6 +15,7 @@
  */
 
 import type { Command } from "commander";
+import { readFileSync } from "node:fs";
 
 import { c, eprintln, info, localTimestamp, println } from "../../../../../_shared/cli-core/index.ts";
 import { buildWebServer, CompatibilityError } from "../../web/server.ts";
@@ -70,6 +71,24 @@ async function runForeground(host: string, port: number, watch?: boolean): Promi
   }
 }
 
+/**
+ * Pull a "Refusing to start" block out of the tail of the daemon log.
+ *
+ * `web start` detaches, so a refusal lands in the log rather than on the
+ * operator's terminal — and "not responding yet" reads like a slow boot when it
+ * is actually a hard, permanent stop with a known remedy.
+ */
+function readStartupRefusal(): string | null {
+  try {
+    const tail = readFileSync(daemonPaths.logFile, "utf8").slice(-4000);
+    const idx = tail.lastIndexOf("Refusing to start:");
+    if (idx === -1) return null;
+    return tail.slice(idx).trim();
+  } catch {
+    return null;
+  }
+}
+
 export function registerWeb(program: Command): void {
   const web = program
     .command("web")
@@ -118,10 +137,21 @@ export function registerWeb(program: Command): void {
               println(c.dim(`  Logs:    ${daemonPaths.logFile}`));
               println(c.dim(`  Stop:    cerefox web stop`));
             } else {
-              eprintln(
-                `Started (pid ${outcome.pid}) but it is not responding on :${port} yet.\n` +
-                  `Check the log for errors: ${daemonPaths.logFile}`,
-              );
+              // The most common reason a daemon fails to answer is not a slow
+              // boot: it is the compatibility gate refusing outright, which
+              // happens to every user upgrading across a minimum-schema bump.
+              // The log already explains it precisely, so surface that instead
+              // of sending someone to go find it.
+              const refusal = readStartupRefusal();
+              if (refusal) {
+                eprintln(refusal);
+                eprintln(`\nFull log: ${daemonPaths.logFile}`);
+              } else {
+                eprintln(
+                  `Started (pid ${outcome.pid}) but it is not responding on :${port} yet.\n` +
+                    `Check the log for errors: ${daemonPaths.logFile}`,
+                );
+              }
               process.exit(1);
             }
             break;


### PR DESCRIPTION
Both found during the live 1.1.0 production upgrade.

## 1. `web start` hid the reason it failed

The daemon detaches, so a compatibility refusal lands in the log rather than on
the terminal. The operator saw:

```
Started (pid 6821) but it is not responding on :8000 yet.
Check the log for errors: /Users/…/.cerefox/web.log
```

That reads like a slow boot. It was a hard, permanent stop, and the log already
explained it exactly:

```
Refusing to start: the deployed Cerefox server is incompatible with this client (v1.1.0).
  • schema v0.9.2 is below the required v0.10.3
Redeploy your server:  cerefox server deploy
```

**Every user upgrading across a minimum-schema bump hits this**, so `web start`
now reads the log tail and prints the refusal when it finds one.

## 2. The Settings page never got #179's refinement

`doctor` learned to distinguish a retired `.env` line that has already been
carried over from one that hasn't. The web UI did not — it said *"delete that
line from your .env"* in both cases.

Those are different situations, and the second is the one that matters: a `.env`
asking for `0.70` against a store running `0.5` means the operator's tuning is
**silently not in effect**, and "just delete the line" would make that permanent.

| State | Now shown |
|---|---|
| `.env` matches the stored value | Grey, inert: *"the stored value already matches, so nothing changes: delete that line"* |
| `.env` differs | Yellow: *"Your .env asked for 0.70, but 0.5 is what actually runs. Set it here if you want the old value back."* |

Numeric comparison, so `0.7` and `0.70` don't read as a conflict.

## Test plan

- [x] `_shared` 345 pass · `packages/memory` 164 pass · typecheck clean
- [x] Playwright — Settings suite passes; the retired-env test now asserts
      whichever branch the environment presents
- [x] Verified both branches live: **matched** (prod, `0.7` vs `0.70`) renders
      inert; **mismatched** (staging, temporarily `0.55` vs `0.70`) names both
      values. Staging restored to `0.7` afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vd45RFdSk8hHupWLn9jfDQ
