### PR TITLE
fix(metadata): refuse non-object metadata at ingest, and stop `document edit` destroying it

### DIFF
--- a/packages/memory/src/cli/commands/document-edit.ts
+++ b/packages/memory/src/cli/commands/document-edit.ts
@@ -7,6 +7,12 @@
  * metadata and PATCHES it: `--set-meta` adds/overwrites individual keys,
  * `--unset-meta` removes them, everything else is preserved.
  *
+ * Two properties this command has to hold, both learned the hard way: it only
+ * writes `metadata` when a metadata flag was passed (so `--title` alone cannot
+ * touch tags), and it refuses a document whose stored metadata is not an object
+ * rather than spreading it, since a spread decomposes such a value instead of
+ * copying it. `cerefox document set-metadata --replace` is the repair path.
+ *
  * Content edits stay on `cerefox document ingest --document-id <id> --update`
  * (re-chunk + re-embed). A `--title` change here refreshes the FTS index
  * (title boosting); the semantic embeddings pick up the new title on the next
@@ -72,8 +78,27 @@ async function action(documentId: string, options: EditOptions): Promise<void> {
     throw userError(`Document ${documentId} is soft-deleted — restore it first (cerefox document restore).`);
   }
 
+  // Refuse to patch metadata that is not an object. The spread below does not
+  // copy a non-object value, it decomposes it: a stored JSON string becomes one
+  // key per character, an array becomes integer-indexed keys, a number or
+  // boolean becomes {}. That write is unconditional and reports success, and
+  // there is no metadata version history to roll back to. Failing loudly leaves
+  // the value recoverable; patching it does not.
+  const stored = doc.metadata;
+  if (stored !== null && stored !== undefined
+      && (typeof stored !== "object" || Array.isArray(stored))) {
+    throw userError(
+      `Document ${documentId} has non-object metadata (${Array.isArray(stored) ? "array" : typeof stored}); refusing to patch it, ` +
+        `because doing so would decompose the stored value rather than copy it.\n` +
+        `Repair it without resending the content:\n` +
+        `  cerefox document set-metadata ${documentId} --replace --json '<the intended object>'\n` +
+        `--replace is required: the default merge is stored || patch, and Postgres treats a ` +
+        `non-object left side as an array, so merging onto this row would produce another non-object.`,
+    );
+  }
+
   // Patch metadata: start from existing, apply sets, then unsets.
-  const metadata: Record<string, unknown> = { ...(doc.metadata ?? {}) };
+  const metadata: Record<string, unknown> = { ...(stored ?? {}) };
   for (const pair of sets) {
     const [k, v] = parseMetaPair(pair);
     metadata[k] = v;
@@ -83,9 +108,18 @@ async function action(documentId: string, options: EditOptions): Promise<void> {
   const newTitle = hasTitle ? options.title!.trim() : (doc.title as string);
   const titleChanged = newTitle !== doc.title;
 
+  // Only write `metadata` when a metadata flag was actually passed. Writing it
+  // unconditionally meant `document edit <id> --title "..."` rewrote metadata
+  // too, so a title-only edit could destroy tags the caller never mentioned.
+  const update: Record<string, unknown> = {
+    title: newTitle,
+    updated_at: new Date().toISOString(),
+  };
+  if (sets.length || unsets.length) update.metadata = metadata;
+
   const { error: updErr } = await client.raw
     .from("cerefox_documents")
-    .update({ title: newTitle, metadata, updated_at: new Date().toISOString() })
+    .update(update)
     .eq("id", documentId);
   if (updErr) throw systemError(`Update failed: ${updErr.message}`);
 

--- a/packages/memory/test/document-edit-metadata.test.ts
+++ b/packages/memory/test/document-edit-metadata.test.ts
@@ -1,0 +1,100 @@
+/**
+ * `document edit` must not destroy metadata it was never asked to change.
+ *
+ * Two defects, one write:
+ *   1. The update payload always carried `metadata`, so `--title` alone
+ *      rewrote it. Nothing on the command line mentioned metadata.
+ *   2. The patch is built with an object spread, which does not copy a
+ *      non-object JSONB value — it decomposes it. A stored JSON string becomes
+ *      one key per character, an array becomes integer-indexed keys, a number
+ *      or boolean becomes {}. The write then reports success, and metadata has
+ *      no version history to roll back to.
+ *
+ * Tested at the source level, in the same spirit as ingest-source-default:
+ * both defects live in how the payload is ASSEMBLED, above the database, so a
+ * round-trip test against a healthy document passes while they are live.
+ *
+ * The RPC assertion is here rather than in a SQL suite because the two halves
+ * are one fix: the RPC guard closes the path that creates the invalid state,
+ * and the CLI guard stops the command that destroys it. Fixing either alone
+ * leaves the class open, which is the #194 shape.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const SRC = readFileSync(
+  join(import.meta.dir, "..", "src", "cli", "commands", "document-edit.ts"),
+  "utf8",
+);
+const RPCS = readFileSync(
+  join(import.meta.dir, "..", "..", "..", "src", "cerefox", "db", "rpcs.sql"),
+  "utf8",
+);
+
+/** The body of cerefox_ingest_document, so a guard elsewhere in rpcs.sql
+ *  cannot make this pass by accident. */
+function ingestFunctionBody(): string {
+  const start = RPCS.indexOf("CREATE FUNCTION cerefox_ingest_document(");
+  expect(start).toBeGreaterThan(-1);
+  const end = RPCS.indexOf("CREATE FUNCTION", start + 1);
+  return RPCS.slice(start, end === -1 ? undefined : end);
+}
+
+describe("document edit: metadata is only written when asked for", () => {
+  test("the update payload is assembled conditionally", () => {
+    // The bug was a single object literal: .update({ title, metadata, ... }).
+    // `metadata` must be attached behind a flag check instead.
+    expect(SRC).toMatch(/if \(sets\.length \|\| unsets\.length\) update\.metadata = metadata;/);
+  });
+
+  test("no unconditional metadata key survives in the update call", () => {
+    const call = SRC.slice(SRC.indexOf(".update("), SRC.indexOf(".eq(\"id\", documentId)"));
+    expect(call).not.toMatch(/\{[^}]*\bmetadata\b[^}]*\}/);
+  });
+});
+
+describe("document edit: non-object metadata is refused, not spread", () => {
+  test("the guard runs before the spread", () => {
+    const guard = SRC.indexOf("refusing to patch it");
+    const spread = SRC.indexOf("{ ...(stored ?? {}) }");
+    expect(guard).toBeGreaterThan(-1);
+    expect(spread).toBeGreaterThan(-1);
+    expect(guard).toBeLessThan(spread);
+  });
+
+  test("arrays are caught too, since typeof [] is 'object'", () => {
+    expect(SRC).toMatch(/typeof stored !== "object" \|\| Array\.isArray\(stored\)/);
+  });
+
+  test("the error names the repair path, including --replace", () => {
+    // Without --replace the repair is a no-op on exactly these rows: the RPC
+    // merges with `stored || patch`, and Postgres treats a non-object left
+    // side as an array, so the result is another non-object value.
+    expect(SRC).toContain("cerefox document set-metadata");
+    expect(SRC).toContain("--replace");
+  });
+});
+
+describe("cerefox_ingest_document refuses non-object metadata", () => {
+  test("the guard exists inside the ingest function", () => {
+    expect(ingestFunctionBody()).toMatch(
+      /p_metadata IS NOT NULL AND jsonb_typeof\(p_metadata\) <> 'object'/,
+    );
+  });
+
+  test("it raises invalid_parameter_value, not a bare exception", () => {
+    const body = ingestFunctionBody();
+    const guard = body.slice(body.indexOf("jsonb_typeof(p_metadata)"));
+    expect(guard.slice(0, guard.indexOf("END IF;"))).toContain("22023");
+  });
+
+  test("NULL metadata stays legal, because it means 'not provided'", () => {
+    // The update branch coalesces to the stored value and the create branch to
+    // '{}'; a guard that rejected NULL would break every partial update.
+    const body = ingestFunctionBody();
+    expect(body).toContain("metadata = COALESCE(p_metadata, metadata)");
+    expect(body).toMatch(/p_metadata IS NOT NULL AND/);
+  });
+});

--- a/src/cerefox/db/migrations/0024_ingest_requires_object_metadata.sql
+++ b/src/cerefox/db/migrations/0024_ingest_requires_object_metadata.sql
@@ -1,0 +1,34 @@
+-- 0024_ingest_requires_object_metadata.sql — metadata must be a JSON object.
+--
+-- No table DDL: the guard lives inside cerefox_ingest_document, which ships in
+-- rpcs.sql and `cerefox server deploy` re-applies wholesale. This migration
+-- exists so the schema version advances in step, which is what tells an
+-- existing deployment it needs that redeploy.
+--
+-- Schema version 0.11.3 → 0.11.4. Behaviour change, not purely additive: an
+-- ingest whose p_metadata is a JSON string, array or scalar now raises 22023
+-- instead of storing a value that every reader treats as an object and that
+-- the next metadata edit destroys. NULL is unaffected — it still means "not
+-- provided". Existing rows are untouched; this closes the path that creates
+-- them rather than repairing what is already stored.
+--
+-- To find rows already in that state:
+--     SELECT id, title FROM cerefox_documents
+--      WHERE jsonb_typeof(metadata) <> 'object';
+--
+-- To repair one, without resending its content:
+--     cerefox document set-metadata <id> --replace --json '<the intended object>'
+--
+-- `--replace` is required. The default merge is `stored || patch`, and
+-- Postgres treats a non-object left-hand side as an array, so merging onto a
+-- corrupt row yields `[<corrupt value>, {<patch>}]` — still not an object.
+
+DO $$
+BEGIN
+    RAISE NOTICE
+        'Migration 0024: cerefox_ingest_document now refuses non-object metadata '
+        '(22023), matching the MCP handler. Existing rows are untouched — find '
+        'them with jsonb_typeof(metadata) <> ''object'' and repair with '
+        '`cerefox document set-metadata <id> --replace --json ...`. '
+        'Schema version 0.11.4.';
+END $$;

--- a/src/cerefox/db/rpcs.sql
+++ b/src/cerefox/db/rpcs.sql
@@ -1391,6 +1391,27 @@ BEGIN
             USING ERRCODE = '22023';  -- invalid_parameter_value
     END IF;
 
+    -- ── Metadata shape guard ─────────────────────────────────────────────
+    -- `metadata` is JSONB, so the column itself accepts any JSON value, but
+    -- every reader treats it as an object: `document edit` rebuilds it with a
+    -- spread (which decomposes a stored string into one key per character),
+    -- the listing query filters on jsonb_typeof because a scalar row poisoned
+    -- it (#89), and cerefox_set_document_metadata refuses a non-object patch.
+    -- The MCP handler has always validated this. This RPC did not, and it is
+    -- reachable from the CLI, contributor scripts, PostgREST and psql — so the
+    -- invalid state was creatable by every caller that did not go through MCP,
+    -- and was then silently destroyed by the next metadata edit. Validating on
+    -- one path only is the shape #194 was opened against; this makes the two
+    -- write paths agree.
+    -- NULL stays legal: it means "not provided", and the branches below
+    -- coalesce it to the stored value (update) or '{}' (create).
+    IF p_metadata IS NOT NULL AND jsonb_typeof(p_metadata) <> 'object' THEN
+        RAISE EXCEPTION
+            'cerefox_ingest_document: metadata must be a JSON object, got % (title=%). A JSON string, array or scalar cannot survive a metadata edit.',
+            jsonb_typeof(p_metadata), p_title
+            USING ERRCODE = '22023';  -- invalid_parameter_value
+    END IF;
+
     -- Validate review_status
     v_status := CASE WHEN p_review_status IN ('approved', 'pending_review')
                      THEN p_review_status ELSE 'approved' END;
@@ -2539,6 +2560,9 @@ SET search_path = public, pg_catalog
 AS $$
     -- Keep in lockstep with the `@version:` marker in schema.sql (cut_release.ts
     -- enforces it). Bump whenever schema.sql OR rpcs.sql changes.
+    -- 0.11.4: cerefox_ingest_document refuses non-object metadata, matching
+    -- the MCP handler. Closes the path that created the rows `document edit`
+    -- then destroyed by spreading them.
     -- 0.11.3 (#204): cerefox_set_document_metadata — metadata-only writes.
     -- 0.11.2 (iteration 36): RLS enabled on cerefox_document_relations,
     -- which iteration 29 left off the list (Supabase rls_disabled_in_public).
@@ -2546,7 +2570,7 @@ AS $$
     -- 0.11.0 supersedes 0.10.6 (v1.2.1, #191): this branch carries that fix plus
     -- the partial-edit surface, and both migrations (0019, 0020) are in the
     -- sequence, so a store deploying this gets everything from both lines.
-    SELECT '0.11.3'::TEXT;
+    SELECT '0.11.4'::TEXT;
 $$;
 
 -- ── cerefox_content_format_stats ─────────────────────────────────────────────

--- a/src/cerefox/db/schema.sql
+++ b/src/cerefox/db/schema.sql
@@ -5,7 +5,7 @@
 -- Requires extensions: vector (pgvector), uuid-ossp
 -- These are enabled at the top of db_deploy.py before this file is applied.
 --
--- @version: 0.11.3
+-- @version: 0.11.4
 -- The `@version` marker above is read by the schema-version-mismatch banner
 -- (see /api/v1/schema-version). Bump it whenever schema.sql OR rpcs.sql
 -- changes in a way that requires `cerefox server deploy` to be re-run —


### PR DESCRIPTION
Fixes #212.

### What was wrong

Two defects that compose. One creates documents whose `metadata` is not a JSON object; the other silently destroys them.

**The RPC accepted what the MCP layer rejects.** `metadata` is JSONB, so the column takes any JSON value, but every reader treats it as an object: `document edit` rebuilds it with a spread, the listing query filters on `jsonb_typeof` because a scalar row poisoned it (#89), and `cerefox_set_document_metadata` refuses a non-object patch. The MCP handler has always validated the input. `cerefox_ingest_document` did not, and it is reachable from the CLI, contributor scripts, PostgREST and psql, so the invalid state was creatable by every caller that did not go through MCP. Validating on one path only is the shape #194 was opened against.

**`document edit` then decomposed such a value instead of copying it.**

```ts
const metadata: Record<string, unknown> = { ...(doc.metadata ?? {}) };
```

A stored JSON string becomes one key per character, an array becomes integer-indexed keys, a number or boolean becomes `{}`. The write was unconditional, the command printed `✓ Edited`, and metadata has no version history, so the original value was gone with nothing to roll back to.

**And a title-only edit rewrote metadata too.** The update payload always carried `metadata`:

```ts
.update({ title: newTitle, metadata, updated_at: ... })
```

so `cerefox document edit <id> --title "New title"` destroyed non-object metadata as well. That is the most surprising form, because nothing on the command line mentions metadata.

### What this changes

**Server (`rpcs.sql`)**

- `cerefox_ingest_document` raises `22023` when `p_metadata` is present and not an object, with the offending `jsonb_typeof` in the message.
- `NULL` stays legal. It means "not provided", and the branches below coalesce it to the stored value on update and `'{}'` on create, so partial updates are unaffected.

**Client (`document-edit.ts`)**

- Refuses a document whose stored metadata is not an object, rather than spreading it, and names the repair path.
- Attaches `metadata` to the update only when `--set-meta` or `--unset-meta` was passed, so `--title` alone cannot touch it.

**The repair path names `--replace` deliberately**

```
cerefox document set-metadata <id> --replace --json '<the intended object>'
```

`set-metadata` is the right surface: metadata-only, no content resend, and it touches neither `source` nor `title`. But its default is merge, and the merge is `COALESCE(v_before,'{}'::jsonb) || p_metadata`. On exactly the rows this guard catches, Postgres treats the non-object left side as an array, so a default merge produces `[<the corrupt value>, {<the patch>}]`: still not an object, and the original value is now nested a level deeper. Verified on PostgreSQL 17.7:

```sql
SELECT '"{\"a\":1}"'::jsonb || '{"note":"hello"}'::jsonb;  -- ["{\"a\":1}", {"note": "hello"}]
SELECT '["a","b"]'::jsonb   || '{"note":"hello"}'::jsonb;  -- ["a", "b", {"note": "hello"}]
SELECT '42'::jsonb          || '{"note":"hello"}'::jsonb;  -- [42, {"note": "hello"}]
```

Without `--replace` the repair would look like a fix and leave the row broken.

### Scope

Existing rows are untouched. This closes the path that creates them and the command that destroys them; repairing what is already stored is the operator's call. Migration `0024` carries the query that finds them:

```sql
SELECT id, title FROM cerefox_documents WHERE jsonb_typeof(metadata) <> 'object';
```

That query may be worth adding to `cerefox doctor`, but it is not in this change.

Schema `0.11.3` → `0.11.4`. Migration 0024 is NOTICE-only, following 0023: the guard ships inside `rpcs.sql`, which `cerefox server deploy` re-applies wholesale, so the migration exists to advance the version in step. `minSchema` is deliberately not raised: the guard is server-side and no client requires it.

This is a behaviour change rather than a pure addition. An ingest whose metadata is a string, array or scalar now fails where it previously succeeded. That input has never been readable as intended by anything downstream, so the failure surfaces a bug at the caller instead of storing a value the next edit would destroy.

### Not in scope

A concurrency token for metadata edits. `document edit` writes through a raw PostgREST update rather than `cerefox_ingest_document`, so it bypasses the `p_expected_content_hash` / `CEREFOX_CONFLICT` machinery entirely, and two concurrent metadata edits still last-write-wins. That is a design question rather than a data-loss fix, and `cerefox_set_document_metadata` already offers a row-locked path for callers who need one.

### Tests

`packages/memory/test/document-edit-metadata.test.ts`, asserted at the source level in the spirit of `ingest-source-default.test.ts`: both defects live in how the payload is assembled, above the database, so a round-trip test against a healthy document passes the whole time they are live. The RPC guard is asserted in the same file, scoped to the body of `cerefox_ingest_document` so a guard elsewhere in `rpcs.sql` cannot satisfy it by accident, because the two halves are one fix.

Each half was reverted and the suite re-run to confirm the tests fail without it: 7 of 8 fail against the pre-fix tree, and the one that passes asserts the pre-existing `COALESCE` behaviour, which is correct.

`_shared` suite: 526 pass, 0 fail. Typecheck clean on both packages.
