### PR TITLE
v1.9.1: fix project-edit description audit (v1.9.0 regression, caught on staging)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,21 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
-Open roadmap.
+### Fixed
+
+- **Project description edits no longer fail (v1.9.0 regression, caught in
+  the staging dress rehearsal before any production deployment).**
+  `cerefox_update_project` appended its audit-diff fragment with
+  `v_changes || 'description changed'`; Postgres resolves the untyped
+  literal via the array||array overload and raises `malformed array
+  literal`, rolling back every project edit that changed a description
+  (rename-only edits worked). Both branches now use `array_append`;
+  migration 0029 re-ships the corrected function. Schema 0.14.0 → 0.14.1.
+- **The gated live remote-MCP suite matches the current server contract**:
+  the 15-tool core surface (its list was stale at 10 from before v1.3–v1.7)
+  and in-band MCP tool errors (`isError`) for validation failures instead of
+  JSON-RPC protocol codes. The release-acceptance project case now covers a
+  description-only edit — the exact branch the regression lived in.
 
 ---
 

--- a/_shared/__tests__/rpc-guard-invariants.test.ts
+++ b/_shared/__tests__/rpc-guard-invariants.test.ts
@@ -231,10 +231,22 @@ describe("store-level writes join the audit trail (0.14.0, #147)", () => {
     };
     // set_config is excluded: its rpcs.sql form is CREATE FUNCTION with
     // narrative comments; its migration copy is checked by the key-lockstep
-    // and content tests instead.
-    for (const fn of ["cerefox_create_project", "cerefox_update_project", "cerefox_delete_project"]) {
-      expect(bodyOf(MIG, fn)).toBe(bodyOf(RPCS, fn));
+    // and content tests instead. Each body is compared against the LATEST
+    // migration that carries it (0029 re-ships update_project's fix).
+    const MIG29 = readFileSync(
+      join(import.meta.dir, "..", "..", "src", "cerefox", "db", "migrations", "0029_fix_project_edit_description_audit.sql"),
+      "utf8",
+    );
+    for (const [fn, mig] of [
+      ["cerefox_create_project", MIG],
+      ["cerefox_update_project", MIG29],
+      ["cerefox_delete_project", MIG],
+    ] as const) {
+      expect(bodyOf(mig, fn)).toBe(bodyOf(RPCS, fn));
     }
+    // The bug class itself: no untyped-literal array append may return.
+    expect(bodyOf(RPCS, "cerefox_update_project")).toContain("array_append");
+    expect(bodyOf(RPCS, "cerefox_update_project")).not.toMatch(/v_changes \|\| '/);
   });
 
   test("migration 0028 locks down every function it creates (REVOKE PUBLIC)", () => {

--- a/packages/memory/test/acceptance/release-acceptance.test.ts
+++ b/packages/memory/test/acceptance/release-acceptance.test.ts
@@ -435,6 +435,11 @@ describe("release acceptance (live)", () => {
     const edited = A.cli(["project", "edit", NAME, "--name", RENAMED, "--author", "acceptance"]);
     expect(edited.code).toBe(0);
 
+    // Description-only edit — the v1.9.0 staging catch: the RPC's untyped
+    // array append killed exactly this branch (rename-only worked).
+    const descEdit = A.cli(["project", "edit", RENAMED, "--description", "battery probe", "--author", "acceptance"]);
+    expect(descEdit.code).toBe(0);
+
     const deleted = A.cli(["project", "delete", RENAMED, "--yes", "--author", "acceptance"]);
     expect(deleted.code).toBe(0);
 
@@ -443,6 +448,7 @@ describe("release acceptance (live)", () => {
     expect(creates).toContain(`Project '${NAME}' created`);
     const edits = (await A.mcp("cerefox_get_audit_log", { operation: "project-edit", limit: 10 })).text;
     expect(edits).toContain(`renamed '${NAME}' → '${RENAMED}'`);
+    expect(edits).toContain("description changed");
     const deletes = (await A.mcp("cerefox_get_audit_log", { operation: "project-delete", limit: 10 })).text;
     expect(deletes).toContain(`Project '${RENAMED}' deleted`);
     // Store-level rows render as "(store)", never "(deleted)".

--- a/packages/memory/test/mcp-remote/mcp-remote.test.ts
+++ b/packages/memory/test/mcp-remote/mcp-remote.test.ts
@@ -133,20 +133,28 @@ describe("cerefox-mcp remote (JSON-RPC over HTTP)", () => {
       expect(resp.result.serverInfo.name).toBe("cerefox");
     });
 
-    test("tools/list returns all 10 tools with schemas", async () => {
+    test("tools/list returns the 15 core tools with schemas", async () => {
       const resp = await rpc("tools/list");
       expect(resp.error).toBeUndefined();
       const names = new Set((resp.result.tools as Array<{ name: string }>).map((t) => t.name));
+      // The 15-tool core surface (relations dormant by default). This list
+      // was stale at 10 from before v1.3–v1.7 grew the surface — the suite
+      // is gated and had not run across those releases.
       const expected = [
         "cerefox_search",
         "cerefox_ingest",
-        "cerefox_list_metadata_keys",
+        "cerefox_insert",
+        "cerefox_edit",
         "cerefox_get_document",
         "cerefox_list_versions",
         "cerefox_get_audit_log",
         "cerefox_list_projects",
+        "cerefox_list_metadata_keys",
         "cerefox_metadata_search",
         "cerefox_set_document_projects",
+        "cerefox_set_document_metadata",
+        "cerefox_delete_document",
+        "cerefox_restore_document",
         "cerefox_get_help",
       ];
       for (const name of expected) expect(names.has(name)).toBe(true);
@@ -259,14 +267,19 @@ describe("cerefox-mcp remote (JSON-RPC over HTTP)", () => {
       expect(text === "No metadata keys found across documents." || text.startsWith("[")).toBe(true);
     });
 
-    test("missing required param → -32602", async () => {
+    test("missing required param → in-band tool error (isError)", async () => {
+      // The server reports validation failures as MCP tool results with
+      // isError, not JSON-RPC protocol errors — the modern MCP convention.
       const resp = await tool("cerefox_search", {});
-      expect(resp.error?.code).toBe(-32602);
+      expect(resp.error).toBeUndefined();
+      expect(resp.result?.isError).toBe(true);
+      expect(JSON.stringify(resp.result)).toContain("query is required");
     });
 
-    test("ingest missing content → -32602", async () => {
+    test("ingest missing content → in-band tool error", async () => {
       const resp = await tool("cerefox_ingest", { title: "No Content" });
-      expect(resp.error?.code).toBe(-32602);
+      expect(resp.error).toBeUndefined();
+      expect(resp.result?.isError).toBe(true);
     });
   });
 
@@ -298,9 +311,12 @@ describe("cerefox-mcp remote (JSON-RPC over HTTP)", () => {
       expect(text).toContain("No documents match");
     });
 
-    test("metadata_search empty filter → error", async () => {
+    test("metadata_search empty filter without any other scope → tool error", async () => {
+      // Since v0.11.1 an empty filter is legal WITH another scope
+      // (project/time); alone it is refused as an in-band tool error.
       const resp = await tool("cerefox_metadata_search", { metadata_filter: {} });
-      expect(resp.error).toBeDefined();
+      expect(resp.error).toBeUndefined();
+      expect(resp.result?.isError).toBe(true);
     });
 
     test("metadata_search with project_name", async () => {
@@ -351,14 +367,16 @@ describe("cerefox-mcp remote (JSON-RPC over HTTP)", () => {
       expect(t2).toContain(docId);
     });
 
-    test("ingest by document_id not found → -32603", async () => {
+    test("ingest by document_id not found → in-band tool error", async () => {
       const resp = await tool("cerefox_ingest", {
         title: "Ghost",
         content: "# Ghost\n\nc.",
         document_id: crypto.randomUUID(),
         author: "e2e-mcp-test",
       });
-      expect(resp.error?.code).toBe(-32603);
+      expect(resp.error).toBeUndefined();
+      expect(resp.result?.isError).toBe(true);
+      expect(JSON.stringify(resp.result).toLowerCase()).toContain("not found");
     });
 
     test("ingest by document_id with update_if_exists=false → note", async () => {

--- a/src/cerefox/db/migrations/0029_fix_project_edit_description_audit.sql
+++ b/src/cerefox/db/migrations/0029_fix_project_edit_description_audit.sql
@@ -1,0 +1,105 @@
+-- Migration 0029 — fix cerefox_update_project's description-change audit
+-- (schema 0.14.1)
+--
+-- v1.9.0's cerefox_update_project appended the audit-diff fragment with
+-- `v_changes || 'description changed'`; Postgres resolves the untyped
+-- literal via the array||array overload and raises `malformed array
+-- literal`, rolling back EVERY project edit that changes a description
+-- (rename-only edits worked — their concatenation is typed TEXT). Found
+-- live in the v1.9.0 staging dress rehearsal before any production
+-- deployment. The fix is array_append on both branches.
+--
+-- The full corrected body ships inside this migration (repair-path closure,
+-- as 0027/0028), plus the same ACL lockdown 0028 gave the original.
+-- Re-runnable.
+
+DROP FUNCTION IF EXISTS cerefox_update_project(UUID, TEXT, TEXT, TEXT, TEXT);
+
+CREATE FUNCTION cerefox_update_project(
+    p_project_id  UUID,
+    -- NULL = keep the current value (the #191/#204 "NULL means not provided"
+    -- convention). An explicit empty name is rejected.
+    p_name        TEXT DEFAULT NULL,
+    p_description TEXT DEFAULT NULL,
+    p_author      TEXT DEFAULT 'unknown',
+    p_author_type TEXT DEFAULT 'user'
+)
+RETURNS TABLE (
+    project_id          UUID,
+    project_name        TEXT,
+    project_description TEXT,
+    created_at          TIMESTAMPTZ,
+    updated_at          TIMESTAMPTZ
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+DECLARE
+    v_old  cerefox_projects%ROWTYPE;
+    v_new  cerefox_projects%ROWTYPE;
+    v_changes TEXT[] := '{}';
+BEGIN
+    IF p_name IS NULL AND p_description IS NULL THEN
+        RAISE EXCEPTION 'Nothing to update: pass p_name and/or p_description' USING ERRCODE = '22023';
+    END IF;
+    IF p_name IS NOT NULL AND NULLIF(BTRIM(p_name), '') IS NULL THEN
+        RAISE EXCEPTION 'Project name cannot be empty' USING ERRCODE = '22023';
+    END IF;
+
+    SELECT p.* INTO v_old FROM cerefox_projects p WHERE p.id = p_project_id FOR UPDATE;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'Project not found: %', p_project_id USING ERRCODE = '22023';
+    END IF;
+
+    UPDATE cerefox_projects SET
+        name        = COALESCE(BTRIM(p_name), name),
+        description = COALESCE(p_description, description),
+        updated_at  = NOW()
+    WHERE id = p_project_id
+    RETURNING * INTO v_new;
+
+    -- The trail records what actually changed, not which arguments arrived.
+    -- array_append, NOT `||`: with an untyped string literal on the right,
+    -- `TEXT[] || 'literal'` resolves to the array||array overload and dies
+    -- with `malformed array literal` — found LIVE on staging (v1.9.0; every
+    -- description-only edit failed; the rename branch only survived because
+    -- its parenthesized concatenation is typed TEXT).
+    IF v_new.name <> v_old.name THEN
+        v_changes := array_append(v_changes, 'renamed ''' || v_old.name || ''' → ''' || v_new.name || '''');
+    END IF;
+    IF COALESCE(v_new.description, '') <> COALESCE(v_old.description, '') THEN
+        v_changes := array_append(v_changes, 'description changed');
+    END IF;
+
+    PERFORM cerefox_create_audit_entry(
+        p_operation   := 'project-edit',
+        p_author      := p_author,
+        p_author_type := p_author_type,
+        p_description := 'Project ''' || v_new.name || ''' edited ('
+            || COALESCE(NULLIF(array_to_string(v_changes, '; '), ''), 'no-op') || ')'
+    );
+    RETURN QUERY SELECT v_new.id, v_new.name, v_new.description,
+                        v_new.created_at, v_new.updated_at;
+END;
+$$;
+
+DO $$
+DECLARE
+  r TEXT;
+BEGIN
+  REVOKE EXECUTE ON FUNCTION cerefox_update_project(UUID, TEXT, TEXT, TEXT, TEXT) FROM PUBLIC;
+  FOREACH r IN ARRAY ARRAY['anon', 'authenticated'] LOOP
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = r) THEN
+      EXECUTE format('REVOKE EXECUTE ON FUNCTION cerefox_update_project(UUID, TEXT, TEXT, TEXT, TEXT) FROM %I', r);
+    END IF;
+  END LOOP;
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'service_role') THEN
+    GRANT EXECUTE ON FUNCTION cerefox_update_project(UUID, TEXT, TEXT, TEXT, TEXT) TO service_role;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+    RAISE NOTICE 'Migration 0029: fixed the project-edit description audit (array_append; description-only edits no longer fail).';
+END $$;

--- a/src/cerefox/db/rpcs.sql
+++ b/src/cerefox/db/rpcs.sql
@@ -2118,11 +2118,16 @@ BEGIN
     RETURNING * INTO v_new;
 
     -- The trail records what actually changed, not which arguments arrived.
+    -- array_append, NOT `||`: with an untyped string literal on the right,
+    -- `TEXT[] || 'literal'` resolves to the array||array overload and dies
+    -- with `malformed array literal` — found LIVE on staging (v1.9.0; every
+    -- description-only edit failed; the rename branch only survived because
+    -- its parenthesized concatenation is typed TEXT).
     IF v_new.name <> v_old.name THEN
-        v_changes := v_changes || ('renamed ''' || v_old.name || ''' → ''' || v_new.name || '''');
+        v_changes := array_append(v_changes, 'renamed ''' || v_old.name || ''' → ''' || v_new.name || '''');
     END IF;
     IF COALESCE(v_new.description, '') <> COALESCE(v_old.description, '') THEN
-        v_changes := v_changes || 'description changed';
+        v_changes := array_append(v_changes, 'description changed');
     END IF;
 
     PERFORM cerefox_create_audit_entry(
@@ -3012,7 +3017,7 @@ AS $$
     -- 0.11.0 supersedes 0.10.6 (v1.2.1, #191): this branch carries that fix plus
     -- the partial-edit surface, and both migrations (0019, 0020) are in the
     -- sequence, so a store deploying this gets everything from both lines.
-    SELECT '0.14.0'::TEXT;
+    SELECT '0.14.1'::TEXT;
 $$;
 
 -- ── cerefox_find_dead_links ──────────────────────────────────────────────────

--- a/src/cerefox/db/schema.sql
+++ b/src/cerefox/db/schema.sql
@@ -5,7 +5,7 @@
 -- Requires extensions: vector (pgvector), uuid-ossp
 -- These are enabled at the top of db_deploy.py before this file is applied.
 --
--- @version: 0.14.0
+-- @version: 0.14.1
 -- The `@version` marker above is read by the schema-version-mismatch banner
 -- (see /api/v1/schema-version). Bump it whenever schema.sql OR rpcs.sql
 -- changes in a way that requires `cerefox server deploy` to be re-run —


### PR DESCRIPTION
The v1.9.0 staging dress rehearsal caught a release-blocking regression before production ever saw it: **every project edit that changes a description failed** with `malformed array literal: "description changed"` — plpgsql resolved the untyped literal in `v_changes || 'description changed'` via the array||array overload. Rename-only edits worked (typed concatenation), which is exactly why the sandbox probe missed it.

## Summary
- `cerefox_update_project`: both diff branches use `array_append`; migration **0029** re-ships the corrected body verbatim + ACL lockdown; schema **0.14.0 → 0.14.1**.
- Coverage that closes the gap: sandbox probe now exercises description-only and combined edits (24/24 on the 0028+0029 chain); the acceptance project case gained a description-only edit; a new invariant forbids the untyped-literal append pattern.
- The gated live remote-MCP suite modernized to the actual server contract (15 core tools; in-band `isError` validation failures) — its expectations were stale from before v1.3 and verified against the live staging server before changing.

## Test plan
- [x] Sandbox 24/24 (v1.8.0-state pg16 → 0028 → 0029 → rpcs refresh converges at 0.14.1)
- [x] Invariants 23/23 incl. verbatim body-compare against migration 0029
- [x] typecheck clean
- [ ] After cut: staging re-verify (description edit round-trip live), then prod gets v1.9.1 directly (v1.9.0 never reaches production)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sjKuLfk74MYdrhKohVD2j