### PR TITLE
MCP tool annotations on all 14 tools, both transports (closes #184)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,18 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
-Open roadmap.
+### Added
+- **MCP tools now declare annotations** (spec 2025-03-26): `readOnlyHint`,
+  `destructiveHint`, `idempotentHint`, `openWorldHint` and a display title, on
+  all 14 tools, over both the local stdio server and the remote Edge Function.
+  Declaring nothing was not neutral: the spec defaults are *not read-only,
+  possibly destructive*, so clients were told `cerefox_search` was as dangerous
+  as a destructive write. The usual response is to blanket-approve the server,
+  which drains the meaning from the prompt on the tools that warrant one. Ten
+  read-only tools are now marked as such; three are marked destructive:
+  `cerefox_set_document_projects`, `cerefox_delete_relation`, and
+  `cerefox_ingest` — the last because `project_names` **replaces** project
+  memberships, and unlike document content, memberships have no version history.
 
 ---
 

--- a/_shared/__tests__/mcp_tools.test.ts
+++ b/_shared/__tests__/mcp_tools.test.ts
@@ -397,3 +397,77 @@ describe("chunker (used by ingest)", () => {
     expect(normalizeContent("a\n\n\n\nb")).toBe("a\n\nb");
   });
 });
+
+describe("tool annotations (MCP 2025-03-26)", () => {
+  // Declaring nothing is not neutral: the spec defaults are readOnlyHint=false
+  // and destructiveHint=true, so an unannotated tool tells every client it may
+  // do something irreversible. That made `cerefox_search` look as dangerous as
+  // a destructive write, and the usual response is to blanket-approve the
+  // server — which drains the meaning from the prompt on the tools that
+  // genuinely warrant one.
+  const READ_ONLY = [
+    "cerefox_search",
+    "cerefox_get_document",
+    "cerefox_metadata_search",
+    "cerefox_list_projects",
+    "cerefox_list_versions",
+    "cerefox_list_metadata_keys",
+    "cerefox_get_audit_log",
+    "cerefox_get_help",
+    "cerefox_get_relations",
+    "cerefox_get_neighbors",
+  ];
+  // Irreversible, because what they remove has NO version history.
+  // cerefox_ingest belongs here for a non-obvious reason: `project_names`
+  // REPLACES the document's project memberships, so a partial list silently
+  // drops the rest. Its content edits are recoverable; its membership edits
+  // are not.
+  const DESTRUCTIVE = [
+    "cerefox_ingest",
+    "cerefox_set_document_projects",
+    "cerefox_delete_relation",
+  ];
+
+  test("every tool declares annotations", () => {
+    const missing = ALL_TOOLS.filter((t) => !t.annotations).map((t) => t.name);
+    expect(missing).toEqual([]);
+  });
+
+  test("read-only tools are marked read-only and not destructive", () => {
+    for (const name of READ_ONLY) {
+      const t = ALL_TOOLS.find((x) => x.name === name);
+      expect(t, `${name} missing`).toBeDefined();
+      expect(t!.annotations?.readOnlyHint, name).toBe(true);
+      expect(t!.annotations?.destructiveHint, name).not.toBe(true);
+    }
+  });
+
+  test("irreversible tools are marked destructive", () => {
+    for (const name of DESTRUCTIVE) {
+      const t = ALL_TOOLS.find((x) => x.name === name);
+      expect(t, `${name} missing`).toBeDefined();
+      expect(t!.annotations?.readOnlyHint, name).toBe(false);
+      expect(t!.annotations?.destructiveHint, name).toBe(true);
+    }
+  });
+
+  test("no tool is both read-only and destructive", () => {
+    for (const t of ALL_TOOLS) {
+      if (t.annotations?.readOnlyHint) {
+        expect(t.annotations.destructiveHint, t.name).not.toBe(true);
+      }
+    }
+  });
+
+  test("nothing claims to reach the open world — every tool talks to the operator's own store", () => {
+    for (const t of ALL_TOOLS) {
+      expect(t.annotations?.openWorldHint, t.name).toBe(false);
+    }
+  });
+
+  test("every tool carries a human-readable title", () => {
+    for (const t of ALL_TOOLS) {
+      expect(typeof t.annotations?.title, t.name).toBe("string");
+    }
+  });
+});

--- a/_shared/mcp-tools/audit-log.ts
+++ b/_shared/mcp-tools/audit-log.ts
@@ -65,6 +65,13 @@ export const auditLogTool: ToolDefinition = {
   name: "cerefox_get_audit_log",
   description:
     "Retrieve audit log entries showing who changed what and when. Supports filtering by document, author, operation type, and time range. Returns entries with document titles, author attribution, size changes, and descriptions.",
+  // Read-only: touches nothing. Safe for a client to run without prompting.
+  annotations: {
+    title: "Read audit log",
+    readOnlyHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   inputSchema: {
     type: "object",
     required: [],

--- a/_shared/mcp-tools/get-document.ts
+++ b/_shared/mcp-tools/get-document.ts
@@ -57,6 +57,13 @@ export const getDocumentTool: ToolDefinition = {
   name: "cerefox_get_document",
   description:
     "Retrieve the full reconstructed content of a document. Pass version_id to retrieve an archived version; omit it (or pass null) for the current version. Version UUIDs are returned by cerefox_list_versions. The response header includes the document's current content_hash — pass it back as expected_content_hash when updating via cerefox_ingest (optimistic concurrency).",
+  // Read-only: touches nothing. Safe for a client to run without prompting.
+  annotations: {
+    title: "Read document",
+    readOnlyHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   inputSchema: {
     type: "object",
     required: ["document_id"],

--- a/_shared/mcp-tools/get-help.ts
+++ b/_shared/mcp-tools/get-help.ts
@@ -71,6 +71,13 @@ export const getHelpTool: ToolDefinition = {
   name: "cerefox_get_help",
   description:
     "Retrieve Cerefox's own agent-usage guidance (the AGENT_QUICK_REFERENCE.md content). Call with no arguments to get the full reference + a section index. Call with `topic` to get a single section (case-insensitive substring match against H2 headings). Use this whenever you're uncertain about Cerefox conventions — link forms, project-membership semantics, update workflows, etc.",
+  // Read-only: touches nothing. Safe for a client to run without prompting.
+  annotations: {
+    title: "Read Cerefox conventions",
+    readOnlyHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   inputSchema: {
     type: "object",
     properties: {

--- a/_shared/mcp-tools/ingest.ts
+++ b/_shared/mcp-tools/ingest.ts
@@ -350,6 +350,17 @@ async function handler(
 export const ingestTool: ToolDefinition = {
   name: "cerefox_ingest",
   description: "Save a note or document to the Cerefox knowledge base.",
+  /** Destructive: `project_names` REPLACES the document's project memberships, and
+ *  memberships have no version history — a partial list silently drops the rest.
+ *  Content itself is version-snapshotted and guarded by expected_content_hash, so
+ *  the destructive part is the membership replace, not the body. */
+  annotations: {
+    title: "Save or update a document",
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
   inputSchema: {
     type: "object",
     required: ["title", "content"],

--- a/_shared/mcp-tools/list-metadata-keys.ts
+++ b/_shared/mcp-tools/list-metadata-keys.ts
@@ -41,6 +41,13 @@ export const listMetadataKeysTool: ToolDefinition = {
   name: "cerefox_list_metadata_keys",
   description:
     "List all metadata keys currently in use across documents in the Cerefox knowledge base. Returns each key with its document count and up to 5 example values.",
+  // Read-only: touches nothing. Safe for a client to run without prompting.
+  annotations: {
+    title: "List metadata keys",
+    readOnlyHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   inputSchema: {
     type: "object",
     properties: {

--- a/_shared/mcp-tools/list-projects.ts
+++ b/_shared/mcp-tools/list-projects.ts
@@ -45,6 +45,13 @@ export const listProjectsTool: ToolDefinition = {
   name: "cerefox_list_projects",
   description:
     "List all projects with their names and IDs. Use this to discover available projects before filtering by project_name in other tools.",
+  // Read-only: touches nothing. Safe for a client to run without prompting.
+  annotations: {
+    title: "List projects",
+    readOnlyHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   inputSchema: {
     type: "object",
     properties: {

--- a/_shared/mcp-tools/list-versions.ts
+++ b/_shared/mcp-tools/list-versions.ts
@@ -53,6 +53,13 @@ export const listVersionsTool: ToolDefinition = {
   name: "cerefox_list_versions",
   description:
     "List all archived versions of a document, newest first. Returns version_id (use with cerefox_get_document), version_number, source, chunk_count, total_chars, and created_at.",
+  // Read-only: touches nothing. Safe for a client to run without prompting.
+  annotations: {
+    title: "List document versions",
+    readOnlyHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   inputSchema: {
     type: "object",
     required: ["document_id"],

--- a/_shared/mcp-tools/metadata-search.ts
+++ b/_shared/mcp-tools/metadata-search.ts
@@ -124,6 +124,13 @@ export const metadataSearchTool: ToolDefinition = {
   name: "cerefox_metadata_search",
   description:
     "Find or list documents by metadata key-value criteria without a text search term. Use to discover documents tagged with specific attributes, browse by taxonomy, retrieve messages/tasks by type and status, or list all documents in a project (pass project_name alone). At least one of metadata_filter, project_name, updated_since, or created_since must be supplied; results are ordered newest-updated first.",
+  // Read-only: touches nothing. Safe for a client to run without prompting.
+  annotations: {
+    title: "Find documents by metadata",
+    readOnlyHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   inputSchema: {
     type: "object",
     properties: {

--- a/_shared/mcp-tools/relations.ts
+++ b/_shared/mcp-tools/relations.ts
@@ -81,6 +81,14 @@ export const setRelationTool: ToolDefinition = {
     "contradicts, duplicates) write both directions. `supersedes` marks the target " +
     "superseded; `contradicts` marks both stale. Any other type string is accepted " +
     "and stored, just without special behaviour. Re-setting the same edge updates it.",
+  /** Upsert: re-running with the same edge changes nothing. Adds an edge; removes nothing. */
+  annotations: {
+    title: "Link two documents",
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   inputSchema: {
     type: "object",
     required: ["source_id", "target_id", "rel_type"],
@@ -143,6 +151,14 @@ export const deleteRelationTool: ToolDefinition = {
   description:
     "Remove a typed relation between two documents. Symmetric types remove both " +
     "directions. Lifecycle status set by an earlier relation is NOT reverted.",
+  /** Removes an edge (and its mirror for symmetric types). Relations are not versioned, so the edge is gone. */
+  annotations: {
+    title: "Remove a relation",
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   inputSchema: {
     type: "object",
     required: ["source_id", "target_id", "rel_type"],
@@ -203,6 +219,13 @@ export const getRelationsTool: ToolDefinition = {
     "List every relation touching a document, in both directions (→ outbound, " +
     "← inbound). Shows each neighbour's title and lifecycle status, so an agent " +
     "can tell whether retrieved knowledge has been superseded or contradicted.",
+  // Read-only: traversal only, mutates nothing.
+  annotations: {
+    title: "List a document's relations",
+    readOnlyHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   inputSchema: {
     type: "object",
     required: ["document_id"],
@@ -267,6 +290,13 @@ export const getNeighborsTool: ToolDefinition = {
     "Use after cerefox_get_relations shows which types exist. depth > 1 follows " +
     "chains (useful for follows / reply_to); cycles terminate safely. Optional " +
     "from_time / to_time filter neighbours by their creation time.",
+  // Read-only: traversal only, mutates nothing.
+  annotations: {
+    title: "Walk the relation graph",
+    readOnlyHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   inputSchema: {
     type: "object",
     required: ["document_id", "rel_type"],

--- a/_shared/mcp-tools/search.ts
+++ b/_shared/mcp-tools/search.ts
@@ -192,6 +192,13 @@ export const searchTool: ToolDefinition = {
   name: "cerefox_search",
   description:
     "Search the Cerefox personal knowledge base. Returns complete documents ranked by hybrid (FTS + semantic) relevance.",
+  // Read-only: touches nothing. Safe for a client to run without prompting.
+  annotations: {
+    title: "Search knowledge base",
+    readOnlyHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   inputSchema: {
     type: "object",
     required: ["query"],

--- a/_shared/mcp-tools/set-document-projects.ts
+++ b/_shared/mcp-tools/set-document-projects.ts
@@ -72,6 +72,15 @@ export const setDocumentProjectsTool: ToolDefinition = {
   name: "cerefox_set_document_projects",
   description:
     "Set the document's project memberships to EXACTLY the given list. Destructive replace: any existing memberships not in this list are removed. Pass an empty list to clear all project memberships. Projects are looked up by name (case-insensitive); missing projects are created. Logged as update-metadata in the audit log — content is untouched. Use cerefox_ingest with project_names if you want to set memberships AND update content in one call. Use this tool when you only need to change project membership without re-writing the document body.",
+  /** Destructive by contract: any membership not in the list is removed, and an
+ *  empty list clears all of them. No version history for memberships. */
+  annotations: {
+    title: "Replace project memberships",
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   inputSchema: {
     type: "object",
     required: ["document_id", "project_names"],

--- a/_shared/mcp-tools/types.ts
+++ b/_shared/mcp-tools/types.ts
@@ -66,10 +66,44 @@ export interface ToolContext {
   accessPath: AccessPath;
 }
 
+/**
+ * MCP tool annotations (spec revision 2025-03-26).
+ *
+ * Hints that let a client reason about a tool BEFORE calling it. Without them a
+ * tool inherits the spec defaults `readOnlyHint: false` and
+ * `destructiveHint: true` — i.e. "may do something irreversible" — so declaring
+ * nothing tells every client that `cerefox_search` is as dangerous as a
+ * destructive write. The usual result is that users blanket-approve the server,
+ * which drains the meaning from the prompt on the tools that genuinely warrant
+ * one.
+ *
+ * These are hints from a server the client may not trust, so a client must not
+ * use them as a security boundary. They exist to inform UX, not to enforce it.
+ */
+export interface ToolAnnotations {
+  /** Human-readable label for UIs. */
+  title?: string;
+  /** The tool does not modify anything. */
+  readOnlyHint?: boolean;
+  /** The tool may perform IRREVERSIBLE updates. Only meaningful when the tool
+   *  is not read-only. Static per tool: if any argument shape can destroy, the
+   *  tool is destructive. */
+  destructiveHint?: boolean;
+  /** Repeated calls with the same arguments have no additional effect. */
+  idempotentHint?: boolean;
+  /** The tool reaches external entities (a web search) rather than a closed
+   *  domain. False throughout Cerefox: every tool talks to the operator's own
+   *  store. */
+  openWorldHint?: boolean;
+}
+
 export interface ToolDefinition {
   name: string;
   description: string;
   inputSchema: JsonSchema;
+  /** See `ToolAnnotations`. Required in practice: a unit test fails if a tool
+   *  omits it, so adding a tool forces the read-only/destructive decision. */
+  annotations?: ToolAnnotations;
   /** Returns the MCP `TextContent.text` body. Tools that fail throw; the
    *  consumer's request wrapper translates thrown errors into JSON-RPC
    *  `-32603` (internal error) responses, or `-32602` (invalid params)

--- a/packages/memory/src/server.ts
+++ b/packages/memory/src/server.ts
@@ -89,6 +89,9 @@ export function buildServer(): ServerHandle {
       name: t.name,
       description: t.description,
       inputSchema: t.inputSchema as Record<string, unknown>,
+      // MCP 2025-03-26 tool annotations. Without them a client must assume the
+      // spec defaults (not read-only, possibly destructive) for every tool.
+      ...(t.annotations ? { annotations: t.annotations } : {}),
     })),
   }));
 

--- a/supabase/functions/cerefox-mcp/index.ts
+++ b/supabase/functions/cerefox-mcp/index.ts
@@ -68,6 +68,8 @@ async function buildToolList(supabase: MCPSupabaseClient) {
     name: t.name,
     description: t.description,
     inputSchema: t.inputSchema,
+    // MCP 2025-03-26 tool annotations; MCP_VERSION already declares that revision.
+    ...(t.annotations ? { annotations: t.annotations } : {}),
   }));
 }
 


### PR DESCRIPTION
Closes #184.

Surfaced when an agent hit an approval gate on `cerefox_set_document_projects`.
That turned out to be a **client-side transient** (the dialog appeared on retry
and the audit log confirms the successful call reached the server) — but
investigating it showed we declare no annotations at all.

## Declaring nothing is not neutral

The spec defaults are `readOnlyHint: false` and `destructiveHint: true`. So every
Cerefox tool was telling every client it might do something irreversible,
`cerefox_search` included. The predictable response is that a user
blanket-approves the server, at which point the prompt on the tools that
genuinely warrant one carries no signal.

## What is marked destructive, and why

Three tools, on one test: **what they remove has no version history.**

| Tool | Why |
|---|---|
| `cerefox_set_document_projects` | Full replace; anything not in the list is removed |
| `cerefox_delete_relation` | Edges are not versioned |
| `cerefox_ingest` | `project_names` **replaces** memberships |

That last one is @fstamatelopoulos's catch and the most important line here. My
first draft called `cerefox_ingest` non-destructive because content is
version-snapshotted and guarded by `expected_content_hash` — true of the body,
and wrong overall, because the same call carries project memberships and a
partial `project_names` silently drops the rest. It matters more than the other
two: **ingest is the write tool agents reach for most**, so the irreversible path
is the well-trodden one.

## The asymmetry this removes was observed in the wild

A client gated the narrow membership tool while `cerefox_ingest` — able to
destroy the same memberships — ran freely. The agent then routed around the
safety prompt by folding `project_names` into an ingest, believing it was the
safer option because it had been pre-approved. Marking ingest destructive closes
exactly that gap.

`openWorldHint: false` throughout: every tool talks to the operator's own store,
never the open web.

## Test plan

- [x] Six unit tests pin the contract, including **"every tool declares
      annotations"** — a new tool cannot be added without making the
      read-only/destructive decision
- [x] `_shared` 351 pass · `packages/memory` 164 pass · typecheck clean
- [x] Verified over the **real MCP protocol**: 10 read-only, 2 destructive with
      relations dormant; with relations enabled, `set_relation` non-destructive
      and idempotent, `delete_relation` destructive, both getters read-only.
      Relations restored to dormant afterwards.
- [ ] Cross-client verification (Claude Code, Claude Desktop, remote) — worth
      doing before release, since client handling of annotations varies

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vd45RFdSk8hHupWLn9jfDQ
