### PR TITLE
fix(ingest): preserve a document's source when p_source is omitted (#191)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
+### Fixed
+- **A content update without an explicit source silently overwrote the
+  document's provenance** (#191). `cerefox_ingest_document`'s UPDATE branch
+  assigned `source = p_source` unconditionally while the columns either side of
+  it coalesced (`source_path` and, since v0.11.1, `metadata`). With
+  `p_source TEXT DEFAULT 'agent'` in the signature, PostgreSQL substituted that
+  default on every omitted argument, so any partial update quietly relabelled the
+  document. `cerefox server migrate-format` hit this at corpus scale: it
+  hardcoded `source: "migrate-format"` for every document it converted, though it
+  reads each one first and `cerefox_get_document` returns `doc_source`. One
+  reported store had 1,317 documents relabelled in a single run, 201 of which
+  carried no `metadata.source_agent` and so had no other provenance field left.
+  Nothing surfaced it: the audit entry reads `update-content`, and version rows
+  carry their own label rather than the document's prior value.
+
+  `p_source` now defaults to NULL and the update coalesces, matching `metadata`
+  exactly; the create path keeps `'agent'` via `COALESCE(p_source, 'agent')`.
+  `migrate-format` passes the document's own source and labels the version it
+  archives `"migrate-format"`, so a conversion is still identifiable in history
+  without rewriting where the document came from. Schema `0.10.5` → `0.10.6`;
+  run `cerefox server deploy`. An explicit `p_source` still relabels, so
+  deliberate callers are unaffected.
+
+  Reported by @tdebasis.
+
 Open roadmap.
 
 ---

--- a/_shared/__tests__/rpc-update-preserves-fields.test.ts
+++ b/_shared/__tests__/rpc-update-preserves-fields.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Guard against the #191 defect class: a document field that a caller may
+ * legitimately omit must be preserved on update, not overwritten.
+ *
+ * `cerefox_ingest_document` serves both "save new content" and "relabel this
+ * document". Its parameters therefore carry two meanings at once, and the only
+ * thing separating them is whether the UPDATE branch coalesces:
+ *
+ *     source      = COALESCE(p_source, source)             -- absent = keep
+ *     source_path = COALESCE(p_source_path, source_path)   -- absent = keep
+ *     metadata    = COALESCE(p_metadata, metadata)         -- absent = keep
+ *
+ * Assign one of those unconditionally and every caller that omits it silently
+ * rewrites it to the parameter default. That is what #191 was: `p_source TEXT
+ * DEFAULT 'agent'` plus a bare `source = p_source`, so `server migrate-format`
+ * relabelled every document it converted and any other partial update quietly
+ * reset provenance to 'agent'. v0.11.1 had already fixed exactly this for
+ * `metadata` after content updates were found to be wiping tags; `source` was
+ * left out of that fix and took another release to surface.
+ *
+ * Both halves are required and neither is sufficient alone:
+ *   - COALESCE without a NULL default never sees NULL, so it cannot fire.
+ *   - A NULL default without COALESCE writes NULL into a NOT NULL column.
+ *
+ * The failure is invisible at runtime: the write succeeds, the audit entry says
+ * 'update-content', and only the stored column disagrees. So the check is
+ * static — parse the SQL and assert both halves.
+ *
+ * Pure text analysis of `rpcs.sql`. No DB, no network.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..");
+
+const RPCS = readFileSync(
+  join(REPO_ROOT, "src", "cerefox", "db", "rpcs.sql"),
+  "utf8",
+);
+
+const MIGRATE_FORMAT = readFileSync(
+  join(REPO_ROOT, "packages", "memory", "src", "cli", "commands", "migrate-format.ts"),
+  "utf8",
+);
+
+const PIPELINE = readFileSync(
+  join(REPO_ROOT, "packages", "memory", "src", "ingestion", "pipeline.ts"),
+  "utf8",
+);
+
+/** The body of `cerefox_ingest_document`, up to the next function definition. */
+function ingestBody(): string {
+  const start = RPCS.indexOf("CREATE FUNCTION cerefox_ingest_document");
+  expect(start).toBeGreaterThan(-1);
+  const rest = RPCS.slice(start + 1);
+  const end = rest.indexOf("\nCREATE FUNCTION ");
+  return end === -1 ? rest : rest.slice(0, end);
+}
+
+/**
+ * Document columns a caller may omit on an update. `metadata` and `source_path`
+ * carry the v0.11.1 fix; `source` joined them in #191.
+ */
+const PRESERVED_ON_UPDATE = ["source", "source_path", "metadata"] as const;
+
+/** Parameters whose absence must be distinguishable from a real value. */
+const OMITTABLE_PARAMS = ["p_source", "p_source_path", "p_metadata"] as const;
+
+describe("cerefox_ingest_document preserves omitted document fields (#191)", () => {
+  const body = ingestBody();
+
+  for (const column of PRESERVED_ON_UPDATE) {
+    test(`${column} is coalesced, not assigned unconditionally`, () => {
+      // The UPDATE list assigns `column = <expr>,`. Capture to end of line
+      // rather than to the first comma: the expected expression contains one.
+      const re = new RegExp(`^\\s*${column}\\s*=\\s*(.+)$`, "m");
+      const match = body.match(re);
+      // A renamed column would make this vacuously pass.
+      expect(match).not.toBeNull();
+      expect(match![1].trim().replace(/,$/, "")).toBe(`COALESCE(p_${column}, ${column})`);
+    });
+  }
+
+  for (const param of OMITTABLE_PARAMS) {
+    test(`${param} declares DEFAULT NULL so omission is detectable`, () => {
+      const re = new RegExp(`^\\s*${param}\\s+[A-Z0-9()]+\\s+DEFAULT\\s+([^,\\n]+)`, "im");
+      const match = body.match(re);
+      expect(match).not.toBeNull();
+      expect(match![1].trim().replace(/,$/, "").toUpperCase()).toBe("NULL");
+    });
+  }
+
+  test("the CREATE path still supplies a concrete source", () => {
+    // NOT NULL column: create cannot inherit a previous value, so the fallback
+    // has to live at the insert.
+    expect(body).toContain("COALESCE(p_source, 'agent')");
+  });
+
+  test("p_source and p_source_label remain distinct", () => {
+    // p_source is the document's origin; p_source_label records how this write
+    // was triggered and lands on the version row. Collapsing them would make
+    // preserving one impossible without falsifying the other.
+    expect(body).toContain(
+      "cerefox_snapshot_version(v_doc_id, p_source_label, p_retention_hours, p_cleanup_enabled)",
+    );
+    expect(body).not.toContain("cerefox_snapshot_version(v_doc_id, p_source,");
+  });
+});
+
+describe("server migrate-format does not relabel what it converts (#191)", () => {
+  test("the ingest call passes the document's own source", () => {
+    // The RPC guard above makes an omitted source safe. This asserts the
+    // stronger client-side property: the command sends the value it read, so it
+    // is also correct against a server that predates the COALESCE.
+    expect(MIGRATE_FORMAT).toContain("source: doc.doc_source");
+  });
+
+  test("no hardcoded document source survives", () => {
+    // `source:` on an ingest call must never be a string literal here. The
+    // version label is a separate key and is allowed to be one.
+    const hardcoded = /(?<!\w)source:\s*["'`]/.exec(MIGRATE_FORMAT);
+    expect(hardcoded).toBeNull();
+  });
+
+  test("the version row still records that migrate-format did the write", () => {
+    // Preserving provenance must not cost the audit trail: the conversion is
+    // still identifiable in version history.
+    expect(MIGRATE_FORMAT).toContain('sourceLabel: "migrate-format"');
+  });
+
+  test("sourceLabel survives the ingestText → updateDocument hand-off", () => {
+    // The RPC call carrying sourceLabel lives in updateDocument, but callers
+    // set it on ingestText, which forwards to updateDocument for every
+    // by-id update — the path migrate-format takes. Omit it from that object
+    // literal and the label is silently dropped: the option still type-checks
+    // on the way in, and nothing fails at runtime. Caught exactly this way
+    // while writing the #191 fix.
+    const calls = [...PIPELINE.matchAll(/await this\.updateDocument\(\{([\s\S]*?)\n\s*\}\)/g)];
+    expect(calls.length).toBeGreaterThan(0);
+    for (const call of calls) expect(call[1]).toContain("sourceLabel");
+  });
+
+  test("doc_source is actually read back from the RPC", () => {
+    // cerefox_get_document returns doc_source; the local type annotation has to
+    // include it or the value is silently undefined at runtime.
+    expect(MIGRATE_FORMAT).toContain("doc_source: string");
+    expect(RPCS).toContain("d.source        AS doc_source");
+  });
+});

--- a/packages/memory/src/cli/commands/migrate-format.ts
+++ b/packages/memory/src/cli/commands/migrate-format.ts
@@ -173,10 +173,12 @@ async function action(options: MigrateOptions): Promise<void> {
     // other reader uses — so we convert exactly what a reader would see.
     // Column names are the RPC's own (doc_title / full_content), not the
     // table's — an easy mismatch to assume wrong, so it is spelled out here.
-    let doc: { doc_title: string; full_content: string; content_hash: string } | null = null;
+    let doc:
+      | { doc_title: string; doc_source: string; full_content: string; content_hash: string }
+      | null = null;
     try {
       const rows = await client.rpc<
-        Array<{ doc_title: string; full_content: string; content_hash: string }>
+        Array<{ doc_title: string; doc_source: string; full_content: string; content_hash: string }>
       >("cerefox_get_document", { p_document_id: id, p_version_id: null });
       doc = rows?.[0] ?? null;
     } catch (err) {
@@ -193,7 +195,12 @@ async function action(options: MigrateOptions): Promise<void> {
         text: doc.full_content,
         title: doc.doc_title,
         documentId: id,
-        source: "migrate-format",
+        // A format conversion is not a change of origin, so the document keeps
+        // the source it came in with (#191 — this used to hardcode
+        // "migrate-format" and overwrite provenance corpus-wide). The version
+        // row still records that this run performed the write.
+        source: doc.doc_source,
+        sourceLabel: "migrate-format",
         author,
         authorType,
         // Compare-and-swap against what we just read: a concurrent edit makes

--- a/packages/memory/src/ingestion/pipeline.ts
+++ b/packages/memory/src/ingestion/pipeline.ts
@@ -89,6 +89,7 @@ export class IngestionPipeline {
       text,
       title,
       source = "paste",
+      sourceLabel,
       sourcePath: sourcePathOpt,
       projectName,
       projectId,
@@ -127,6 +128,7 @@ export class IngestionPipeline {
         text,
         title,
         source,
+        sourceLabel,
         projectIds: fullSetResolved,
         metadata,
         author,
@@ -174,6 +176,7 @@ export class IngestionPipeline {
           text,
           title,
           source,
+          sourceLabel,
           projectIds: fullSetResolved,
           metadata,
           author,
@@ -318,6 +321,7 @@ export class IngestionPipeline {
       text,
       title,
       source = "manual",
+      sourceLabel,
       projectId,
       projectIds,
       metadata,
@@ -506,7 +510,10 @@ export class IngestionPipeline {
       contentFormat: CONTENT_FORMAT_BLIND_STITCH,
       author,
       authorType,
-      sourceLabel: source,
+      // The document's origin and the reason for this particular write are the
+      // same thing for an ordinary save, and different for a maintenance pass
+      // that rewrites a document without changing where it came from (#191).
+      sourceLabel: sourceLabel ?? source,
       // Deliberately NOT passed: version retention is the store's policy, read
       // by the RPC from cerefox_config. Sending this client's env values here is
       // what made the surviving history depend on which client wrote last — an

--- a/packages/memory/src/ingestion/types.ts
+++ b/packages/memory/src/ingestion/types.ts
@@ -51,6 +51,17 @@ export interface IngestTextOptions {
   text: string;
   title: string;
   source?: string;            // default "paste"
+  /**
+   * Version-row label recording how THIS write was triggered, as distinct from
+   * `source`, which is the document's own origin. Defaults to `source`, which
+   * is right for ordinary saves where the two coincide.
+   *
+   * They diverge for maintenance commands that rewrite a document without
+   * changing where it came from: `server migrate-format` preserves the
+   * document's `source` and labels the version it archives "migrate-format",
+   * so the history still shows which run performed the conversion (#191).
+   */
+  sourceLabel?: string;
   sourcePath?: string | null;
   projectName?: string | null;
   projectId?: string | null;
@@ -88,6 +99,8 @@ export interface UpdateDocumentOptions {
   text: string;
   title: string;
   source?: string;             // default "manual"
+  /** Version-row label — see IngestTextOptions.sourceLabel. Defaults to `source`. */
+  sourceLabel?: string;
   projectId?: string | null;
   projectIds?: string[] | null;
   metadata?: Record<string, unknown> | null;

--- a/src/cerefox/db/migrations/0020_ingest_preserves_source.sql
+++ b/src/cerefox/db/migrations/0020_ingest_preserves_source.sql
@@ -1,0 +1,59 @@
+-- 0020_ingest_preserves_source.sql — stop content updates from silently
+-- overwriting a document's provenance (#191, reported by @tdebasis).
+--
+-- `cerefox_ingest_document`'s UPDATE branch assigned the source column
+-- unconditionally:
+--
+--     source      = p_source                              -- unconditional
+--     source_path = COALESCE(p_source_path, source_path)  -- preserved
+--     metadata    = COALESCE(p_metadata, metadata)        -- preserved
+--
+-- with `p_source TEXT DEFAULT 'agent'` in the signature. The two columns either
+-- side of it already implement the "absent means keep" rule — metadata got it in
+-- v0.11.1, after content updates without metadata were found to be wiping tags.
+-- source was left out of that fix.
+--
+-- Two consequences, both silent:
+--
+--   * Any caller that updates a document without passing p_source rewrites that
+--     document's source to the parameter default 'agent'. Nothing in the RPC's
+--     output, the audit entry, or the version row records that it happened: the
+--     audit operation is 'update-content', and version rows carry their own
+--     source label rather than the document's prior value.
+--   * `cerefox server migrate-format` hit this at corpus scale. It hardcoded
+--     source: "migrate-format" for every document it converted, even though it
+--     reads each document first and cerefox_get_document returns doc_source. A
+--     format conversion is not a change of origin, so every converted document
+--     lost the label it came in with.
+--
+-- Reported impact on one store: 1,317 documents rewritten to 'migrate-format' in
+-- a single run, 201 of which carried no metadata.source_agent and so had no
+-- other provenance field to fall back on. A second store on the same instance
+-- independently reported 509 of 553. Recovery required a point-in-time dump from
+-- before the run.
+--
+-- Fix: p_source defaults to NULL and the UPDATE branch coalesces, matching
+-- metadata and source_path exactly. The CREATE path keeps 'agent' as its
+-- concrete fallback via COALESCE(p_source, 'agent'), so new documents are
+-- unchanged. An explicit value still relabels, so deliberate callers are
+-- unaffected.
+--
+-- Note the distinction this preserves: p_source is the document's origin, while
+-- p_source_label records how a particular write was triggered and is stored on
+-- the version row. migrate-format now passes the document's own source for the
+-- former and keeps "migrate-format" for the latter, so the version history still
+-- shows which run performed the conversion.
+--
+-- Lives in rpcs.sql, which `cerefox server deploy` re-applies. This migration
+-- exists so the schema version moves and operators are told to redeploy.
+--
+-- Idempotent: safe to re-run.
+
+DO $$
+BEGIN
+    RAISE NOTICE
+        'Migration 0020: cerefox_ingest_document now preserves a document''s '
+        'source when p_source is omitted. Before this, any content update '
+        'without an explicit source silently rewrote provenance to ''agent'', '
+        'and migrate-format relabelled every document it converted (#191).';
+END $$;

--- a/src/cerefox/db/rpcs.sql
+++ b/src/cerefox/db/rpcs.sql
@@ -1258,7 +1258,12 @@ $$;
 --
 -- Parameters:
 --   p_document_id     : NULL for create, UUID for update
---   p_title, p_source, p_source_path, p_content_hash : document fields
+--   p_title, p_source_path, p_content_hash : document fields
+--   p_source          : origin label. NULL = "not provided" → create uses
+--                       'agent', update keeps the existing source (#191). Pass a
+--                       value explicitly to relabel. Distinct from
+--                       p_source_label, which records how THIS write was
+--                       triggered and is stored on the version row.
 --   p_metadata        : JSONB metadata. NULL = "not provided" → create uses '{}',
 --                       update keeps the existing metadata (v0.11.1). Pass '{}'
 --                       explicitly to clear all metadata.
@@ -1291,7 +1296,10 @@ DROP FUNCTION IF EXISTS cerefox_ingest_document(UUID, TEXT, TEXT, TEXT, TEXT, JS
 CREATE FUNCTION cerefox_ingest_document(
     p_document_id       UUID        DEFAULT NULL,
     p_title             TEXT        DEFAULT 'Untitled',
-    p_source            TEXT        DEFAULT 'agent',
+    -- NULL = "not provided": create uses 'agent', update KEEPS the existing
+    -- source (#191 — a content update without a source used to overwrite the
+    -- document's provenance). Pass a value to relabel deliberately.
+    p_source            TEXT        DEFAULT NULL,
     p_source_path       TEXT        DEFAULT NULL,
     p_content_hash      TEXT        DEFAULT '',
     -- NULL = "not provided": create uses '{}', update KEEPS existing metadata
@@ -1445,9 +1453,11 @@ BEGIN
 
         -- Update document record. metadata: NULL = keep existing (v0.11.1 —
         -- a content update without metadata must not wipe the document's tags).
+        -- source: same rule, same reason (#191 — a content update without a
+        -- source must not wipe the document's provenance).
         UPDATE cerefox_documents SET
             title = p_title,
-            source = p_source,
+            source = COALESCE(p_source, source),
             source_path = COALESCE(p_source_path, source_path),
             content_hash = p_content_hash,
             metadata = COALESCE(p_metadata, metadata),
@@ -1465,7 +1475,7 @@ BEGIN
             title, source, source_path, content_hash, metadata,
             chunk_count, total_chars, review_status
         ) VALUES (
-            p_title, p_source, p_source_path, p_content_hash, COALESCE(p_metadata, '{}'::JSONB),
+            p_title, COALESCE(p_source, 'agent'), p_source_path, p_content_hash, COALESCE(p_metadata, '{}'::JSONB),
             v_chunk_count, v_total_chars, v_status
         )
         RETURNING id INTO v_doc_id;
@@ -2333,7 +2343,7 @@ SET search_path = public, pg_catalog
 AS $$
     -- Keep in lockstep with the `@version:` marker in schema.sql (cut_release.ts
     -- enforces it). Bump whenever schema.sql OR rpcs.sql changes.
-    SELECT '0.10.5'::TEXT;
+    SELECT '0.10.6'::TEXT;
 $$;
 
 -- ── cerefox_content_format_stats ─────────────────────────────────────────────

--- a/src/cerefox/db/schema.sql
+++ b/src/cerefox/db/schema.sql
@@ -5,7 +5,7 @@
 -- Requires extensions: vector (pgvector), uuid-ossp
 -- These are enabled at the top of db_deploy.py before this file is applied.
 --
--- @version: 0.10.5
+-- @version: 0.10.6
 -- The `@version` marker above is read by the schema-version-mismatch banner
 -- (see /api/v1/schema-version). Bump it whenever schema.sql OR rpcs.sql
 -- changes in a way that requires `cerefox server deploy` to be re-run —


### PR DESCRIPTION
Fixes #191.

### What was wrong

`cerefox_ingest_document`'s UPDATE branch assigned the source column unconditionally while the columns either side of it coalesced:

```sql
source      = p_source                              -- unconditional
source_path = COALESCE(p_source_path, source_path)  -- preserved
metadata    = COALESCE(p_metadata, metadata)        -- preserved
```

With `p_source TEXT DEFAULT 'agent'` in the signature, PostgreSQL substitutes that default on every omitted argument, so any caller doing a partial update silently relabelled the document. `metadata` had the same hazard and got the `COALESCE` treatment in v0.11.1; `source` was left out of that fix.

`server migrate-format` is the loudest case rather than a separate bug: it hardcoded `source: "migrate-format"` for every document it converted, even though it reads each document first and `cerefox_get_document` already returns `doc_source`. A format conversion is not a change of origin.

### What this changes

**Server (`rpcs.sql`)**

- `p_source` now defaults to `NULL`, so "not provided" is distinguishable from a real value.
- The UPDATE branch coalesces: `source = COALESCE(p_source, source)`.
- The CREATE path keeps its concrete fallback via `COALESCE(p_source, 'agent')`, since the column is `NOT NULL` and a new document has nothing to inherit.
- An explicit `p_source` still relabels, so deliberate callers are unaffected.

**Client (`migrate-format`)**

- Passes the document's own `doc_source` instead of a literal. This also means the command is correct against a server that predates this change, rather than depending on it.
- Keeps `"migrate-format"` as the **version** label, so history still shows which run performed the conversion.

That second point is the one design decision in here worth flagging. `p_source` and `p_source_label` mean different things: the first is where a document came from, the second is what triggered a particular write, and only the second belongs on the version row (its own docs say "How the update was triggered"). They were previously always the same value, so `ingestText` had no way to express the difference. This adds an optional `sourceLabel` that defaults to `source`, leaving every existing caller byte-identical in behaviour. If you would rather not grow that surface, the alternative is to drop the option and let the version row carry the document's source; say the word and I will cut it.

`sourceLabel` is threaded through `ingestText` to `updateDocument` because the by-id update path is the one `migrate-format` takes. That hand-off was easy to miss and is covered by a test below.

### Schema and compatibility

Schema `0.10.5` to `0.10.6`, migration `0020` (NOTICE-only, in the same shape as `0018`, since the change itself lives in `rpcs.sql`, which `server deploy` re-applies). Migration `0019` is left free for #190.

**`minSchema` is deliberately not raised.** By the criterion in `_shared/compatibility/index.ts`, a minimum should move only when the client misbehaves against an older server. Here it does not: the client now sends an explicit source, which is correct on `0.10.5` and `0.10.6` alike. This is the "0.10.4 changed a fallback value" case from that file's own worked example, not the "0.10.5 ignores a configured policy" case. Operators still want `server deploy` to get the server-side guard for other callers, and the migration notice tells them so.

### Verification

Behavioural, on two scratch PostgreSQL databases built from `schema.sql` + `rpcs.sql`: one from this branch, one from `origin/main`, driven by the same script. Every assertion reads the stored column back rather than trusting a return value.

| Probe | `origin/main` (0.10.5) | this branch (0.10.6) |
|---|---|---|
| create with `p_source => 'my-pipeline'` | `my-pipeline` | `my-pipeline` |
| **update, `p_source` omitted** | **`agent`** | **`my-pipeline`** |
| version label after that update | `migrate-format` | `migrate-format` |
| update with explicit `p_source` (control) | `deliberate-relabel` | `deliberate-relabel` |
| create with no source (control) | `agent` | `agent` |
| `metadata` preserved across updates (control) | `{"keep": "me"}` | `{"keep": "me"}` |

Exactly one row differs. The controls matter as much as the fix: they show the change is confined to the omitted-argument case and does not disturb explicit relabels, the create default, or the neighbouring preserved columns.

Static tests in `_shared/__tests__/rpc-update-preserves-fields.test.ts`, following the shape of the existing `rpc-config-defaults.test.ts` (#183): pure text analysis of `rpcs.sql` and the client sources, no DB or network. They assert both halves of the invariant, because neither is sufficient alone: a `COALESCE` with a concrete default never sees NULL, and a NULL default without a `COALESCE` writes NULL into a `NOT NULL` column.

Checked against the unfixed tree before trusting them: 7 of the 13 fail on `origin/main`, including all four client-side assertions. The 5 that pass there are the pre-existing `metadata` / `source_path` invariants, which this change must not break.

`cd _shared && bun test` is 370 passing, 0 failing. `bun run typecheck` is clean. `bun scripts/cut_release.ts --check` exits 0 with the schema markers in lockstep. `packages/memory` type-checks to exactly the same 9 pre-existing errors as `origin/main` (#171), none introduced.

### Note on existing data

This stops the overwrite; it does not restore what was already overwritten. Values lost to an earlier run are only recoverable from a backup predating it. If it would be useful I can follow up with a short recovery note for the guide, since the audit log does not record the prior value and version rows carry their own label.
