### PR TITLE
API attribution, optimistic locking everywhere, and a test suite that had stopped running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,25 +22,37 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
   app and every existing client are unaffected. `author` and `requestor` stand
   in for each other, and `author_type: "agent"` queues an ingest for review
   exactly as it does over MCP — that equivalence is the point.
+- **`DELETE /api/v1/documents/{id}` requires the content hash from an
+  identified caller**, as `X-Cerefox-Expected-Content-Hash` or an
+  `expected_content_hash` query parameter — the same "a delete must follow a
+  read" rule `cerefox_delete_document` enforces over MCP. The route previously
+  passed no CAS token at all, which was defensible while its only caller was
+  the web UI, where a human sees the document and confirms in a dialog.
+  Identified callers have no such dialog. An anonymous caller is the bundled
+  UI and is unaffected.
 - **A new `api` access path**, derived rather than accepted: name yourself and
   the operation logs as `api`, otherwise `webapp`. There is deliberately no way
   to request a particular access path, because it is the one field in the usage
   log the server still sets itself. The Dashboard counts `api` toward agent
   operations and the Analytics filter offers it.
-- **`docs/guides/api.md`**, the first reference for the HTTP API: what it is,
-  the caller-attribution contract, the full endpoint list, and a plain
-  statement that the surface has **no authentication** and is loopback-bound by
-  design.
+- **`docs/guides/api.md`**, the first reference for the HTTP API: the
+  caller-attribution contract, the concurrency rules, and the full endpoint
+  list — opening with an unmissable statement that the surface has **no
+  authentication of any kind** and is **for local access only**. Not to be
+  exposed to a LAN, a tunnel, or a TLS-only reverse proxy: encryption is not
+  authorization. Adding a locally generated key is tracked as #229.
 
 ### Fixed
 
 - **`POST /api/v1/documents/{id}/upload` has failed on every call since
   v0.11.0 (#228).** It passed neither `expected_content_hash` nor
-  `last_write_wins`, so the concurrency contract introduced in v0.11.0
-  rejected it every time. It now accepts the hash optionally and defaults to
-  last-write-wins, which is the file-re-sync case the design names. The bundled
-  web app never calls this endpoint, so nothing user-visible broke; API clients
-  got a hard stop.
+  `last_write_wins`, so the concurrency contract introduced in v0.11.0 rejected
+  it every time. It now takes the same contract as every other content update:
+  send the hash you read, or say `last_write_wins=true` explicitly. There is no
+  implicit default — the endpoint has been a hard error for eleven releases, so
+  there is no working caller to stay compatible with and the strict semantics
+  cost nothing. The bundled web app never calls this endpoint; API clients got
+  a hard stop.
 - **`cerefox doctor` named the wrong config file (#225).** The `legacy env`
   check hardcoded `~/.cerefox/.env` instead of asking the resolver, so under
   `CEREFOX_CONFIG_DIR` it contradicted the `config` line four rows above it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,84 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
-Open roadmap.
+### Added
+
+- **`/api/v1` accepts an optional caller identity (#226).** `author`,
+  `requestor` and `author_type`, as `X-Cerefox-Author` /
+  `X-Cerefox-Requestor` / `X-Cerefox-Author-Type` headers on any method, or as
+  fields in the JSON body / multipart form where a route has one (a header
+  wins). The API hardcoded `author: "web-ui"` at 17 call sites, so any client
+  but the bundled web app was unattributable — which pushed agent harnesses
+  onto MCP purely to obtain an identity. **Omitted, nothing changes**: the
+  stored audit and usage rows are byte-identical to before, so the bundled web
+  app and every existing client are unaffected. `author` and `requestor` stand
+  in for each other, and `author_type: "agent"` queues an ingest for review
+  exactly as it does over MCP — that equivalence is the point.
+- **A new `api` access path**, derived rather than accepted: name yourself and
+  the operation logs as `api`, otherwise `webapp`. There is deliberately no way
+  to request a particular access path, because it is the one field in the usage
+  log the server still sets itself. The Dashboard counts `api` toward agent
+  operations and the Analytics filter offers it.
+- **`docs/guides/api.md`**, the first reference for the HTTP API: what it is,
+  the caller-attribution contract, the full endpoint list, and a plain
+  statement that the surface has **no authentication** and is loopback-bound by
+  design.
+
+### Fixed
+
+- **`POST /api/v1/documents/{id}/upload` has failed on every call since
+  v0.11.0 (#228).** It passed neither `expected_content_hash` nor
+  `last_write_wins`, so the concurrency contract introduced in v0.11.0
+  rejected it every time. It now accepts the hash optionally and defaults to
+  last-write-wins, which is the file-re-sync case the design names. The bundled
+  web app never calls this endpoint, so nothing user-visible broke; API clients
+  got a hard stop.
+- **`cerefox doctor` named the wrong config file (#225).** The `legacy env`
+  check hardcoded `~/.cerefox/.env` instead of asking the resolver, so under
+  `CEREFOX_CONFIG_DIR` it contradicted the `config` line four rows above it.
+  It also fired on any `<cwd>/.env` whatsoever, without the `CEREFOX_*`-key
+  test the resolver has used since iter-24 — so running `cerefox` inside an
+  unrelated project named that project's config file and called it "Safe to
+  delete."
+- **The web-integration test suite had been skipping since v0.9.0.** Its
+  Supabase probe shelled out to `cerefox list-projects`, renamed to
+  `project list` in v0.9.0; the renamed-verb husk exits non-zero by design and
+  the probe read that as "backend unreachable". Eleven releases of a green
+  suite running nothing, and the reason #228 went unnoticed. The probe is now
+  one shared implementation that throws when the CLI rejects the probe command,
+  because "the backend is down" and "that command no longer exists" are
+  different answers and only the first justifies a skip.
+- **The destructive web tests no longer spend Edge Function quota.** They built
+  their fixture through the deployed `cerefox-ingest` function, a workaround
+  from v0.6 when `/api/v1/ingest` was a 503 stub. They now ingest over HTTP
+  like every other test in that directory.
+- **Two tests failed under the documented staging invocation**
+  (`CEREFOX_CONFIG_DIR=… bun test`), both environment-sensitivity in the tests
+  rather than product bugs. A red test under the command the guides give
+  teaches people that red is normal.
+- **Audit authorship is consistent across the web routes.** Review-status
+  changes and version archives recorded `author: "user"` while every other web
+  write recorded `"web-ui"`, so an `author='web-ui'` filter silently missed
+  both. Existing rows are unchanged.
+
+### Changed
+
+- **The repo-root `docker-compose.yml` publishes to `127.0.0.1` (#227).** Its
+  short `"8000:8000"` / `"5432:5432"` form binds the host's `0.0.0.0`, so it
+  exposed an unauthenticated write API and a database with in-file credentials
+  to the local network. Both shipped local paths (`docker/local/`) already bind
+  loopback deliberately; this file contradicted them. `--host 0.0.0.0` in the
+  `Dockerfile` CMD is correct and stays: the container's loopback is not the
+  host's, so the bind must be broad and the publish narrow.
+- **`require_requestor_identity` documents what it actually covers.** It is
+  enforced by the Edge Functions only, including remote MCP — **not** by the
+  local stdio MCP server, `/api/v1`, or the CLI. No behaviour change; the
+  setting's name promised more than it delivered and an operator enabling it
+  deserves to know where the gaps are.
+- **The root `typecheck` script now includes the frontend.** `tsc --noEmit` in
+  `frontend/` checks nothing (its `tsconfig.json` is `files: []` plus project
+  references), so a local typecheck silently skipped the whole SPA. CI built it
+  and was unaffected.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,11 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
   stored audit and usage rows are byte-identical to before, so the bundled web
   app and every existing client are unaffected. `author` and `requestor` stand
   in for each other, and `author_type: "agent"` queues an ingest for review
-  exactly as it does over MCP — that equivalence is the point.
+  exactly as it does over MCP — that equivalence is the point. The identity is
+  **declared, not verified**: it is a label for attribution and record-keeping
+  (the audit trail, usage analytics, the review queue), not a credential and
+  not a security measure. Nothing checks it, exactly as nothing checks `author`
+  over MCP.
 - **`DELETE /api/v1/documents/{id}` requires the content hash from an
   identified caller**, as `X-Cerefox-Expected-Content-Hash` or an
   `expected_content_hash` query parameter — the same "a delete must follow a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,8 +119,8 @@ lifecycle/server commands (`init`, `doctor`, `status`, `configure-agent`,
 - **Fire-and-forget ingestion**: ingestion can be async; failures log errors but don't block
 - **Parameterized limits**: response size limits, chunk sizes, etc. are configurable via settings
 - **Two-table design**: `cerefox_documents` (document-level) + `cerefox_chunks` (chunk-level) for clean separation
-- **Usage tracking**: `cerefox_usage_log` logs all operations (reads and writes); `cerefox_config` stores runtime config (e.g., `usage_tracking_enabled`). Opt-in; controlled via RPC, not env vars. `cerefox_log_usage` RPC checks config on every call and returns immediately when disabled. Each entry records `requestor` (who: agent name or "user") and `access_path` (where: remote-mcp, local-mcp, edge-function, webapp, cli).
-- **Requestor enforcement**: optional `require_requestor_identity` config (default false) makes `requestor`/`author` mandatory on MCP tool calls. Optional `requestor_identity_format` config validates against a regex pattern. Both controlled via `cerefox_config`.
+- **Usage tracking**: `cerefox_usage_log` logs all operations (reads and writes); `cerefox_config` stores runtime config (e.g., `usage_tracking_enabled`). Opt-in; controlled via RPC, not env vars. `cerefox_log_usage` RPC checks config on every call and returns immediately when disabled. Each entry records `requestor` (who: agent name or "user") and `access_path` (where: remote-mcp, local-mcp, edge-function, webapp, cli, api). The domain is defined ONCE in `_shared/mcp-tools/access-paths.ts` and everything else derives from it — the column itself is free text with no CHECK, so that type is the guard. `api` means `/api/v1` called by a client that identified itself (v1.11.0, #226); `webapp` means the same routes with no identity supplied.
+- **Requestor enforcement**: optional `require_requestor_identity` config (default false) makes `requestor`/`author` mandatory, and optional `requestor_identity_format` validates them against a regex. Both controlled via `cerefox_config`. **Scope, stated precisely because the name promises more than it delivers: these are enforced by the Edge Functions only** — each of the 9 carries its own copy of the check, including `cerefox-mcp` (the REMOTE MCP transport). The **local stdio MCP server does not enforce them, and neither does `/api/v1`.** So enabling it does not make identity required everywhere. Making it global means one shared helper every transport calls, not a tenth copy of the block.
 
 ### Configuration
 - Config is loaded from `.env` / environment via `_shared/config/`
@@ -466,6 +466,7 @@ These live in `docs/guides/` and are written for someone who has never seen the 
 | `setup-local.md` | Full local Docker deployment |
 | `setup-cloud-run.md` | GCP Cloud Run deployment |
 | `access-paths.md` | All access layers, credentials, and integration paths |
+| `api.md` | The `/api/v1` HTTP API: its (absent) auth posture, caller attribution, endpoint list |
 | `connect-agents.md` | MCP setup for Claude, Cursor, and generic clients |
 | `configuration.md` | All `CEREFOX_` environment variables with defaults |
 | `linking.md` | Document links: forms, the write-time validation guardrail (why LLMs corrupt long ids), the dead-link sweep |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ Single-user, open-source (Apache 2.0), designed to be cheap/free to operate. See
 - **Shared TS modules**: `_shared/{config,db-client,db-status,embeddings,mcp-tools}/` — imported by both Edge Functions (Deno) and local server (Node/Bun) via structural typing
 - **Package management**: bun workspaces for TS
 - **Testing**: `bun test` (TypeScript) — the only test runner as of v0.9.0 (pytest retired; `tests/**/*.py` deleted)
-- **Type-checking**: `tsc --noEmit` for TS (`bun run typecheck`)
+- **Type-checking**: `bun run typecheck` — `tsc --noEmit` for `_shared` + `packages/memory`, `tsc -b` for the frontend (a plain `--noEmit` there checks nothing)
 
 ## Project Structure
 
@@ -81,7 +81,7 @@ cerefox/
 ## Development Conventions
 
 ### Code Style
-- Type-check TypeScript with `bun run typecheck` (`tsc --noEmit`)
+- Type-check TypeScript with `bun run typecheck` (covers `_shared`, `packages/memory` and the frontend)
 - Type hints on all public functions
 - Docstrings only where the purpose isn't obvious from the name/signature
 - Prefer simple, flat code over abstractions — don't create a helper for something used once

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ cd frontend && bun run test:e2e                         # UI e2e (Playwright)
 CEREFOX_LIVE_E2E=1 bun test test/edge-functions test/mcp-remote  # live EF e2e (opt-in)
 
 # Type-check
-bun run typecheck            # tsc --noEmit across _shared
+bun run typecheck            # tsc across _shared, packages/memory and the frontend (tsc -b)
 
 # Build frontend
 cd frontend && bun install && bun run build
@@ -244,7 +244,7 @@ If something needs fixing after a tag is published, **cut a new patch version**.
 
 PRs must pass these jobs before merge. Cold-cache wall clock is ~60-90 seconds. Live e2e tests (`CEREFOX_LIVE_E2E=1 bun test test/edge-functions test/mcp-remote`, `scripts/check_ef_parity.ts`) need Supabase credentials and are run manually by the maintainer before each cut — see `docs/research/v0.7-manual-test-plan.md` (the rolling test plan that spans v0.5 → v0.7).
 
-**Type-checking**: `bun run typecheck` (`tsc --noEmit` across `_shared`) is the TS quality gate. A dedicated formatter/linter (biome) is not yet wired.
+**Type-checking**: `bun run typecheck` (`tsc --noEmit` across `_shared` and `packages/memory`, plus `tsc -b` for the frontend — a plain `tsc --noEmit` in `frontend/` checks nothing, because its `tsconfig.json` is `files: []` plus project references) is the TS quality gate. A dedicated formatter/linter (biome) is not yet wired.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ Full setup for every client — plus a manual per-client config appendix for whe
 | [`docs/guides/agent-coordination.md`](docs/guides/agent-coordination.md) | Multi-agent coordination patterns and best practices |
 | [`docs/guides/response-limits.md`](docs/guides/response-limits.md) | Response size limits: per-path behaviour and tuning |
 | [`docs/guides/access-paths.md`](docs/guides/access-paths.md) | All access layers, credentials, and integration paths |
+| [`docs/guides/api.md`](docs/guides/api.md) | The `/api/v1` HTTP API: security posture, caller attribution, endpoints |
 | [`docs/guides/setup-local.md`](docs/guides/setup-local.md) | Local / self-hosted (Docker) backend — install, `cerefox-local`, MCP |
 | [`docs/guides/ops-scripts.md`](docs/guides/ops-scripts.md) | Backup, restore, migrate, sync docs |
 | [`docs/guides/setup-cloud-run.md`](docs/guides/setup-cloud-run.md) | Google Cloud Run deployment |

--- a/_shared/config-catalog/index.ts
+++ b/_shared/config-catalog/index.ts
@@ -49,7 +49,8 @@ export const CONFIG_CATALOG: ReadonlyArray<ConfigKeySpec> = [
   },
   {
     key: "require_requestor_identity",
-    description: "Require a requestor/author on MCP tool calls.",
+    description:
+      "Require a requestor/author. Enforced on the Edge Functions (incl. remote MCP) ONLY — not local MCP, /api/v1 or the CLI.",
     kind: "boolean",
     defaultValue: "false",
     group: "Governance",

--- a/_shared/config/index.ts
+++ b/_shared/config/index.ts
@@ -1,4 +1,5 @@
 export {
+  envFileHasCerefoxKey,
   isDevMode,
   resolveConfigDir,
   resolveEnvFile,

--- a/_shared/config/paths.ts
+++ b/_shared/config/paths.ts
@@ -78,14 +78,23 @@ export function resolveConfigDir(opts: ResolverOptions = {}): string {
   // leftover in the pre-iter-24 review; resolved here.
   const here = opts.cwd ?? processCwd();
   const cwdEnv = join(here, ".env");
-  if (existsSync(cwdEnv) && cwdEnvHasCerefoxKey(cwdEnv)) {
+  if (existsSync(cwdEnv) && envFileHasCerefoxKey(cwdEnv)) {
     return resolvePath(here);
   }
 
   return userState;
 }
 
-function cwdEnvHasCerefoxKey(envPath: string): boolean {
+/**
+ * `true` if `envPath` looks like a *Cerefox* env file, i.e. it declares at
+ * least one `CEREFOX_*` key.
+ *
+ * Exported (iter-40, #225) because `doctor` needs the same test: without it,
+ * the `legacy env` check reported any unrelated project's `.env` as a
+ * leftover Cerefox config and told the user it was safe to delete. The
+ * predicate was already the resolver's rule; it just wasn't shared.
+ */
+export function envFileHasCerefoxKey(envPath: string): boolean {
   try {
     const contents = readFileSync(envPath, "utf8");
     return /^\s*CEREFOX_[A-Z0-9_]+\s*=/m.test(contents);
@@ -119,7 +128,7 @@ export function isDevMode(opts: ResolverOptions = {}): boolean {
   // `.env` only counts as "Cerefox dev-mode" when it actually has a
   // CEREFOX_* key. An unrelated Node project's .env doesn't trip
   // dev-mode detection.
-  return existsSync(cwdEnv) && cwdEnvHasCerefoxKey(cwdEnv);
+  return existsSync(cwdEnv) && envFileHasCerefoxKey(cwdEnv);
 }
 
 /**

--- a/_shared/mcp-tools/access-paths.ts
+++ b/_shared/mcp-tools/access-paths.ts
@@ -1,0 +1,51 @@
+/**
+ * The `access_path` vocabulary — a dependency-free leaf module so the frontend
+ * can import it through the `@cerefox/access-paths` vite alias (same pattern
+ * as `@cerefox/audit-ops` and `@cerefox/schemas`) without dragging server-side
+ * helpers into the bundle. `_shared/mcp-tools/types.ts` re-exports the type
+ * for Node/Deno consumers; there is exactly ONE definition.
+ *
+ * **Why this is a shared const and not three literals** (iter-40, #226): the
+ * domain was previously written out by hand in three places — the `AccessPath`
+ * union here, `deriveAccessPathStats()` in the frontend, and the Analytics
+ * page's filter dropdown. A hand-maintained list that must match another
+ * hand-maintained list drifts; on this project that exact shape produced the
+ * missing RLS table, the unguarded test suites, and the Edge Function bundle
+ * allow-list. Adding `"api"` would have been the fourth instance.
+ *
+ * Now the union is derived from this array, and the frontend's label map is a
+ * `Record<AccessPath, string>`, so a value added here that is not given a
+ * label fails the frontend typecheck rather than quietly vanishing from a
+ * dropdown. `deriveAccessPathStats()` still resolves by name on purpose (an
+ * unknown path must not silently inflate the agent total) and is covered by
+ * its own tests.
+ *
+ * There is deliberately NO database CHECK on `cerefox_usage_log.access_path`
+ * (verified: the column is free text). This type is the guard.
+ */
+
+/**
+ * Logical channels through which a Cerefox operation can reach the backend.
+ *
+ *   - `remote-mcp`    — `cerefox-mcp` Edge Function (HTTP MCP transport).
+ *   - `local-mcp`     — `@cerefox/memory`'s stdio MCP bin.
+ *   - `cli`           — the `cerefox` CLI bin.
+ *   - `webapp`        — `/api/v1` called by the bundled web UI, i.e. a caller
+ *                       that supplied no identity of its own.
+ *   - `edge-function` — a primitive Cerefox Edge Function (GPT Actions,
+ *                       direct HTTP).
+ *   - `api`           — `/api/v1` called by something that named itself
+ *                       (#226). Derived from the presence of caller identity,
+ *                       never accepted from the request; see
+ *                       `packages/memory/src/web/identity.ts`.
+ */
+export const ACCESS_PATHS = [
+  "remote-mcp",
+  "local-mcp",
+  "cli",
+  "webapp",
+  "edge-function",
+  "api",
+] as const;
+
+export type AccessPath = (typeof ACCESS_PATHS)[number];

--- a/_shared/mcp-tools/types.ts
+++ b/_shared/mcp-tools/types.ts
@@ -16,6 +16,8 @@
  * each consumer; the handlers themselves are runtime-agnostic.
  */
 
+import type { AccessPath } from "./access-paths.ts";
+
 /** Structural type for the Supabase client surface the handlers actually
  *  use (`.rpc()` + `.from()`). We deliberately don't `import { SupabaseClient }
  *  from "@supabase/supabase-js"` here because Bun workspaces install a
@@ -42,23 +44,20 @@ export type JsonSchema = Record<string, unknown>;
 
 /**
  * Logical channel through which a Cerefox operation reached the backend.
- * Recorded in `cerefox_usage_log.access_path` so the analytics dashboard
- * can attribute load to each surface.
+ * Recorded in `cerefox_usage_log.access_path` so the analytics dashboard can
+ * attribute load to each surface.
  *
- * Values:
- *   - `remote-mcp`  — `cerefox-mcp` Edge Function (HTTP MCP transport).
- *   - `local-mcp`   — `@cerefox/memory`'s `cerefox-mcp` stdio bin.
- *   - `cli`         — the `cerefox` CLI bin (v0.5+). Mirrors the
- *                     Python CLI's `access_path = "cli"`.
+ * **Defined once** in the dependency-free leaf `./access-paths.ts`, and
+ * re-exported here so server-side callers keep importing it from `types.ts`.
+ * The values, and why the definition moved, are documented there.
  *
- * Adding a new channel here also requires updating
- * `cerefox_usage_log.access_path`'s documented domain (no DB CHECK exists —
- * verified in review; the column is free text and this type is the guard).
+ * Adding a channel means adding it to `ACCESS_PATHS` and then to
+ * `deriveAccessPathStats()` in the frontend, which resolves paths by exact
+ * name and deliberately ignores unknown ones. A value added to the vocabulary
+ * but not to the deriver is stored, charted, and invisible on the dashboard.
  */
-// The documented access_path domain (CLAUDE.md → usage tracking) — the type
-// had lagged at the three MCP-era values while webapp/edge-function callers
-// logged through wider-typed wrappers.
-export type AccessPath = "remote-mcp" | "local-mcp" | "cli" | "webapp" | "edge-function";
+export type { AccessPath };
+export { ACCESS_PATHS } from "./access-paths.ts";
 
 export interface ToolContext {
   /** OpenAI/Fireworks API key for tools that need to embed (search, ingest).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 
 # ── Cerefox local stack ────────────────────────────────────────────────────────
-# ⚠ UNTESTED end-to-end (tracked in docs/TODO.md). The `cerefox` service builds
+# ⚠ UNTESTED end-to-end. The `cerefox` service builds
 # the TypeScript web image (Dockerfile → `cerefox web`); the former Python/FastAPI
 # image was retired in v0.9.
 #
@@ -15,6 +15,12 @@ version: "3.9"
 #   docker compose up -d              # start everything
 #   docker compose up -d postgres     # start only the database
 #   docker compose logs -f cerefox   # watch the web UI logs
+#
+# Ports are published to 127.0.0.1 only. Cerefox has no authentication on
+# /api/v1 or on this Postgres, so exposing either beyond the host is a
+# decision to make deliberately, not a default to inherit. The supported local
+# install (docker/local/) does the same thing and offers CEREFOX_LOCAL_BIND for
+# the LAN case.
 
 services:
 
@@ -30,7 +36,10 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
     ports:
-      - "5432:5432"
+      # Loopback-only, matching docker/local/compose.yml and the installer
+      # (#227). Docker's short "5432:5432" form binds the HOST's 0.0.0.0, so
+      # this published a database with in-file credentials to the LAN.
+      - "127.0.0.1:5432:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U cerefox -d cerefox"]
       interval: 10s
@@ -67,7 +76,12 @@ services:
     volumes:
       - cerefox_data:/data
     ports:
-      - "8000:8000"
+      # Loopback-only (#227). /api/v1 has no authentication, so the short
+      # form published an unauthenticated write API on every interface.
+      # `--host 0.0.0.0` in the Dockerfile CMD is correct and stays: the
+      # container's own loopback is not the host's, so the BIND must be broad
+      # and the PUBLISH is what should be narrow.
+      - "127.0.0.1:8000:8000"
 
 volumes:
   postgres_data:

--- a/docs/e2e-use-cases.md
+++ b/docs/e2e-use-cases.md
@@ -191,6 +191,27 @@ bun test test/acceptance` (refuses unlabelled production targets).
 | acceptance | #147 config audit | A config change lands in the audit trail with author and old→new value (skips when the key is unset — writing would flip it to explicitly-set) | Done |
 | acceptance | #147/#219 project audit | Project create/edit/delete audit atomically via the RPCs: real diff recorded, "(store)" rendering, repeat delete adds no entry | Done |
 
+### 6E. HTTP API boundary (`packages/memory/test/web-integration/`, v1.11.0)
+
+Spawns a real `cerefox web` from `packages/memory/dist` and drives `/api/v1`
+over HTTP against a live database, asserting on the **stored rows**, not the
+responses. Probe-and-skip via the shared `_live-probe.ts`, which *throws* if
+the CLI rejects the probe command (the suite had skipped silently from v0.9.0
+to v1.10.1 because its probe used a renamed verb). Refuses an unlabelled
+(production) target. Self-cleans `[E2E web-attr]` / `[E2E …]` data.
+
+| Suite | Test | Use Case | Status |
+|-------|------|----------|--------|
+| attribution | default | No identity → audit `author='web-ui'`, `author_type='user'`, usage `access_path='webapp'`; the pre-#226 row byte for byte | Done |
+| attribution | named | `X-Cerefox-Author` + `X-Cerefox-Author-Type: agent` → recorded as itself, `access_path='api'`, document lands `pending_review` | Done |
+| attribution | body | Identity as JSON body fields is honoured | Done |
+| attribution | invalid type | `author_type: robot` → 400 naming the field, nothing stored | Done |
+| attribution | delete | Identified caller without hash → 400 `CEREFOX_TOKEN_REQUIRED`, document intact; with hash → 200 | Done |
+| attribution | anon delete | No identity, no hash → 200 (the bundled UI's path, unchanged) | Done |
+| attribution | read | `X-Cerefox-Requestor` on GET → usage row `requestor`/`access_path='api'` | Done |
+| ingest | upload | `POST /documents/{id}/upload` without token → 400 `CEREFOX_TOKEN_REQUIRED`; with `expected_content_hash` → replaced (#228, broken since v0.11.0) | Done |
+| destructive | fixture | Fixtures ingested over HTTP with `author_type: agent`, no Edge Function calls | Done |
+
 ### 7. Governance Features (future e2e)
 
 | # | Use Case | Status |

--- a/docs/guides/access-paths.md
+++ b/docs/guides/access-paths.md
@@ -216,6 +216,7 @@ single container with an internally-held token.
 | ChatGPT Custom GPT | HTTPS → primitive Edge Functions | Cerefox access token (`cfx_pat_…`) | AI assistant via GPT Actions |
 | curl / HTTP scripts | HTTPS → primitive Edge Functions | Cerefox access token (`cfx_pat_…`) | Ad-hoc queries, automation |
 | Web UI (`cerefox web`) | Supabase REST API | Secret key (or legacy service_role) | Web UI backend (TS Hono) |
+| **HTTP client → `/api/v1`** | Plain HTTP to `cerefox web` / Cerefox Local | **None** — loopback-bound by default | A local program or bot harness that wants HTTP rather than MCP. Identifies itself with `X-Cerefox-Author` / `X-Cerefox-Requestor` (v1.11.0). See [`api.md`](api.md) |
 | `cerefox` CLI (human) | Supabase REST API | Secret key (or legacy service_role) | Ingestion, search, reindex, backup |
 | Local coding agent via `cerefox` CLI | Supabase REST API | Secret key (or legacy service_role) | User-authorised agent (Claude Code, Codex CLI, opencode, OpenClaw, Hermes, …) acting on user's behalf via Bash tool |
 | `cerefox server deploy` / deployment scripts | Direct TCP | DB password | Schema deploy, data restore |

--- a/docs/guides/access-paths.md
+++ b/docs/guides/access-paths.md
@@ -216,7 +216,7 @@ single container with an internally-held token.
 | ChatGPT Custom GPT | HTTPS → primitive Edge Functions | Cerefox access token (`cfx_pat_…`) | AI assistant via GPT Actions |
 | curl / HTTP scripts | HTTPS → primitive Edge Functions | Cerefox access token (`cfx_pat_…`) | Ad-hoc queries, automation |
 | Web UI (`cerefox web`) | Supabase REST API | Secret key (or legacy service_role) | Web UI backend (TS Hono) |
-| **HTTP client → `/api/v1`** | Plain HTTP to `cerefox web` / Cerefox Local | **None** — loopback-bound by default | A local program or bot harness that wants HTTP rather than MCP. Identifies itself with `X-Cerefox-Author` / `X-Cerefox-Requestor` (v1.11.0). See [`api.md`](api.md) |
+| **HTTP client → `/api/v1`** | Plain HTTP to `cerefox web` / Cerefox Local | **None** — loopback-bound by default | A local program or bot harness that wants HTTP rather than MCP. Names itself with `X-Cerefox-Author` / `X-Cerefox-Requestor` (v1.11.0): a declared label for attribution, not a verified identity. See [`api.md`](api.md) |
 | `cerefox` CLI (human) | Supabase REST API | Secret key (or legacy service_role) | Ingestion, search, reindex, backup |
 | Local coding agent via `cerefox` CLI | Supabase REST API | Secret key (or legacy service_role) | User-authorised agent (Claude Code, Codex CLI, opencode, OpenClaw, Hermes, …) acting on user's behalf via Bash tool |
 | `cerefox server deploy` / deployment scripts | Direct TCP | DB password | Schema deploy, data restore |

--- a/docs/guides/api.md
+++ b/docs/guides/api.md
@@ -1,0 +1,182 @@
+# The `/api/v1` HTTP API
+
+`cerefox web` serves a JSON API at `/api/v1` alongside the web UI. It was built
+as the UI's own backend, and since **v1.11.0** it is also usable by other
+clients: any caller can identify itself, so its reads and writes are attributed
+to it rather than to the web app.
+
+This guide covers what you need to call it from something that is not the
+bundled UI. It is not an exhaustive endpoint reference; the routes live in
+`packages/memory/src/web/routes/` and the response shapes are pinned by the zod
+schemas in `_shared/schemas/`.
+
+**If you are choosing a surface, read [`access-paths.md`](access-paths.md)
+first.** MCP is the right answer for most agents. This API is the right answer
+when you want plain HTTP, are already running `cerefox web` (or Cerefox Local),
+and do not want an MCP client in the loop.
+
+---
+
+## Read this before you expose it
+
+**`/api/v1` has no authentication.** There is no token, no session, and no
+per-route check. Anything that can reach the port can read, write, and delete
+every document in the store.
+
+That is a deliberate consequence of how Cerefox is deployed, not an oversight
+to route around:
+
+- `cerefox web` binds `127.0.0.1` by default.
+- Cerefox Local publishes its container port to `127.0.0.1` by default
+  (`CEREFOX_LOCAL_BIND` opts into a wider bind).
+- Both assume a single-user machine, where the boundary is the loopback
+  interface.
+
+So: **do not publish this port to a network you do not control**, do not put it
+behind a reverse proxy without adding authentication of your own, and treat
+`--host 0.0.0.0` as a decision rather than a convenience. If you need a
+network-reachable Cerefox, the Edge Functions are the surface designed for it
+(they authenticate in-function against a Cerefox access token).
+
+---
+
+## Identifying your client
+
+By default every call is recorded as the web app: author `web-ui`, author type
+`user`, access path `webapp`. Supply an identity and it is recorded as you.
+
+Three optional fields:
+
+| Field | Header | Recorded as | Default |
+|---|---|---|---|
+| author | `X-Cerefox-Author` | `cerefox_audit_log.author` on writes | `web-ui` |
+| requestor | `X-Cerefox-Requestor` | `cerefox_usage_log.requestor` on reads and writes | `web-ui` |
+| author type | `X-Cerefox-Author-Type` | `cerefox_audit_log.author_type` | `user` |
+
+`author_type` must be `user` or `agent`. Anything else is a `400` naming the
+two valid values.
+
+**Headers work on every method.** A `GET` cannot carry a body, and reads are
+half the point of attribution, so headers are the primary mechanism. Endpoints
+that take a JSON body (or a multipart form) also accept the same three as
+fields in it, for clients that find that more natural. If both appear, the
+header wins.
+
+```bash
+# A write, attributed
+curl -X POST http://127.0.0.1:8000/api/v1/ingest \
+  -H 'Content-Type: application/json' \
+  -H 'X-Cerefox-Author: my-bot' \
+  -H 'X-Cerefox-Author-Type: agent' \
+  -d '{"title": "Meeting notes", "content": "# Notes\n\n..."}'
+
+# A read, attributed
+curl http://127.0.0.1:8000/api/v1/documents/<uuid> \
+  -H 'X-Cerefox-Requestor: my-bot'
+```
+
+`author` and `requestor` stand in for each other. They name one actor; MCP
+splits them only because reads and writes log to different tables. Supplying
+either identifies you for both, so a client that only sets `X-Cerefox-Author`
+still has its reads attributed correctly.
+
+### Two consequences worth knowing before you use it
+
+**`author_type: agent` queues your documents for review.** An agent-authored
+ingest lands in `pending_review` rather than `approved`, exactly as it does
+over MCP. That equivalence is the point of the feature: the same actor is
+recorded, and treated, identically whichever transport it used. If you want
+your writes approved on arrival, send `user` (or send nothing).
+
+**Identifying yourself changes the access path.** There is deliberately no way
+to ask for a particular `access_path`: the server derives it. Supply any
+identity field and the operation is logged as `api`; supply none and it is
+logged as `webapp`. The reasoning is that `access_path` is the one field in the
+usage log the server still sets itself, so accepting it from the caller would
+let a client misreport which transport it used. In the Analytics dashboard,
+`api` operations count toward the agent total; `webapp` does not.
+
+### Attribution is not authentication
+
+Nothing verifies an identity claim, here or anywhere else in Cerefox. MCP takes
+`author` as a client-declared string; the Edge Functions accept whatever
+`requestor` arrives. These fields exist so a trail is *legible*, not so it is
+*provable*. On an API with no authentication at all, the identity you send is a
+label you chose, and it should be read that way.
+
+`require_requestor_identity` and `requestor_identity_format` do **not** apply to
+this surface. They are enforced by the Edge Functions only. See
+[`configuration.md`](configuration.md).
+
+---
+
+## Endpoints
+
+Base URL is wherever `cerefox web` is listening (`http://127.0.0.1:8000` by
+default; Cerefox Local picks its own port and `cerefox-local status` prints it).
+
+| Method + path | Purpose |
+|---|---|
+| `GET /version` | Server version and environment label. |
+| `GET /schema-version` | Deployed schema version. |
+| `GET /search?q=…` | Hybrid search (FTS + semantic). |
+| `GET /dashboard`, `GET /dashboard/recent-docs` | Dashboard aggregates. |
+| `GET /documents/{id}` | Full document, with metadata, projects and versions. |
+| `GET /documents/{id}/chunks` | The document's chunks. |
+| `GET /documents/{id}/versions` | Version history. |
+| `GET /documents/{id}/download` | Raw markdown. |
+| `GET /documents/trash` | Soft-deleted documents. |
+| `POST /documents/metadata-search` | Query by metadata / project / time, no text query. |
+| `GET /metadata-keys` | Metadata keys with counts and example values. |
+| `GET /resolve-link`, `GET /check-filename` | Link and title resolution helpers. |
+| `POST /ingest` | Create or update from JSON (`title`, `content`, …). |
+| `POST /ingest/file` | Create from a multipart file upload. |
+| `POST /documents/{id}/upload` | Replace a document's content from a file. |
+| `POST /documents/{id}/edit` | Update title, content, metadata, projects. |
+| `DELETE /documents/{id}` | Soft-delete (to trash). |
+| `POST /documents/{id}/restore` | Restore from trash. |
+| `DELETE /documents/{id}/purge` | Permanent delete. Irreversible. |
+| `POST /documents/{id}/review-status` | Approve or re-queue for review. |
+| `GET /projects`, `POST /projects`, `PUT /projects/{id}`, `DELETE /projects/{id}` | Project CRUD. |
+| `GET /projects/{id}/documents` | A project's documents. |
+| `GET /config`, `GET /config/{key}`, `PUT /config/{key}` | Runtime config. |
+| `GET /audit-log` | Audit trail, filterable. |
+| `GET /usage-log`, `GET /usage-log/summary`, `GET /usage-log/export.csv` | Usage queries. |
+
+Paths are shown without the `/api/v1` prefix for width; every one carries it.
+The writes and the two reads that log usage (`/search`, `/documents/{id}`)
+honour the identity headers. `/version` needs nothing.
+
+### Content updates need a concurrency token
+
+Anything that changes a document's content requires the `content_hash` you read
+it at, as `expected_content_hash`, or an explicit `last_write_wins`. A stale
+hash gets a `409`; omitting both gets a `400` with `CEREFOX_TOKEN_REQUIRED`.
+This matches every other Cerefox surface; see the MCP guidance in
+`AGENT_GUIDE.md` for the read → modify → write loop.
+
+`POST /documents/{id}/upload` is the exception: replacing a document wholesale
+from a file is a re-sync, so it defaults to last-write-wins. Pass
+`expected_content_hash` as a form field if you want the checked path.
+
+---
+
+## Choosing between this and MCP
+
+Both surfaces run the same code underneath and write the same rows. The
+practical differences:
+
+| | `/api/v1` | MCP |
+|---|---|---|
+| Transport | Plain HTTP | stdio or Streamable HTTP |
+| Client needs | An HTTP client | An MCP client |
+| Identity | Optional, defaults to `web-ui` | Per-call `author`/`requestor` |
+| Partial edits | `POST /documents/{id}/edit` | `cerefox_insert`, `cerefox_edit` |
+| Guidance for agents | This guide | `cerefox_get_help()`, in-band |
+| Authentication | None | None locally; token or OAuth remotely |
+
+If an agent is doing the calling, MCP is usually better: the tools carry their
+own documentation, and `cerefox_get_help()` keeps the conventions in front of
+the model. Reach for the API when the caller is a program you are writing
+yourself, or when you want one transport for a harness that already speaks
+HTTP.

--- a/docs/guides/api.md
+++ b/docs/guides/api.md
@@ -17,26 +17,38 @@ and do not want an MCP client in the loop.
 
 ---
 
-## Read this before you expose it
+## ⚠ This API is unauthenticated. It is for local access only.
 
-**`/api/v1` has no authentication.** There is no token, no session, and no
-per-route check. Anything that can reach the port can read, write, and delete
-every document in the store.
+**`/api/v1` has no authentication of any kind.** No token, no session, no
+per-route check. Anything that can open a TCP connection to the port can read
+every document, edit them, delete them, and permanently purge them.
 
-That is a deliberate consequence of how Cerefox is deployed, not an oversight
-to route around:
+**Never expose this port outside the machine it runs on.** Not to your LAN, not
+through a tunnel, not behind a reverse proxy that does not add authentication of
+its own. There is no setting that makes it safe to do so, and a proxy that only
+adds TLS adds nothing here: encryption is not authorization.
 
-- `cerefox web` binds `127.0.0.1` by default.
-- Cerefox Local publishes its container port to `127.0.0.1` by default
-  (`CEREFOX_LOCAL_BIND` opts into a wider bind).
-- Both assume a single-user machine, where the boundary is the loopback
-  interface.
+The surface is designed for **local callers only**:
 
-So: **do not publish this port to a network you do not control**, do not put it
-behind a reverse proxy without adding authentication of your own, and treat
-`--host 0.0.0.0` as a decision rather than a convenience. If you need a
-network-reachable Cerefox, the Edge Functions are the surface designed for it
-(they authenticate in-function against a Cerefox access token).
+- an agent or bot harness running on the same machine,
+- the bundled web UI in your own browser,
+- your own scripts on localhost.
+
+Both supported deployments bind loopback by default and mean it:
+
+- `cerefox web` binds `127.0.0.1`.
+- Cerefox Local publishes its container port to `127.0.0.1`
+  (`CEREFOX_LOCAL_BIND` exists for the case where you have decided otherwise
+  and accept what follows).
+
+`--host 0.0.0.0` and a wider `CEREFOX_LOCAL_BIND` are decisions with a blast
+radius, not conveniences. If you need Cerefox reachable over a network, use the
+Edge Functions: that is the surface built for it, and it authenticates every
+request in-function against a Cerefox access token.
+
+*Adding a locally generated key to this surface is tracked as
+[#229](https://github.com/fstamatelopoulos/cerefox/issues/229). Until it ships,
+the loopback interface is the whole security boundary.*
 
 ---
 
@@ -147,17 +159,29 @@ Paths are shown without the `/api/v1` prefix for width; every one carries it.
 The writes and the two reads that log usage (`/search`, `/documents/{id}`)
 honour the identity headers. `/version` needs nothing.
 
-### Content updates need a concurrency token
+### Every mutation needs a concurrency token
 
-Anything that changes a document's content requires the `content_hash` you read
-it at, as `expected_content_hash`, or an explicit `last_write_wins`. A stale
-hash gets a `409`; omitting both gets a `400` with `CEREFOX_TOKEN_REQUIRED`.
-This matches every other Cerefox surface; see the MCP guidance in
-`AGENT_GUIDE.md` for the read → modify → write loop.
+Cerefox uses optimistic locking, and this API is no exception. A content update
+requires the `content_hash` you read the document at, as
+`expected_content_hash`, or an explicit `last_write_wins`. A stale hash returns
+`409`; sending neither returns `400` with `CEREFOX_TOKEN_REQUIRED`. Read, then
+modify, then write with the token you read.
 
-`POST /documents/{id}/upload` is the exception: replacing a document wholesale
-from a file is a re-sync, so it defaults to last-write-wins. Pass
-`expected_content_hash` as a form field if you want the checked path.
+`POST /documents/{id}/upload` takes the same contract: pass
+`expected_content_hash` as a form field, or `last_write_wins=true` if the file
+you are uploading is an external source of truth and a conflict is genuinely
+meaningless. There is no implicit default.
+
+**Delete follows a read too.** `DELETE /documents/{id}` requires the hash from
+an identified caller, as `X-Cerefox-Expected-Content-Hash` or an
+`expected_content_hash` query parameter, exactly as `cerefox_delete_document`
+requires it over MCP. A caller that sends no identity is the bundled web UI,
+which confirms with the human in a dialog instead, and it keeps working
+unchanged.
+
+Purge (`DELETE /documents/{id}/purge`) is irreversible and takes no token. It is
+reachable by anything that can reach the port, which is another reason the
+warning at the top of this guide is not boilerplate.
 
 ---
 

--- a/docs/guides/api.md
+++ b/docs/guides/api.md
@@ -57,6 +57,14 @@ the loopback interface is the whole security boundary.*
 By default every call is recorded as the web app: author `web-ui`, author type
 `user`, access path `webapp`. Supply an identity and it is recorded as you.
 
+**This identity is declared, not verified.** It is a label the caller chooses,
+recorded for attribution and record-keeping: so the audit trail says which
+harness wrote a document, so usage analytics can tell your bot's reads from the
+web app's, and so an agent-authored ingest is queued for review. It is not a
+credential, it grants nothing, and nothing checks it. See
+[Attribution is not authentication](#attribution-is-not-authentication) below
+before relying on it for anything else.
+
 Three optional fields:
 
 | Field | Header | Recorded as | Default |
@@ -110,11 +118,22 @@ let a client misreport which transport it used. In the Analytics dashboard,
 
 ### Attribution is not authentication
 
-Nothing verifies an identity claim, here or anywhere else in Cerefox. MCP takes
-`author` as a client-declared string; the Edge Functions accept whatever
-`requestor` arrives. These fields exist so a trail is *legible*, not so it is
-*provable*. On an API with no authentication at all, the identity you send is a
-label you chose, and it should be read that way.
+`author`, `requestor` and `author_type` are **declared by the caller and taken
+at face value**. Nothing verifies them, here or anywhere else in Cerefox: MCP
+takes `author` as a client-declared string, and the Edge Functions accept
+whatever `requestor` arrives. Any client can send any name, including a name
+another client uses.
+
+They exist for **attribution and record-keeping**: a legible audit trail, usage
+analytics that can tell callers apart, and the review-queue behaviour of
+`author_type: agent`. They are not a security measure, they do not establish an
+authenticated identity, and no access decision is made on them. Treat a name in
+the audit log as "what the caller said", never as "who the caller was".
+
+Authentication for this surface is a separate problem and is tracked as
+[#229](https://github.com/fstamatelopoulos/cerefox/issues/229). A key, when it
+ships, will prove that a caller is allowed to talk to this server; it will not
+prove the caller is who it says it is, and these fields will remain labels.
 
 `require_requestor_identity` and `requestor_identity_format` do **not** apply to
 this surface. They are enforced by the Edge Functions only. See

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -441,7 +441,7 @@ Each usage log entry records:
 | Field | Description |
 |-------|-------------|
 | `operation` | What was called: `search`, `metadata_search`, `get_document`, `list_versions`, `get_audit_log`, `list_metadata_keys`, `list_projects` |
-| `access_path` | Where the call came from: `remote-mcp`, `local-mcp`, `edge-function`, `webapp`, `cli` |
+| `access_path` | Where the call came from: `remote-mcp`, `local-mcp`, `edge-function`, `webapp`, `cli`, `api` |
 | `requestor` | Who made the call: agent name (e.g., "Claude Code", "mcp-agent") or "user" for webapp/CLI |
 | `document_id` | Optional: which document was accessed (for get_document, list_versions) |
 | `project_id` | Optional: which project was filtered on |
@@ -452,7 +452,7 @@ Each usage log entry records:
 The `access_path` is set by the caller layer (not the end user):
 - Edge Functions set `"edge-function"` (GPT Actions, direct HTTP callers)
 - `cerefox-mcp` tool handlers set `"remote-mcp"` (Claude Code, Cursor, Claude Desktop)
-- The web UI's JSON API routes set `"webapp"`
+- The web UI's JSON API routes set `"webapp"` when the caller sends no identity, and `"api"` when it names itself with `X-Cerefox-Author` / `X-Cerefox-Requestor` (v1.11.0; see [`api.md`](api.md)). The path is derived, never accepted from the caller.
 - Local MCP server sets `"local-mcp"`
 - CLI sets `"cli"` for read/search commands
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -477,9 +477,33 @@ optional. When omitted, it defaults to `"mcp-agent"`. This means the usage log s
 `"mcp-agent"` for all calls that don't explicitly identify themselves, making analytics
 less useful in multi-agent setups.
 
-You can optionally enforce caller identification so that all MCP tool calls must include
+You can optionally enforce caller identification so that MCP tool calls must include
 a requestor/author identity. Calls without identity receive a JSON-RPC `-32602` error
 with a helpful message telling the agent what to provide.
+
+### What it actually covers
+
+**These two settings are enforced by the Edge Functions only.** Each of the nine
+Edge Functions carries the check, including `cerefox-mcp`, which is the **remote**
+MCP transport. Nothing else does:
+
+| Surface | Enforced? |
+|---|---|
+| Edge Functions (GPT Actions, direct HTTP) | Yes |
+| Remote MCP (`cerefox-mcp` Edge Function) | Yes |
+| **Local MCP** (`cerefox mcp`, stdio) | **No** |
+| **`/api/v1`** (`cerefox web`, Cerefox Local) | **No** |
+| CLI | **No** |
+
+This is stated plainly because the setting's name promises more than it
+delivers: enabling it does not make identity required everywhere, and an
+operator who assumes otherwise has a gap exactly where their local agents are.
+The reason it is scoped this way is that the Edge Functions are the
+internet-facing surface, while the local surfaces are already reachable only by
+whoever is on the machine.
+
+If you need it everywhere, that is a shared helper every transport calls, not a
+tenth copy of the same block. Raise an issue rather than assuming it is there.
 
 ### Enabling enforcement
 

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -28,15 +28,23 @@
 ---
 ## Current Focus
 
-**2026-08-22 — v1.10.0 + v1.10.1 SHIPPED and verified on BOTH staging and
-production. Production jumped 1.9.1 → 1.10.1 in one hop (migration 0030 ran
-clean; the interrupted-then-rerun deploy proved the idempotency design;
-guides re-synced 17/17; acceptance 15/15 on prod; #222 warning verified
-firing on prod CLI and quiet on clean writes). #222 closed. #154 deferred to
-a well-announced v1.11.0 (platform drop ≠ patch). The 1.10.x line was
-announced in Discord `#announcements` on 2026-08-22. Nothing is in flight.
-Next: v1.11.0 (commander 15 + Node ≥ 22.12 + installer detection) when
-scheduled.**
+**2026-09-01 — Iteration 40 IN PROGRESS on `feat/v1.11.0-api-attribution`,
+target v1.11.0: optional `author`/`requestor`/`author_type` on `/api/v1`
+(#226), the `doctor` config-dir misreport (#225), and the repo-root compose
+bind (#227). Detail: [iteration 40](plans/iteration-40-api-attribution.md).**
+
+**v1.11.0 is this work, NOT the Node baseline drop.** #154 (commander 15,
+Node ≥ 22.12, installer detection) moves to **v1.12.0** — decision
+2026-09-01. The two want opposite announcements: one says "check your Node
+version before upgrading", the other says "here is a new optional
+parameter", and bundling them buries the warning.
+
+Previously: **v1.10.0 + v1.10.1 SHIPPED** (2026-08-22) and verified on BOTH
+staging and production. Production jumped 1.9.1 → 1.10.1 in one hop
+(migration 0030 ran clean; the interrupted-then-rerun deploy proved the
+idempotency design; guides re-synced 17/17; acceptance 15/15 on prod; #222
+warning verified firing on prod CLI and quiet on clean writes). #222 closed.
+The 1.10.x line was announced in Discord `#announcements` on 2026-08-22.
 
 Schema is at 0.15.0 (shipped in v1.10.0); `minSchema` is **0.14.0**, raised
 in v1.9.0 — the FIRST raise since the policy was written (see iteration 38).
@@ -105,8 +113,13 @@ one:
 
 ## Active iteration
 
+**[Iteration 40 — API attribution and environment honesty](plans/iteration-40-api-attribution.md)**
+— ⏳ **IN PROGRESS** (opened 2026-09-01), target v1.11.0. No schema change
+expected. Closes #225, #226, #227.
+
 **[Iteration 39 — Audit consistency: the web save on shared cores](plans/iteration-39-audit-consistency.md)**
-— ⏳ **IN PROGRESS**, target v1.10.0 (schema 0.15.0, migration 0030).
+— ✅ **CLOSED, shipped v1.10.0 + v1.10.1** (2026-08-22; schema 0.15.0,
+migration 0030), verified on staging and production, announced.
 
 **[Iteration 38 — Audit completeness, settings clarity, docs restoration](plans/iteration-38-audit-completeness.md)**
 — ✅ **CLOSED, shipped v1.9.0/v1.9.1/v1.9.2** (2026-08-17/18), verified on

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -33,11 +33,12 @@ production. Production jumped 1.9.1 → 1.10.1 in one hop (migration 0030 ran
 clean; the interrupted-then-rerun deploy proved the idempotency design;
 guides re-synced 17/17; acceptance 15/15 on prod; #222 warning verified
 firing on prod CLI and quiet on clean writes). #222 closed. #154 deferred to
-a well-announced v1.11.0 (platform drop ≠ patch). Next: maintainer backup
-(post-upgrade), Discord announcement for the 1.10.x line, then v1.11.0
-(commander 15 + Node ≥ 22.12 + installer detection) when scheduled.**
+a well-announced v1.11.0 (platform drop ≠ patch). The 1.10.x line was
+announced in Discord `#announcements` on 2026-08-22. Nothing is in flight.
+Next: v1.11.0 (commander 15 + Node ≥ 22.12 + installer detection) when
+scheduled.**
 
-Schema is at 0.15.0 (v1.10.0 in progress); `minSchema` is **0.14.0**, raised
+Schema is at 0.15.0 (shipped in v1.10.0); `minSchema` is **0.14.0**, raised
 in v1.9.0 — the FIRST raise since the policy was written (see iteration 38).
 The tool surface is 15 core + 4 dormant relation tools (delete/restore
 joined in v1.7.0).

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -28,10 +28,15 @@
 ---
 ## Current Focus
 
-**2026-09-01 — Iteration 40 IN PROGRESS on `feat/v1.11.0-api-attribution`,
-target v1.11.0: optional `author`/`requestor`/`author_type` on `/api/v1`
-(#226), the `doctor` config-dir misreport (#225), and the repo-root compose
-bind (#227). Detail: [iteration 40](plans/iteration-40-api-attribution.md).**
+**2026-09-01 — Iteration 40 IMPLEMENTATION COMPLETE on
+`feat/v1.11.0-api-attribution`, target v1.11.0, awaiting review + release.
+Optional `author`/`requestor`/`author_type` on `/api/v1` (#226), the `doctor`
+config-dir misreport (#225), the repo-root compose bind (#227), and #228 —
+`POST /documents/{id}/upload`, broken since v0.11.0 and found only because the
+same work revealed that the web-integration suite had been skipping since
+v0.9.0. No schema change. Verified on staging (215 pass / 0 fail) and in a
+throwaway Cerefox Local container. Detail:
+[iteration 40](plans/iteration-40-api-attribution.md).**
 
 **v1.11.0 is this work, NOT the Node baseline drop.** #154 (commander 15,
 Node ≥ 22.12, installer detection) moves to **v1.12.0** — decision
@@ -114,8 +119,12 @@ one:
 ## Active iteration
 
 **[Iteration 40 — API attribution and environment honesty](plans/iteration-40-api-attribution.md)**
-— ⏳ **IN PROGRESS** (opened 2026-09-01), target v1.11.0. No schema change
-expected. Closes #225, #226, #227.
+— ⏳ **IMPLEMENTATION COMPLETE, awaiting review + release** (2026-09-01), target
+v1.11.0. **No schema change.** Closes #225, #226, #227, and #228 (found in
+flight). Verified on staging (215 pass / 0 fail) and in a throwaway Cerefox
+Local container. The find that outlived the feature: the web-integration suite
+had been skipping since v0.9.0 on a renamed probe verb, which is how #228
+survived eleven releases.
 
 **[Iteration 39 — Audit consistency: the web save on shared cores](plans/iteration-39-audit-consistency.md)**
 — ✅ **CLOSED, shipped v1.10.0 + v1.10.1** (2026-08-22; schema 0.15.0,

--- a/docs/plans/iteration-40-api-attribution.md
+++ b/docs/plans/iteration-40-api-attribution.md
@@ -130,7 +130,14 @@ in lockstep and this section is wrong.
 - [x] **Audit authorship unification** — the two `author: "user"` routes.
 - [x] **#227** — repo-root `docker-compose.yml` publishes to loopback.
 - [x] **#228 (found in flight)** — `POST /documents/{id}/upload` broken since
-      v0.11.0; accepts the hash optionally, defaults to last-write-wins.
+      v0.11.0. Takes the SAME contract as every other content update: the hash,
+      or an explicit `last_write_wins=true`. No implicit default — the endpoint
+      has been a hard error for eleven releases, so there is no working caller
+      to preserve and the strict semantics cost nothing.
+- [x] **Delete follows a read on the API too.** `DELETE /documents/{id}`
+      requires the hash from an identified caller, matching what
+      `cerefox_delete_document` enforces over MCP. Anonymous callers (the
+      bundled UI, which confirms in a dialog) are unaffected.
 - [x] **Tests** — resolver unit tests (20), deriver tests (+3), HTTP-boundary
       attribution tests (5) covering omitted-parameter parity against the
       stored row.
@@ -158,6 +165,15 @@ fixture through the deployed `cerefox-ingest` Edge Function, a v0.6 workaround
 from when `/api/v1/ingest` was a 503 stub. That suite is not one of the two
 `CEREFOX_LIVE_E2E` suites permitted to spend free-tier quota. It now ingests
 over HTTP, and the dead helper is deleted rather than left for reuse.
+
+**Live suites skip in a full run (#230, filed, not fixed here).**
+`ingest.test.ts` passes when its directory is run and skips under the
+documented full `bun test`, because `LIVE_OK` is frozen at module load and
+`live-write-guard-coverage.test.ts` blanks `CEREFOX_CONFIG_DIR` mid-run to
+exercise the guard. Same shape as the renamed-probe bug — a suite reporting
+success while running nothing — with ordering as the trigger instead of a stale
+verb. Filed rather than fixed because the durable answer is to evaluate
+`LIVE_OK` lazily across every live suite, which is its own change.
 
 **A local `bun run typecheck` never checked the frontend.** `tsc --noEmit`
 there checks nothing, because `tsconfig.json` is `files: []` plus references.

--- a/docs/plans/iteration-40-api-attribution.md
+++ b/docs/plans/iteration-40-api-attribution.md
@@ -1,0 +1,151 @@
+# Iteration 40 — API attribution and environment honesty (v1.11.0)
+
+**Status: IN PROGRESS** (opened 2026-09-01). Branch:
+`feat/v1.11.0-api-attribution`. Target: **v1.11.0**. No schema change
+expected (see "No schema change" below).
+
+Closes [#225](https://github.com/fstamatelopoulos/cerefox/issues/225),
+[#226](https://github.com/fstamatelopoulos/cerefox/issues/226),
+[#227](https://github.com/fstamatelopoulos/cerefox/issues/227).
+
+## Why
+
+`/api/v1` was built as the web app's private backend and hardcodes its own
+identity: `author: "web-ui"` at 17 call sites, `access_path: "webapp"`
+unconditionally in `logWebUsage()`. Any other client of that API is therefore
+unattributable, which pushes agent harnesses onto the MCP surface purely to
+obtain an identity, even where the HTTP API would serve them better. #226
+reports exactly that: a harness reading over the API and writing over MCP,
+split for no reason other than this gap.
+
+Two smaller items ride along because they are the same subject (who and where
+an operation came from) and because they are cheap once the code is open:
+`doctor` misreporting which config file is in effect (#225), and the repo-root
+compose file contradicting the shipped installers on network exposure (#227).
+
+## Design decisions
+
+Confirmed with the maintainer 2026-09-01 before implementation.
+
+- **Optional parameters, defaults unchanged.** `author`, `requestor` and
+  `author_type` are accepted and optional everywhere. Omitted, the routes
+  behave exactly as today: `author: "web-ui"`, `author_type: "user"`,
+  `access_path: "webapp"`. The bundled web app is not modified and no
+  existing client observes a difference. This is the whole design constraint,
+  not a nicety.
+
+- **`access_path` is derived, never accepted.** A caller-settable
+  `access_path` would let a client lie about *where* as well as *who*, and
+  *where* is the only field in the usage log currently worth trusting because
+  the server sets it per transport. Rule: **if any caller identity is
+  supplied, `access_path` is `"api"`; otherwise `"webapp"`.**
+
+  This is an approximation and is recorded as one. It reads "named itself" as
+  the signal that the caller is not the bundled web app. The known edge: if
+  the web app ever passes a real `requestor` (multi-user, SSO), it would begin
+  labelling itself `"api"`. Acceptable now, since it passes nothing, and
+  commented at the derivation site so a future reader does not have to
+  rediscover the coupling.
+
+- **`"api"` becomes a first-class access path.** `AccessPath` in
+  `_shared/mcp-tools/types.ts` is the guard for this domain (the DB column is
+  free text, no CHECK, verified). Adding the value there, in the type's doc
+  comment, and in `CLAUDE.md`'s usage-tracking paragraph is what makes it
+  documented rather than incidental.
+
+- **The dashboard must learn `"api"` explicitly.**
+  `deriveAccessPathStats()` resolves each path by exact name and deliberately
+  refuses to sweep unknown values into `agentOps` ("a future transport should
+  appear deliberately, not by silently inflating this number"), with a test
+  pinning that refusal. Left alone, API-attributed operations would be
+  written, charted in Analytics, and invisible in the Dashboard agent tile.
+  This is the failure this iteration is most likely to ship by accident.
+
+- **No `/api/v2`.** These are additive optional parameters that reproduce
+  current behaviour byte for byte when omitted, which is what a stable v1
+  absorbs. A v2 would mean two route trees, two test suites, and a permanent
+  question about which the bundled app targets. The version bump stays
+  available for a change that genuinely breaks callers.
+
+- **Attribution is not authentication, and that is not this iteration's
+  problem to solve.** No Cerefox transport verifies an identity claim: MCP
+  takes `author` as a client-declared string, the Edge Functions accept
+  whatever `requestor` arrives. This change extends an existing convention to
+  one more surface. It introduces no new trust assumption, and withholding it
+  would not make identity trustworthy anywhere else. That `/api/v1` has no
+  authentication at all is real, separate, and belongs in its own issue.
+
+- **`require_requestor_identity` scope: document, do not duplicate.** The
+  config is enforced in each Edge Function separately (eight near-identical
+  copies) and by neither the web API nor the local stdio MCP server. Adding a
+  ninth copy buys little and risks breaking installs that have it enabled. The
+  fix is honesty: state the transports it covers in
+  `docs/guides/configuration.md` and in the config catalog description, so an
+  operator who enables it is not left believing identity is required
+  everywhere. If it is ever made global it goes in one shared helper that all
+  transports call.
+
+## Found during recon, folded in
+
+**`documents-write.ts` is inconsistent with itself.** The review-status route
+(`:401`) and the version-archive route (`:436`) write `author: "user"`, while
+every other web write uses `"web-ui"`. `projects.ts` documents the intended
+convention explicitly ("the convention every other web audit site uses, so
+`author='web-ui'` catches dashboard-originated store-level writes too") and
+those two routes silently break it: an `author='web-ui'` audit filter misses
+every review-status change and every version archive.
+
+Unifying them on `"web-ui"` is a **behaviour change to existing audit
+authorship** for those two operations, so it is called out here rather than
+slipped in. Judgement: consistency wins, because the current state makes an
+audit filter quietly incomplete, which is worse than a visible change in what
+two operations record. Existing rows are not rewritten.
+
+## No schema change
+
+`cerefox_usage_log.access_path` is `TEXT NOT NULL` with no CHECK and no enum
+(`src/cerefox/db/schema.sql:415`), so `"api"` needs no migration and no
+`schema_version` bump. Recorded explicitly because the reflex on this project
+is to bump, and the gate in `cut_release.ts` only fires when `db/` changes.
+If a step below ends up touching `src/cerefox/db/`, both literals get bumped
+in lockstep and this section is wrong.
+
+## Steps
+
+- [ ] **#225** — `checkLegacyShadowEnv()` resolves the active env file through
+      `resolveEnvFile()` instead of assuming `~/.cerefox/.env`, and gates on
+      the same "has a `CEREFOX_*` key" heuristic `resolveConfigDir()` uses, so
+      it stops calling an unrelated project's `.env` safe to delete. Tests
+      drive the resolver, never a hardcoded path.
+- [ ] **#226 core** — a single shared helper resolves caller identity and the
+      derived access path from a request, used by every `/api/v1` route that
+      writes or logs. One implementation, not 17 edits.
+- [ ] **#226 routes** — ingest, document write, projects, config routes accept
+      the optional parameters; `logWebUsage()` accepts requestor and access
+      path.
+- [ ] **#226 domain** — `AccessPath` gains `"api"`; `deriveAccessPathStats()`
+      and its test learn it; `CLAUDE.md` usage-tracking paragraph updated.
+- [ ] **Audit authorship unification** — the two `author: "user"` routes move
+      to the shared resolver.
+- [ ] **#227** — repo-root `docker-compose.yml` binds published ports to
+      loopback, matching `docker/local/compose.yml` and the installer.
+- [ ] **Tests** — unit tests for the resolver and the deriver; HTTP-boundary
+      tests under `web-integration/` covering omitted-parameter parity and
+      supplied-parameter attribution.
+- [ ] **Docs** — `/api/v1` reference guide; `configuration.md` enforcement
+      scope; CHANGELOG.
+- [ ] **Live regression** — staging first, then a throwaway local Docker
+      instance. The maintainer's own Cerefox Local is in use by another agent
+      and is not to be touched.
+
+## Verification plan
+
+- `bun test` in `_shared/` and `packages/memory/` (built bin).
+- HTTP-boundary tests against staging (`CEREFOX_CONFIG_DIR=~/.cerefox/staging`),
+  which is where the write-bearing suites are allowed to run.
+- A second, throwaway Cerefox Local container on a non-default port, to
+  exercise the API path the reporting harness actually uses. The maintainer's
+  running instance is off limits.
+- The parity assertion that matters: with no parameters supplied, audit and
+  usage rows are identical to those the current code writes. Recorded as a
+  baseline and compared, rather than eyeballed.

--- a/docs/plans/iteration-40-api-attribution.md
+++ b/docs/plans/iteration-40-api-attribution.md
@@ -1,12 +1,13 @@
 # Iteration 40 — API attribution and environment honesty (v1.11.0)
 
-**Status: IN PROGRESS** (opened 2026-09-01). Branch:
-`feat/v1.11.0-api-attribution`. Target: **v1.11.0**. No schema change
-expected (see "No schema change" below).
+**Status: IMPLEMENTATION COMPLETE, awaiting review + release** (opened 2026-09-01). Branch:
+`feat/v1.11.0-api-attribution`. Target: **v1.11.0**. No schema change (confirmed, see below).
 
 Closes [#225](https://github.com/fstamatelopoulos/cerefox/issues/225),
 [#226](https://github.com/fstamatelopoulos/cerefox/issues/226),
-[#227](https://github.com/fstamatelopoulos/cerefox/issues/227).
+[#227](https://github.com/fstamatelopoulos/cerefox/issues/227), and
+[#228](https://github.com/fstamatelopoulos/cerefox/issues/228) (filed in
+flight — see "Found in flight" below).
 
 ## Why
 
@@ -112,31 +113,58 @@ in lockstep and this section is wrong.
 
 ## Steps
 
-- [ ] **#225** — `checkLegacyShadowEnv()` resolves the active env file through
-      `resolveEnvFile()` instead of assuming `~/.cerefox/.env`, and gates on
-      the same "has a `CEREFOX_*` key" heuristic `resolveConfigDir()` uses, so
-      it stops calling an unrelated project's `.env` safe to delete. Tests
-      drive the resolver, never a hardcoded path.
-- [ ] **#226 core** — a single shared helper resolves caller identity and the
-      derived access path from a request, used by every `/api/v1` route that
-      writes or logs. One implementation, not 17 edits.
-- [ ] **#226 routes** — ingest, document write, projects, config routes accept
-      the optional parameters; `logWebUsage()` accepts requestor and access
-      path.
-- [ ] **#226 domain** — `AccessPath` gains `"api"`; `deriveAccessPathStats()`
-      and its test learn it; `CLAUDE.md` usage-tracking paragraph updated.
-- [ ] **Audit authorship unification** — the two `author: "user"` routes move
-      to the shared resolver.
-- [ ] **#227** — repo-root `docker-compose.yml` binds published ports to
-      loopback, matching `docker/local/compose.yml` and the installer.
-- [ ] **Tests** — unit tests for the resolver and the deriver; HTTP-boundary
-      tests under `web-integration/` covering omitted-parameter parity and
-      supplied-parameter attribution.
-- [ ] **Docs** — `/api/v1` reference guide; `configuration.md` enforcement
-      scope; CHANGELOG.
-- [ ] **Live regression** — staging first, then a throwaway local Docker
-      instance. The maintainer's own Cerefox Local is in use by another agent
-      and is not to be touched.
+- [x] **#225** — `checkLegacyShadowEnv()` resolves the active env file through
+      `resolveEnvFile()` and gates on the shared `CEREFOX_*`-key predicate.
+      Both guards proven to fire independently by regressing each alone.
+- [x] **#226 core** — `packages/memory/src/web/identity.ts`: one resolver, used
+      by every route that writes or logs. Headers first, body honoured, derived
+      access path, `author_type` validated at the boundary (the DB CHECK would
+      otherwise surface as a 500 for a caller mistake).
+- [x] **#226 routes** — ingest (3), document write (6), projects (3), config,
+      and the two reads that log usage. No route carries a default any more.
+- [x] **#226 domain** — the vocabulary moved to a dependency-free leaf
+      (`_shared/mcp-tools/access-paths.ts`); `AccessPath` derives from it, the
+      Analytics filter derives from it through a vite alias, and its label map
+      is keyed by the union so an unlabelled path fails the typecheck.
+      `deriveAccessPathStats()` and the Dashboard learn `api` explicitly.
+- [x] **Audit authorship unification** — the two `author: "user"` routes.
+- [x] **#227** — repo-root `docker-compose.yml` publishes to loopback.
+- [x] **#228 (found in flight)** — `POST /documents/{id}/upload` broken since
+      v0.11.0; accepts the hash optionally, defaults to last-write-wins.
+- [x] **Tests** — resolver unit tests (20), deriver tests (+3), HTTP-boundary
+      attribution tests (5) covering omitted-parameter parity against the
+      stored row.
+- [x] **Docs** — `docs/guides/api.md` (new), `configuration.md` enforcement
+      scope, config-catalog description, `access-paths.md` + README + CLAUDE.md
+      cross-links, CHANGELOG.
+- [x] **Live regression** — staging 215 pass / 0 fail; a throwaway Cerefox
+      Local container on 18040, destroyed afterwards.
+
+## Found in flight
+
+Three things this iteration did not set out to fix, recorded because each was
+invisible until the code was opened.
+
+**The web-integration suite had been skipping since v0.9.0.** `probeSupabase()`
+shelled out to `cerefox list-projects`; v0.9.0 renamed that verb and left a
+husk that exits non-zero by design. The probe read that as "backend
+unreachable". Eleven releases, green throughout, running nothing — and the
+reason #228 survived. The fix is one probe that **throws** when the CLI rejects
+the probe command, because a probe that cannot tell "the backend is down" from
+"that command no longer exists" is not a probe.
+
+**Turning the suite on turned its billing on.** `destructive.test.ts` built its
+fixture through the deployed `cerefox-ingest` Edge Function, a v0.6 workaround
+from when `/api/v1/ingest` was a 503 stub. That suite is not one of the two
+`CEREFOX_LIVE_E2E` suites permitted to spend free-tier quota. It now ingests
+over HTTP, and the dead helper is deleted rather than left for reuse.
+
+**A local `bun run typecheck` never checked the frontend.** `tsc --noEmit`
+there checks nothing, because `tsconfig.json` is `files: []` plus references.
+CI builds the frontend and was unaffected, but the local script that people
+actually run was blind to the whole SPA. This is the same shape as the two
+incidents `CLAUDE.md` already records under "tests and CI are only as honest as
+their coverage", which is why it is written down rather than quietly fixed.
 
 ## Verification plan
 

--- a/docs/solution-design.md
+++ b/docs/solution-design.md
@@ -45,7 +45,7 @@ The original spec used a single `cerefox_notes` table. The current design uses:
 - **`cerefox_chunks`** — search corpus and version store. Current chunks have `version_id IS NULL`; archived chunks have `version_id` pointing to their version row. All embeddings and FTS live here, on current chunks only (archived chunks carry none — see §7.5).
 - **`cerefox_document_versions`** — lightweight version metadata rows (`version_number`, `source`, `chunk_count`, `total_chars`, `archived`, `created_at`). No content TEXT, no `content_hash`/`metadata` snapshot columns — content for any version is reconstructed from its archived chunks. Created only when content actually changes. Includes `archived` boolean for protecting specific versions from retention cleanup.
 - **`cerefox_audit_log`** — immutable, append-only log of all write operations. Records author, author_type ('user' or 'agent'), operation type, size delta, and description. FK references to documents and versions (SET NULL on delete). Used for accountability and temporal queries.
-- **`cerefox_usage_log`** — opt-in log of all operations (reads and writes) across all access paths. Records operation, access_path ('remote-mcp', 'local-mcp', 'edge-function', 'webapp', 'cli'), requestor (agent name or 'user'), document_id, query_text, result_count. Feeds the analytics page. Controlled by `cerefox_config` ('usage_tracking_enabled'). The `cerefox_log_usage` RPC checks config on every call and returns immediately when disabled.
+- **`cerefox_usage_log`** — opt-in log of all operations (reads and writes) across all access paths. Records operation, access_path ('remote-mcp', 'local-mcp', 'edge-function', 'webapp', 'cli', 'api' — the last for `/api/v1` called by a client that identified itself, v1.11.0), requestor (agent name or 'user'), document_id, query_text, result_count. Feeds the analytics page. Controlled by `cerefox_config` ('usage_tracking_enabled'). The `cerefox_log_usage` RPC checks config on every call and returns immediately when disabled.
 - **`cerefox_config`** — key-value runtime config stored in Postgres. Currently used for `usage_tracking_enabled`. No redeploy needed to toggle -- `cerefox_set_config` validates against an allowlist.
 
 Key design properties:
@@ -1185,7 +1185,7 @@ table on every call and returns immediately when tracking is disabled (no perfor
 impact).
 
 Each usage log entry records: `operation` (what), `access_path` (where: remote-mcp,
-local-mcp, edge-function, webapp, cli), `requestor` (who: agent name or "user"),
+local-mcp, edge-function, webapp, cli, api), `requestor` (who: agent name or "user"),
 `document_id`, `query_text`, and `result_count`. The `requestor` field enables
 multi-agent analytics -- distinguishing between different agents (e.g., "archiver",
 "master", "Claude Code") in usage patterns.

--- a/docs/specs/concurrency-control-design.md
+++ b/docs/specs/concurrency-control-design.md
@@ -57,7 +57,13 @@ conflicts meaningless:
 | `cerefox document ingest-dir` | passes `last_write_wins` internally (filesystem is the source of truth) |
 | `cerefox guides ingest` (self-docs sync) | same |
 | Python frozen fallback (`db/client.py`) | passes `last_write_wins` (preserves its historical behavior; explicitly unsafe — one deliberate exception to its frozen status) |
-| Everything else (MCP, EF, CLI single-doc, web edit) | must supply `expected_content_hash` or explicitly pass the flag |
+| Everything else (MCP, EF, CLI single-doc, web edit, web upload-replace) | must supply `expected_content_hash` or explicitly pass the flag |
+
+Delete follows the same read-before-write rule: `cerefox_delete_document` takes
+`p_expected_content_hash` (0.12.0, #208), MCP requires it, and since v1.11.0 so
+does `DELETE /api/v1/documents/{id}` for any caller that identifies itself. The
+bundled web UI sends no identity and confirms with the human in a dialog
+instead, which is its safeguard.
 
 ### Error surface
 

--- a/frontend/src/lib/access-path-stats.test.ts
+++ b/frontend/src/lib/access-path-stats.test.ts
@@ -70,4 +70,36 @@ describe("dashboard access-path split (#195)", () => {
     const d = derive([...REAL, { access_path: "future-transport", count: 999 }]);
     expect(d.agentOps).toBe(638);
   });
+
+  // ── `api`: /api/v1 with caller identity (#226, iter-40) ──────────────────
+  //
+  // The deliberate-inclusion rule above is exactly why this needs its own
+  // coverage. `api` rows reach the database and the Analytics chart as soon
+  // as the server writes them; without the line in the deriver they would be
+  // absent from this tile and nobody would see a number go wrong, only a
+  // number stay smaller than it should be.
+
+  test("identified API calls count as agent operations", () => {
+    const d = derive([...REAL, { access_path: "api", count: 100 }]);
+    expect(d.apiOps).toBe(100);
+    expect(d.agentOps).toBe(738);
+  });
+
+  test("api is reported separately from webapp", () => {
+    const d = derive([...REAL, { access_path: "api", count: 100 }]);
+    // Same route, different callers: the bundled web app supplied no identity,
+    // the API client did. Merging them would erase the distinction the whole
+    // feature exists to record.
+    expect(d.webOps).toBe(652);
+    expect(d.apiOps).toBe(100);
+    expect(d.webOps).not.toBe(d.apiOps);
+  });
+
+  test("no api rows reads as zero, not as missing", () => {
+    // Every install before v1.11.0 has no `api` rows at all. That must be a
+    // clean zero, not NaN and not an inflated agent total.
+    const d = derive(REAL);
+    expect(d.apiOps).toBe(0);
+    expect(d.agentOps).toBe(638);
+  });
 });

--- a/frontend/src/lib/access-path-stats.ts
+++ b/frontend/src/lib/access-path-stats.ts
@@ -16,7 +16,9 @@ export interface AccessPathStats {
   localMcpOps: number;
   remoteMcpOps: number;
   efOps: number;
-  /** MCP + Edge Function. Deliberately excludes CLI — see below. */
+  /** `/api/v1` calls from a client that identified itself (#226). */
+  apiOps: number;
+  /** MCP + Edge Function + identified API. Deliberately excludes CLI — see below. */
   agentOps: number;
   cliOps: number;
   webOps: number;
@@ -27,14 +29,21 @@ export function deriveAccessPathStats(rows: AccessPathRow[] | undefined): Access
   const localMcpOps = at("local-mcp");
   const remoteMcpOps = at("remote-mcp");
   const efOps = at("edge-function");
+  // `api` = /api/v1 with caller identity supplied (#226). Added here
+  // deliberately, which is the whole point of the rule below: the value
+  // existed in the database and on the Analytics chart the moment the server
+  // started writing it, and would have been invisible in this tile until
+  // someone noticed an undercount months later.
+  const apiOps = at("api");
   return {
     localMcpOps,
     remoteMcpOps,
     efOps,
+    apiOps,
     // Only the paths that are unambiguously agents. An unknown access path is
     // NOT swept in: a future transport should appear deliberately, not by
     // silently inflating this number.
-    agentOps: localMcpOps + remoteMcpOps + efOps,
+    agentOps: localMcpOps + remoteMcpOps + efOps + apiOps,
     // CLI is reported alongside, never folded in. The usage log records both
     // requestor and access path, but the summary endpoint does not
     // cross-tabulate them, so an agent's CLI use cannot be told from a human's

--- a/frontend/src/pages/AnalyticsPage.tsx
+++ b/frontend/src/pages/AnalyticsPage.tsx
@@ -14,6 +14,7 @@ import {
   Title,
   Tooltip,
 } from "@mantine/core";
+import { ACCESS_PATHS, type AccessPath } from "@cerefox/access-paths";
 import { ResponsiveBar } from "@nivo/bar";
 import { ResponsivePie } from "@nivo/pie";
 import { IconDownload, IconPlayerPlay } from "@tabler/icons-react";
@@ -43,13 +44,22 @@ const DATE_PRESETS = [
   { value: "all", label: "All time" },
 ];
 
+// Derived from the shared vocabulary, not hand-mirrored (#226). The label map
+// is keyed by the union, so a new access path that nobody labelled fails the
+// typecheck instead of quietly missing from this dropdown — which is how the
+// filter came to be missing `api` in the first place.
+const ACCESS_PATH_LABELS: Record<AccessPath, string> = {
+  "remote-mcp": "Remote MCP",
+  "local-mcp": "Local MCP",
+  "edge-function": "Edge Function",
+  webapp: "Web App",
+  cli: "CLI",
+  api: "API (identified)",
+};
+
 const ACCESS_PATH_OPTIONS = [
   { value: "", label: "All paths" },
-  { value: "remote-mcp", label: "Remote MCP" },
-  { value: "local-mcp", label: "Local MCP" },
-  { value: "edge-function", label: "Edge Function" },
-  { value: "webapp", label: "Web App" },
-  { value: "cli", label: "CLI" },
+  ...ACCESS_PATHS.map((p) => ({ value: p, label: ACCESS_PATH_LABELS[p] })),
 ];
 
 const PIE_COLORS = [

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -92,6 +92,7 @@ export function DashboardPage() {
     localMcpOps,
     remoteMcpOps,
     efOps,
+    apiOps,
     agentOps,
     cliOps,
     webOps,
@@ -236,13 +237,13 @@ export function DashboardPage() {
               `edge` moves down because it is an agent path that is normally
               zero (ChatGPT Actions only), so it reads as noise in the badge and
               as information here. */}
-          {(efOps > 0 || cliOps > 0 || webOps > 0) && (
+          {(efOps > 0 || apiOps > 0 || cliOps > 0 || webOps > 0) && (
             <div
               className={styles.statSub}
-              title="edge = ChatGPT Actions (counted in the total above). cli and web are NOT counted as agent operations: the usage summary cannot separate an agent's CLI use from a person's."
+              title="edge = ChatGPT Actions and api = an /api/v1 client that identified itself (both counted in the total above). cli and web are NOT counted as agent operations: the usage summary cannot separate an agent's CLI use from a person's, and web is the bundled UI."
             >
-              {efOps.toLocaleString()} edge · {cliOps.toLocaleString()} cli ·{" "}
-              {webOps.toLocaleString()} web
+              {efOps.toLocaleString()} edge · {apiOps.toLocaleString()} api ·{" "}
+              {cliOps.toLocaleString()} cli · {webOps.toLocaleString()} web
             </div>
           )}
         </div>

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -19,7 +19,8 @@
     "paths": {
       "@/*": ["src/*"],
       "@cerefox/schemas": ["../_shared/schemas"],
-      "@cerefox/audit-ops": ["../_shared/mcp-tools/audit-ops.ts"]
+      "@cerefox/audit-ops": ["../_shared/mcp-tools/audit-ops.ts"],
+      "@cerefox/access-paths": ["../_shared/mcp-tools/access-paths.ts"]
     },
 
     /* Linting */

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -17,6 +17,9 @@ export default defineConfig({
       // Round 4: the audit page's store-level-op set imports the shared
       // definition instead of hand-mirroring it (same pattern as schemas).
       '@cerefox/audit-ops': path.resolve(here, '..', '_shared', 'mcp-tools', 'audit-ops.ts'),
+      // #226: the Analytics access-path filter derives its options from the
+      // shared vocabulary rather than hand-mirroring it (same pattern again).
+      '@cerefox/access-paths': path.resolve(here, '..', '_shared', 'mcp-tools', 'access-paths.ts'),
     },
   },
   server: {

--- a/package.json
+++ b/package.json
@@ -15,9 +15,10 @@
   },
   "scripts": {
     "test": "cd _shared && bun test",
-    "typecheck": "npm run typecheck:shared && npm run typecheck:memory",
+    "typecheck": "npm run typecheck:shared && npm run typecheck:memory && npm run typecheck:frontend",
     "typecheck:shared": "cd _shared && npx tsc --noEmit",
     "typecheck:memory": "cd packages/memory && npx tsc --noEmit",
+    "typecheck:frontend": "cd frontend && npx tsc -b --force",
     "bundle:help": "bun scripts/bundle_help.ts",
     "check:help": "bun scripts/check_help_bundle.ts",
     "build:memory": "cd packages/memory && bun run build"

--- a/packages/memory/src/cli/util/checks.ts
+++ b/packages/memory/src/cli/util/checks.ts
@@ -20,9 +20,10 @@ import { PKG_VERSION } from "../../meta.ts";
 import { EF_LAST_CHANGED, EF_VERSION } from "../../../../../_shared/ef-meta/index.ts";
 import { loadSettings } from "../../../../../_shared/config/index.ts";
 import {
+  envFileHasCerefoxKey,
   resolveConfigDir,
   resolveEnvFile,
-  USER_STATE_DIR_NAME,
+  type ResolverOptions,
 } from "../../../../../_shared/config/index.ts";
 import {
   aggregatorUrlFor,
@@ -691,31 +692,53 @@ export function checkMcpConfigs(): CheckResult {
 }
 
 /**
- * v0.5.3: when `~/.cerefox/.env` exists AND a different `<cwd>/.env` exists,
- * report the CWD file as a shadowed legacy config. The TS CLI reads the
- * home file (new precedence), but Python's `uv run cerefox …` still reads
- * the CWD file during the migration window — safe to delete in v0.9+.
+ * v0.5.3: when the active config file exists AND a different `<cwd>/.env`
+ * exists, report the CWD file as a shadowed legacy config. The TS CLI reads
+ * the active file (new precedence), but Python's `uv run cerefox …` still
+ * read the CWD file during the migration window — safe to delete in v0.9+.
  *
  * Returns `null` when there's nothing interesting to report (no shadowing,
- * or the two paths resolve to the same physical file via symlink).
+ * the two paths resolve to the same physical file via symlink, or the CWD
+ * file isn't a Cerefox env at all).
+ *
+ * **Two bugs fixed in iter-40 (#225), both from this check making up its own
+ * rules instead of asking the resolver:**
+ *
+ *  1. It hardcoded `~/.cerefox/.env` as the shadower. Under
+ *     `CEREFOX_CONFIG_DIR` (how the staging convention works) that is not the
+ *     file in effect, so `doctor` printed a `config` line and a `legacy env`
+ *     line naming two different authorities. `doctor` is what people run to
+ *     confirm which environment they are addressing, so a false statement
+ *     there costs more than its size.
+ *  2. It fired on the mere existence of both files, without the
+ *     `CEREFOX_*`-key test `resolveConfigDir()` has used since iter-24. Run
+ *     `cerefox` from any unrelated project that happens to have a `.env` and
+ *     doctor named that project's file and called it "Safe to delete."
+ *
+ * Both are why this takes `ResolverOptions` and routes through
+ * `resolveEnvFile()`: a test that asserts on a hardcoded path would pass
+ * before and after a wrong fix.
  */
-export function checkLegacyShadowEnv(): CheckResult | null {
-  const home = homedir();
-  const homeEnv = join(home, USER_STATE_DIR_NAME, ".env");
-  const cwdEnv = join(process.cwd(), ".env");
-  if (!existsSync(homeEnv) || !existsSync(cwdEnv)) return null;
-  // Same file via symlink? Skip.
+export function checkLegacyShadowEnv(
+  opts: ResolverOptions = {},
+): CheckResult | null {
+  const activeEnv = resolveEnvFile(opts);
+  const cwdEnv = join(opts.cwd ?? process.cwd(), ".env");
+  if (!existsSync(activeEnv) || !existsSync(cwdEnv)) return null;
+  // The active config IS the CWD file (legacy dev-mode). Nothing is shadowed.
   try {
-    if (realpathSync(homeEnv) === realpathSync(cwdEnv)) return null;
+    if (realpathSync(activeEnv) === realpathSync(cwdEnv)) return null;
   } catch {
     // realpath failed on one of them — fall through to reporting.
   }
+  // Only a Cerefox env is ours to call disposable.
+  if (!envFileHasCerefoxKey(cwdEnv)) return null;
   return {
     name: "legacy env",
     status: "skipped",
-    detail: `${cwdEnv} (shadowed by ~/.cerefox/.env)`,
+    detail: `${cwdEnv} (shadowed by ${activeEnv})`,
     hint:
-      "Shadowed by ~/.cerefox/.env and no longer read by anything (Python was removed at " +
+      `Shadowed by ${activeEnv} and no longer read by anything (Python was removed at ` +
       "v1.0.0). Safe to delete.",
   };
 }

--- a/packages/memory/src/web/identity.ts
+++ b/packages/memory/src/web/identity.ts
@@ -1,0 +1,181 @@
+/**
+ * Caller identity for `/api/v1` (iter-40, #226).
+ *
+ * `/api/v1` was built as the web app's private backend and hardcoded its own
+ * identity: `author: "web-ui"` at every write, `access_path: "webapp"` at
+ * every usage-log entry. Any other client of the API was therefore
+ * unattributable, which pushed agent harnesses onto the MCP surface purely to
+ * obtain an identity, even where the HTTP API served them better.
+ *
+ * This module is the single place that answers "who is calling, and over
+ * what". Every route asks it; no route invents its own default.
+ *
+ * ## The contract
+ *
+ * - **Omitted, nothing changes.** No identity supplied means `web-ui` / `user`
+ *   / `webapp`, byte-identical to the pre-#226 behaviour. The bundled web app
+ *   sends nothing and is not modified.
+ * - **Headers, then body.** Headers work uniformly on every method (a GET
+ *   read cannot carry a body, and reads are half the point), so they are the
+ *   primary mechanism. JSON bodies are also honoured, because a client that
+ *   puts `author` in the body it is already sending has made an obvious and
+ *   reasonable guess, and silently ignoring it would be the worst outcome.
+ *   A header wins over a body field when both appear; that conflict is
+ *   pathological, but a stated rule beats an emergent one.
+ * - **`access_path` is derived, never accepted.** See below.
+ *
+ * ## Why `access_path` is not a parameter
+ *
+ * It is the one field in `cerefox_usage_log` still worth trusting, because
+ * the server sets it per transport rather than taking the caller's word.
+ * Accepting it would let a client lie about *where* as well as *who*, and
+ * *where* is what the analytics dashboard attributes load with.
+ *
+ * So it is derived: **if the caller named itself at all, the path is `"api"`;
+ * otherwise `"webapp"`.** That is an approximation, deliberately. It reads
+ * "supplied an identity" as "is not the bundled web app", which holds today
+ * because the web app supplies none.
+ *
+ * **The known edge**: if the web app ever passes a real `requestor`
+ * (multi-user, SSO, anything), it will start labelling itself `"api"`. That
+ * is a coupling, not a bug, and this comment is where a future reader finds
+ * out about it before being surprised by a dashboard.
+ *
+ * ## `author_type` has consequences
+ *
+ * `author_type: "agent"` makes an ingest land in `pending_review` rather than
+ * `approved` (`ingestion/pipeline.ts`), exactly as it does on the MCP path.
+ * That equivalence is the feature: the same actor is recorded, and treated,
+ * identically whichever transport it used. It is not a side effect to be
+ * engineered away, and it is documented in the API guide so nobody discovers
+ * it by finding their documents queued for review.
+ */
+
+import type { Context } from "hono";
+
+/** Access paths this server can record. A subset of `AccessPath`. */
+export type WebAccessPath = "webapp" | "api";
+
+export const DEFAULT_WEB_AUTHOR = "web-ui";
+export const DEFAULT_WEB_AUTHOR_TYPE = "user" as const;
+
+export interface CallerIdentity {
+  /** Recorded as `cerefox_audit_log.author` on writes. */
+  author: string;
+  /** Recorded as `cerefox_audit_log.author_type`. Drives ingest review status. */
+  authorType: "user" | "agent";
+  /** Recorded as `cerefox_usage_log.requestor` on reads and writes. */
+  requestor: string;
+  /** Derived, never accepted. See the module comment. */
+  accessPath: WebAccessPath;
+  /** True when the caller supplied any identity field at all. */
+  named: boolean;
+}
+
+/** The identity the API has always recorded when the caller supplies none. */
+export const WEB_UI_IDENTITY: CallerIdentity = {
+  author: DEFAULT_WEB_AUTHOR,
+  authorType: DEFAULT_WEB_AUTHOR_TYPE,
+  requestor: DEFAULT_WEB_AUTHOR,
+  accessPath: "webapp",
+  named: false,
+};
+
+export type IdentityResult =
+  | { ok: true; identity: CallerIdentity }
+  | { ok: false; detail: string };
+
+const HEADER = {
+  author: "x-cerefox-author",
+  authorType: "x-cerefox-author-type",
+  requestor: "x-cerefox-requestor",
+} as const;
+
+/**
+ * A supplied field must be a non-blank string. `undefined` means "not
+ * supplied"; anything else supplied but unusable is an error rather than a
+ * silent fallback, because silently recording `web-ui` for a caller that
+ * tried to identify itself is precisely the failure this feature exists to
+ * remove.
+ */
+function readField(
+  c: Context,
+  headerName: string,
+  body: Record<string, unknown> | null | undefined,
+  bodyKey: string,
+): { ok: true; value: string | undefined } | { ok: false; detail: string } {
+  const header = c.req.header(headerName);
+  if (header !== undefined) {
+    if (header.trim() === "") {
+      return { ok: false, detail: `${headerName} must not be blank.` };
+    }
+    return { ok: true, value: header.trim() };
+  }
+  if (body && bodyKey in body) {
+    const raw = body[bodyKey];
+    if (raw === null || raw === undefined) return { ok: true, value: undefined };
+    if (typeof raw !== "string") {
+      return { ok: false, detail: `${bodyKey} must be a string.` };
+    }
+    if (raw.trim() === "") {
+      return { ok: false, detail: `${bodyKey} must not be blank.` };
+    }
+    return { ok: true, value: raw.trim() };
+  }
+  return { ok: true, value: undefined };
+}
+
+/**
+ * Resolve who is calling. Pass the parsed JSON body when the route has one;
+ * omit it for GET/DELETE routes, which are header-only.
+ *
+ * Returns `ok: false` with a message suitable for a 400 when a supplied value
+ * is unusable. `author_type` is validated here rather than at the database,
+ * where the `cerefox_audit_log` CHECK would surface as a raw Postgres error.
+ */
+export function resolveCallerIdentity(
+  c: Context,
+  body?: Record<string, unknown> | null,
+): IdentityResult {
+  const author = readField(c, HEADER.author, body, "author");
+  if (!author.ok) return author;
+  const requestor = readField(c, HEADER.requestor, body, "requestor");
+  if (!requestor.ok) return requestor;
+  const authorType = readField(c, HEADER.authorType, body, "author_type");
+  if (!authorType.ok) return authorType;
+
+  if (
+    authorType.value !== undefined &&
+    authorType.value !== "user" &&
+    authorType.value !== "agent"
+  ) {
+    return {
+      ok: false,
+      detail: `author_type must be "user" or "agent" (got ${JSON.stringify(authorType.value)}).`,
+    };
+  }
+
+  const named =
+    author.value !== undefined ||
+    requestor.value !== undefined ||
+    authorType.value !== undefined;
+
+  if (!named) return { ok: true, identity: WEB_UI_IDENTITY };
+
+  // author and requestor stand in for each other: they name the same actor,
+  // and MCP splits them only because reads and writes log to different
+  // tables. A caller that gives one has identified itself for both.
+  const resolvedAuthor = author.value ?? requestor.value ?? DEFAULT_WEB_AUTHOR;
+  const resolvedRequestor = requestor.value ?? author.value ?? DEFAULT_WEB_AUTHOR;
+
+  return {
+    ok: true,
+    identity: {
+      author: resolvedAuthor,
+      authorType: (authorType.value as "user" | "agent") ?? DEFAULT_WEB_AUTHOR_TYPE,
+      requestor: resolvedRequestor,
+      accessPath: "api",
+      named: true,
+    },
+  };
+}

--- a/packages/memory/src/web/routes/config.ts
+++ b/packages/memory/src/web/routes/config.ts
@@ -20,6 +20,7 @@ import {
 } from "../../../../../_shared/config-catalog/index.ts";
 import { resolveEnvFile } from "../../../../../_shared/config/index.ts";
 import type { WebContext } from "../context.ts";
+import { resolveCallerIdentity } from "../identity.ts";
 import { storeWriteRemediation } from "../../../../../_shared/mcp-tools/_utils.ts";
 
 function unwrapScalarRpc(data: unknown): string | null {
@@ -137,14 +138,18 @@ export function registerConfigRoutes(app: Hono, ctx: WebContext): void {
     const invalid = validateConfigValue(key, value);
     if (invalid) return c.json({ detail: invalid }, 400);
 
-    // Author "web-ui" + author_type "user": the same convention every other
-    // web audit site uses, so an author='web-ui' filter catches dashboard
-    // config changes too. The RPC records the entry in-transaction (0.14.0).
+    // "web-ui" / "user" remains the default when the caller supplies no
+    // identity: the same convention every other web audit site uses, so an
+    // author='web-ui' filter still catches dashboard config changes. A caller
+    // that names itself is recorded as itself (#226). The RPC records the
+    // entry in-transaction (0.14.0).
+    const who = resolveCallerIdentity(c, body as Record<string, unknown>);
+    if (!who.ok) return c.json({ detail: who.detail }, 400);
     const { error } = await ctx.supabase.rpc("cerefox_set_config", {
       p_key: key,
       p_value: value,
-      p_author: "web-ui",
-      p_author_type: "user",
+      p_author: who.identity.author,
+      p_author_type: who.identity.authorType,
     });
     if (error) {
       // One classifier shared with the CLI (round 4): deployment-state

--- a/packages/memory/src/web/routes/discovery.ts
+++ b/packages/memory/src/web/routes/discovery.ts
@@ -20,6 +20,7 @@ import { fetchAllPages } from "../../../../../_shared/db-client/paginate.ts";
 import { getMinSearchScore, getSearchAlpha } from "../../../../../_shared/mcp-tools/_utils.js";
 import type { WebContext } from "../context.ts";
 import { logWebUsage } from "../usage.ts";
+import { resolveCallerIdentity } from "../identity.ts";
 
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -515,7 +516,16 @@ export function registerDiscoveryRoutes(app: Hono, ctx: WebContext): void {
       }
     }
 
-    logWebUsage(ctx, { operation: "search", query_text: q, result_count: results.length });
+    // Reads are header-only: a GET carries no body (#226).
+    const who = resolveCallerIdentity(c);
+    if (!who.ok) return c.json({ detail: who.detail }, 400);
+    logWebUsage(ctx, {
+      operation: "search",
+      query_text: q,
+      result_count: results.length,
+      requestor: who.identity.requestor,
+      access_path: who.identity.accessPath,
+    });
 
     return c.json({
       results,

--- a/packages/memory/src/web/routes/documents-read.ts
+++ b/packages/memory/src/web/routes/documents-read.ts
@@ -22,6 +22,7 @@ import { Hono } from "hono";
 
 import type { WebContext } from "../context.ts";
 import { logWebUsage } from "../usage.ts";
+import { resolveCallerIdentity } from "../identity.ts";
 
 interface DocReconRow {
   document_id?: string;
@@ -154,7 +155,15 @@ export function registerDocumentReadRoutes(app: Hono, ctx: WebContext): void {
     const projectIds = await listDocumentProjectIds(ctx, documentId);
     const versions = await listDocumentVersions(ctx, documentId);
 
-    logWebUsage(ctx, { operation: "get-document", document_id: documentId });
+    // Reads are header-only: a GET carries no body (#226).
+    const who = resolveCallerIdentity(c);
+    if (!who.ok) return c.json({ detail: who.detail }, 400);
+    logWebUsage(ctx, {
+      operation: "get-document",
+      document_id: documentId,
+      requestor: who.identity.requestor,
+      access_path: who.identity.accessPath,
+    });
 
     return c.json({
       document_id: documentId,

--- a/packages/memory/src/web/routes/documents-write.ts
+++ b/packages/memory/src/web/routes/documents-write.ts
@@ -50,6 +50,7 @@ import {
   IngestionPipeline,
 } from "../../ingestion/pipeline.ts";
 import type { WebContext } from "../context.ts";
+import { resolveCallerIdentity } from "../identity.ts";
 
 // `normaliseForHash` + `contentHash` promoted to `_shared/ingest/pipeline-
 // helpers.ts` in iter-25 Part 25C so the TS ingestion pipeline (v0.7) and
@@ -107,6 +108,8 @@ export function registerDocumentWriteRoutes(app: Hono, ctx: WebContext): void {
     } catch {
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
+    const who = resolveCallerIdentity(c, body);
+    if (!who.ok) return c.json({ detail: who.detail }, 400);
     const title = String(body.title ?? "").trim();
     const content = String(body.content ?? "");
     const projectIds = Array.isArray(body.project_ids)
@@ -185,8 +188,8 @@ export function registerDocumentWriteRoutes(app: Hono, ctx: WebContext): void {
           // Carried-vs-absent (round 2): {} must CLEAR metadata on a
           // content-changing save too, not silently vanish.
           metadata: body.metadata != null ? metadata : undefined,
-          author: "web-ui",
-          authorType: "user",
+          author: who.identity.author,
+          authorType: who.identity.authorType,
           // Optimistic concurrency (iter-32): the SPA sends the content_hash
           // it loaded the document with; a concurrent change → 409 below.
           expectedContentHash:
@@ -279,9 +282,9 @@ export function registerDocumentWriteRoutes(app: Hono, ctx: WebContext): void {
         // (which clears every key) — round 2 caught null wiping metadata.
         metadata: body.metadata != null ? metadata : undefined,
         projectIds: Array.isArray(body.project_ids) ? projectIds : undefined,
-        author: "web-ui",
-        authorType: "user",
-        accessPath: "webapp",
+        author: who.identity.author,
+        authorType: who.identity.authorType,
+        accessPath: who.identity.accessPath,
       });
       return c.json({ success: true, reindexed: false, ...facets });
     } catch (err) {
@@ -305,10 +308,13 @@ export function registerDocumentWriteRoutes(app: Hono, ctx: WebContext): void {
   // ── DELETE /documents/{id} ─────────────────────────────────────────────────
   app.delete("/api/v1/documents/:document_id", async (c) => {
     const documentId = c.req.param("document_id");
+    // No body on this method — identity comes from headers only.
+    const who = resolveCallerIdentity(c);
+    if (!who.ok) return c.json({ detail: who.detail }, 400);
     const { data, error } = await ctx.supabase.rpc("cerefox_delete_document", {
       p_document_id: documentId,
-      p_author: "web-ui",
-      p_author_type: "user",
+      p_author: who.identity.author,
+      p_author_type: who.identity.authorType,
     });
     if (error) {
       // 0.12.0: a missing document RAISEs instead of silently no-opping. A
@@ -328,10 +334,13 @@ export function registerDocumentWriteRoutes(app: Hono, ctx: WebContext): void {
   // ── POST /documents/{id}/restore ───────────────────────────────────────────
   app.post("/api/v1/documents/:document_id/restore", async (c) => {
     const documentId = c.req.param("document_id");
+    // No body on this method — identity comes from headers only.
+    const who = resolveCallerIdentity(c);
+    if (!who.ok) return c.json({ detail: who.detail }, 400);
     const { data, error } = await ctx.supabase.rpc("cerefox_restore_document", {
       p_document_id: documentId,
-      p_author: "web-ui",
-      p_author_type: "user",
+      p_author: who.identity.author,
+      p_author_type: who.identity.authorType,
     });
     if (error) {
       // Two-tab race: A purges, B restores. 404 keeps the wrong-state class
@@ -352,10 +361,13 @@ export function registerDocumentWriteRoutes(app: Hono, ctx: WebContext): void {
   // ── DELETE /documents/{id}/purge ───────────────────────────────────────────
   app.delete("/api/v1/documents/:document_id/purge", async (c) => {
     const documentId = c.req.param("document_id");
+    // No body on this method — identity comes from headers only.
+    const who = resolveCallerIdentity(c);
+    if (!who.ok) return c.json({ detail: who.detail }, 400);
     const { error } = await ctx.supabase.rpc("cerefox_purge_document", {
       p_document_id: documentId,
-      p_author: "web-ui",
-      p_author_type: "user",
+      p_author: who.identity.author,
+      p_author_type: who.identity.authorType,
     });
     if (error) return c.json({ detail: error.message }, 500);
     return c.json({ success: true });
@@ -370,6 +382,8 @@ export function registerDocumentWriteRoutes(app: Hono, ctx: WebContext): void {
     } catch {
       return c.json({ detail: "Invalid JSON body" }, 400);
     }
+    const who = resolveCallerIdentity(c, body);
+    if (!who.ok) return c.json({ detail: who.detail }, 400);
     const status = body.status;
     if (status !== "approved" && status !== "pending_review") {
       return c.json(
@@ -398,7 +412,8 @@ export function registerDocumentWriteRoutes(app: Hono, ctx: WebContext): void {
 
     await createAuditEntry(ctx, {
       operation: "status-change",
-      author: "user",
+      author: who.identity.author,
+      authorType: who.identity.authorType,
       documentId,
       description: `Review status changed from '${oldStatus}' to '${status}'`,
     });
@@ -417,6 +432,8 @@ export function registerDocumentWriteRoutes(app: Hono, ctx: WebContext): void {
       } catch {
         return c.json({ detail: "Invalid JSON body" }, 400);
       }
+      const who = resolveCallerIdentity(c, body);
+      if (!who.ok) return c.json({ detail: who.detail }, 400);
       const archived = Boolean(body.archived);
 
       const { data, error } = await ctx.supabase
@@ -433,7 +450,8 @@ export function registerDocumentWriteRoutes(app: Hono, ctx: WebContext): void {
       const op = archived ? "archive" : "unarchive";
       await createAuditEntry(ctx, {
         operation: op,
-        author: "user",
+        author: who.identity.author,
+        authorType: who.identity.authorType,
         documentId: ver?.document_id ?? documentId,
         versionId,
         description: `Version ${ver?.version_number ?? "?"} ${op}d`,

--- a/packages/memory/src/web/routes/documents-write.ts
+++ b/packages/memory/src/web/routes/documents-write.ts
@@ -311,10 +311,40 @@ export function registerDocumentWriteRoutes(app: Hono, ctx: WebContext): void {
     // No body on this method — identity comes from headers only.
     const who = resolveCallerIdentity(c);
     if (!who.ok) return c.json({ detail: who.detail }, 400);
+
+    // Optimistic locking on delete (iter-40). The RPC has taken an optional
+    // CAS token since 0.12.0 (#208) and cerefox_delete_document over MCP
+    // REQUIRES it: a delete must follow a read. This route passed nothing,
+    // which was defensible while the only caller was the web UI, where the
+    // human sees the document and confirms in a dialog.
+    //
+    // Opening the surface to identified clients removes that safeguard without
+    // replacing it, so: a caller that names itself must present the hash, the
+    // same rule it would meet over MCP. An anonymous caller is the bundled web
+    // UI and keeps today's behaviour exactly, which is the compatibility
+    // promise this whole change is built on.
+    const expectedHash = (
+      c.req.header("x-cerefox-expected-content-hash") ??
+      c.req.query("expected_content_hash") ??
+      ""
+    ).trim();
+    if (who.identity.named && expectedHash === "") {
+      return c.json(
+        {
+          detail:
+            "CEREFOX_TOKEN_REQUIRED: an identified caller must send the content_hash it read, " +
+            "as the X-Cerefox-Expected-Content-Hash header or an expected_content_hash query " +
+            "parameter. A delete must follow a read.",
+        },
+        400,
+      );
+    }
+
     const { data, error } = await ctx.supabase.rpc("cerefox_delete_document", {
       p_document_id: documentId,
       p_author: who.identity.author,
       p_author_type: who.identity.authorType,
+      p_expected_content_hash: expectedHash === "" ? null : expectedHash,
     });
     if (error) {
       // 0.12.0: a missing document RAISEs instead of silently no-opping. A

--- a/packages/memory/src/web/routes/ingest.ts
+++ b/packages/memory/src/web/routes/ingest.ts
@@ -256,23 +256,21 @@ export function registerIngestRoutes(app: Hono, ctx: WebContext): void {
         // began requiring one — every call returned CEREFOX_TOKEN_REQUIRED.
         // It went unnoticed for eleven releases because the only test covering
         // it lives in the web-integration suite, which had been skipping since
-        // v0.9.0 on a renamed probe verb. The bundled web app never calls this
-        // endpoint, so nothing user-visible broke; API clients got a hard stop.
+        // v0.9.0 on a renamed probe verb.
         //
-        // Replacing a document's content with an uploaded file IS the
-        // file-re-sync case the design names as the legitimate use of
-        // last_write_wins (`ingest-dir` and `guides ingest` do the same), so
-        // that is the default and it restores the pre-v0.11 contract. A caller
-        // that wants the safe path sends expected_content_hash and gets a 409
-        // on a stale token like every other write.
+        // It takes the SAME contract as every other content update: send the
+        // hash you read, or say last_write_wins explicitly. There is no
+        // implicit last-write-wins default, because there is no working caller
+        // to stay compatible with — the endpoint has been a hard error since
+        // v0.11.0, so the strict semantics cost nothing and a silent clobber
+        // would have been a new way to lose data on a surface we are opening
+        // to more clients.
         expectedContentHash:
           typeof form.expected_content_hash === "string" &&
           form.expected_content_hash.trim() !== ""
             ? form.expected_content_hash.trim()
             : null,
-        lastWriteWins:
-          !(typeof form.expected_content_hash === "string" &&
-            form.expected_content_hash.trim() !== ""),
+        lastWriteWins: String(form.last_write_wins ?? "") === "true",
       });
       logWebUsage(ctx, {
         operation: "ingest",

--- a/packages/memory/src/web/routes/ingest.ts
+++ b/packages/memory/src/web/routes/ingest.ts
@@ -27,6 +27,7 @@ import { fileToMarkdown } from "../../ingestion/file-to-markdown.ts";
 import { IngestionPipeline } from "../../ingestion/pipeline.ts";
 import type { WebContext } from "../context.ts";
 import { logWebUsage } from "../usage.ts";
+import { resolveCallerIdentity } from "../identity.ts";
 
 interface IngestResponse {
   success: boolean;
@@ -61,6 +62,9 @@ export function registerIngestRoutes(app: Hono, ctx: WebContext): void {
     if (!title) return c.json(notReady("Title is required."), 200);
     if (!content.trim()) return c.json(notReady("Content cannot be empty."), 200);
 
+    const who = resolveCallerIdentity(c, body);
+    if (!who.ok) return c.json({ detail: who.detail }, 400);
+
     try {
       const pipeline = new IngestionPipeline({
         supabase: ctx.supabase,
@@ -76,8 +80,8 @@ export function registerIngestRoutes(app: Hono, ctx: WebContext): void {
         metadata: (body.metadata as Record<string, string> | undefined) ?? null,
         updateExisting: Boolean(body.update_existing),
         documentId: (body.document_id as string | undefined) ?? null,
-        author: "web-ui",
-        authorType: "user",
+        author: who.identity.author,
+        authorType: who.identity.authorType,
       });
       const skipped = result.action === "skipped";
       const resp: IngestResponse = {
@@ -88,7 +92,12 @@ export function registerIngestRoutes(app: Hono, ctx: WebContext): void {
         updated: result.reindexed,
       };
       if (result.note) resp.note = result.note;
-      logWebUsage(ctx, { operation: "ingest", document_id: result.documentId });
+      logWebUsage(ctx, {
+        operation: "ingest",
+        document_id: result.documentId,
+        requestor: who.identity.requestor,
+        access_path: who.identity.accessPath,
+      });
       return c.json(resp, 200);
     } catch (err) {
       return c.json(
@@ -139,6 +148,10 @@ export function registerIngestRoutes(app: Hono, ctx: WebContext): void {
       }
     }
 
+    // Multipart form fields are strings, so the same resolver reads them.
+    const who = resolveCallerIdentity(c, form);
+    if (!who.ok) return c.json({ detail: who.detail }, 400);
+
     try {
       const pipeline = new IngestionPipeline({
         supabase: ctx.supabase,
@@ -152,11 +165,16 @@ export function registerIngestRoutes(app: Hono, ctx: WebContext): void {
         projectIds,
         metadata,
         updateExisting,
-        author: "web-ui",
-        authorType: "user",
+        author: who.identity.author,
+        authorType: who.identity.authorType,
       });
       const skipped = result.action === "skipped";
-      logWebUsage(ctx, { operation: "ingest", document_id: result.documentId });
+      logWebUsage(ctx, {
+        operation: "ingest",
+        document_id: result.documentId,
+        requestor: who.identity.requestor,
+        access_path: who.identity.accessPath,
+      });
       return c.json(
         {
           success: !skipped,
@@ -218,6 +236,9 @@ export function registerIngestRoutes(app: Hono, ctx: WebContext): void {
     const title =
       (existing.title as string | null) || file.name || "Untitled";
 
+    const who = resolveCallerIdentity(c, form);
+    if (!who.ok) return c.json({ detail: who.detail }, 400);
+
     try {
       const pipeline = new IngestionPipeline({
         supabase: ctx.supabase,
@@ -228,10 +249,37 @@ export function registerIngestRoutes(app: Hono, ctx: WebContext): void {
         text,
         title,
         source: "file",
-        author: "web-ui",
-        authorType: "user",
+        author: who.identity.author,
+        authorType: who.identity.authorType,
+        // Optimistic concurrency (iter-40, #228). This route passed NEITHER a
+        // hash nor last_write_wins, so from v0.11.0 — when content updates
+        // began requiring one — every call returned CEREFOX_TOKEN_REQUIRED.
+        // It went unnoticed for eleven releases because the only test covering
+        // it lives in the web-integration suite, which had been skipping since
+        // v0.9.0 on a renamed probe verb. The bundled web app never calls this
+        // endpoint, so nothing user-visible broke; API clients got a hard stop.
+        //
+        // Replacing a document's content with an uploaded file IS the
+        // file-re-sync case the design names as the legitimate use of
+        // last_write_wins (`ingest-dir` and `guides ingest` do the same), so
+        // that is the default and it restores the pre-v0.11 contract. A caller
+        // that wants the safe path sends expected_content_hash and gets a 409
+        // on a stale token like every other write.
+        expectedContentHash:
+          typeof form.expected_content_hash === "string" &&
+          form.expected_content_hash.trim() !== ""
+            ? form.expected_content_hash.trim()
+            : null,
+        lastWriteWins:
+          !(typeof form.expected_content_hash === "string" &&
+            form.expected_content_hash.trim() !== ""),
       });
-      logWebUsage(ctx, { operation: "ingest", document_id: result.documentId });
+      logWebUsage(ctx, {
+        operation: "ingest",
+        document_id: result.documentId,
+        requestor: who.identity.requestor,
+        access_path: who.identity.accessPath,
+      });
       return c.json(
         {
           success: true,

--- a/packages/memory/src/web/routes/projects.ts
+++ b/packages/memory/src/web/routes/projects.ts
@@ -11,16 +11,19 @@
  *
  * 0.14.0 (#147/#219): the three write routes call the project write RPCs
  * (cerefox_create_project / cerefox_update_project / cerefox_delete_project),
- * which perform the write AND its audit entry in one transaction. Author is
- * "web-ui" with author_type "user" — the convention every other web audit
- * site follows (documents-write.ts, ingest.ts), so filtering the trail by
- * author='web-ui' catches dashboard-originated store-level writes too.
+ * which perform the write AND its audit entry in one transaction. Author
+ * defaults to "web-ui" with author_type "user" — the convention every other
+ * web audit site follows (documents-write.ts, ingest.ts), so filtering the
+ * trail by author='web-ui' still catches dashboard-originated store-level
+ * writes. Since #226 a caller that identifies itself is recorded as itself;
+ * see `../identity.ts`.
  */
 
 import { Hono } from "hono";
 
 import { isDuplicateKeyError, storeWriteRemediation } from "../../../../../_shared/mcp-tools/_utils.ts";
 import type { WebContext } from "../context.ts";
+import { resolveCallerIdentity } from "../identity.ts";
 
 interface ProjectRpcRow {
   project_id: string;
@@ -75,11 +78,13 @@ export function registerProjectsRoutes(app: Hono, ctx: WebContext): void {
     const name = String(body.name ?? "").trim();
     if (!name) return c.json({ detail: "Project name is required" }, 400);
     const description = String(body.description ?? "").trim();
+    const who = resolveCallerIdentity(c, body as Record<string, unknown>);
+    if (!who.ok) return c.json({ detail: who.detail }, 400);
     const { data, error } = await ctx.supabase.rpc("cerefox_create_project", {
       p_name: name,
       p_description: description,
-      p_author: "web-ui",
-      p_author_type: "user",
+      p_author: who.identity.author,
+      p_author_type: who.identity.authorType,
     });
     if (error) {
       const msg = error.message ?? "";
@@ -120,12 +125,14 @@ export function registerProjectsRoutes(app: Hono, ctx: WebContext): void {
     }
     // The RPC updates only the provided fields, diffs against the stored
     // row for the audit description, and audits in-transaction (#219).
+    const who = resolveCallerIdentity(c, body as Record<string, unknown>);
+    if (!who.ok) return c.json({ detail: who.detail }, 400);
     const { data, error } = await ctx.supabase.rpc("cerefox_update_project", {
       p_project_id: projectId,
       p_name: update.name ?? null,
       p_description: update.description ?? null,
-      p_author: "web-ui",
-      p_author_type: "user",
+      p_author: who.identity.author,
+      p_author_type: who.identity.authorType,
     });
     if (error) {
       const msg = error.message ?? "";
@@ -145,10 +152,13 @@ export function registerProjectsRoutes(app: Hono, ctx: WebContext): void {
     // The RPC deletes and audits atomically, and audits ONLY when a row was
     // actually removed — the audit log must never assert an event that did
     // not occur (double-click, stale tab → 404 here, no entry).
+    // No body on this method — identity comes from headers only.
+    const who = resolveCallerIdentity(c);
+    if (!who.ok) return c.json({ detail: who.detail }, 400);
     const { data, error } = await ctx.supabase.rpc("cerefox_delete_project", {
       p_project_id: projectId,
-      p_author: "web-ui",
-      p_author_type: "user",
+      p_author: who.identity.author,
+      p_author_type: who.identity.authorType,
     });
     if (error) return c.json({ detail: error.message }, 500);
     const row = (data as Array<{ deleted: boolean }> | null)?.[0];

--- a/packages/memory/src/web/usage.ts
+++ b/packages/memory/src/web/usage.ts
@@ -10,6 +10,7 @@
  */
 
 import type { WebContext } from "./context.ts";
+import { DEFAULT_WEB_AUTHOR, type WebAccessPath } from "./identity.ts";
 
 export interface WebUsageParams {
   operation: string;
@@ -18,14 +19,20 @@ export interface WebUsageParams {
   query_text?: string | null;
   result_count?: number | null;
   requestor?: string | null;
+  /**
+   * Where the call came from (iter-40, #226). Derived from whether the caller
+   * identified itself — never taken from the request. Defaults to `"webapp"`,
+   * which is what every caller was recorded as before #226.
+   */
+  access_path?: WebAccessPath | null;
 }
 
 export function logWebUsage(ctx: WebContext, params: WebUsageParams): void {
   Promise.resolve(
     ctx.supabase.rpc("cerefox_log_usage", {
       p_operation: params.operation,
-      p_access_path: "webapp",
-      p_requestor: params.requestor ?? "web-ui",
+      p_access_path: params.access_path ?? "webapp",
+      p_requestor: params.requestor ?? DEFAULT_WEB_AUTHOR,
       p_document_id: params.document_id ?? null,
       p_project_id: params.project_id ?? null,
       p_query_text: params.query_text ?? null,

--- a/packages/memory/test/_live-probe.ts
+++ b/packages/memory/test/_live-probe.ts
@@ -1,0 +1,91 @@
+/**
+ * The one "is the live backend reachable?" probe.
+ *
+ * ## Why this is a shared module and not three copies
+ *
+ * It was three copies, and two of them rotted. The probe spawned
+ * `cerefox list-projects --json` and treated a non-zero exit as "backend
+ * unreachable". **v0.9.0 renamed that verb to `project list`**, leaving
+ * `list-projects` as a deliberate husk that prints a pointer and exits 1.
+ *
+ * The husk worked exactly as designed. The probe read its exit code as
+ * "Supabase is unreachable" and skipped. From v0.9.0 to v1.10.1 the entire
+ * `web-integration/` HTTP-boundary suite and the live half of
+ * `stdio-smoke.test.ts` reported success while running nothing. Eleven
+ * releases, a green suite, and no coverage — found only because a new test
+ * in that directory skipped when it should have run.
+ *
+ * Two lessons are baked in below:
+ *
+ *  1. **One implementation.** A probe copied into each file is a list that has
+ *     to match another list (the CLI's verbs), and that shape has now produced
+ *     four incidents on this project.
+ *  2. **A probe must not be able to fail silently.** "The backend is
+ *     unreachable" and "I asked the CLI something it does not understand" are
+ *     different answers, and only the first justifies a skip. The second is a
+ *     broken harness and must be loud. `probeSupabase()` throws on it.
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+export const PKG_ROOT = join(HERE, "..");
+export const REPO_ROOT = join(PKG_ROOT, "..", "..");
+export const BIN = join(PKG_ROOT, "dist", "bin", "cerefox.js");
+
+/**
+ * The probe command. `project list` is cheap, read-only, and touches the Data
+ * API — which is exactly the reachability question.
+ */
+export const PROBE_ARGV = ["project", "list", "--json"] as const;
+
+/**
+ * Output that means the CLI did not understand us, rather than that the
+ * backend is down. A renamed-verb husk and commander's unknown-command error
+ * both land here.
+ */
+const HARNESS_BROKEN = /was renamed|unknown command|unknown option|display help/i;
+
+export interface ProbeResult {
+  ok: boolean;
+  status: number;
+  output: string;
+}
+
+/** Run the probe once and return the raw result, without interpreting it. */
+export function runProbe(): ProbeResult {
+  if (!existsSync(BIN)) return { ok: false, status: -1, output: "" };
+  const result = spawnSync("node", [BIN, ...PROBE_ARGV], {
+    cwd: REPO_ROOT,
+    env: { ...process.env },
+    timeout: 10_000,
+    encoding: "utf8",
+  });
+  const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+  return { ok: result.status === 0, status: result.status ?? -1, output };
+}
+
+/**
+ * `true` when the live backend answered. `false` means genuinely unreachable
+ * or unconfigured, which is a legitimate reason to skip.
+ *
+ * **Throws** when the CLI rejected the probe command itself. That is a broken
+ * test harness, and the whole point of this module is that it can no longer
+ * be mistaken for an absent backend.
+ */
+export function probeSupabase(): boolean {
+  const probe = runProbe();
+  if (probe.ok) return true;
+  if (HARNESS_BROKEN.test(probe.output)) {
+    throw new Error(
+      `Live probe is broken: \`cerefox ${PROBE_ARGV.join(" ")}\` was rejected by the CLI ` +
+        `(exit ${probe.status}). This is NOT an unreachable backend — it means the probe ` +
+        `command no longer exists under that name, which is how the web-integration suite ` +
+        `silently skipped from v0.9.0 to v1.10.1. Fix PROBE_ARGV.\n\nCLI said:\n${probe.output.trim()}`,
+    );
+  }
+  return false;
+}

--- a/packages/memory/test/cli-deploy-server.test.ts
+++ b/packages/memory/test/cli-deploy-server.test.ts
@@ -9,7 +9,8 @@
 
 import { describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -64,12 +65,25 @@ describe("cerefox deploy-server CLI", () => {
   });
 
   test("missing CEREFOX_DATABASE_URL → pre-flight refuses with remediation", () => {
-    const { stdout, stderr, status } = run(["server", "deploy", "--schema-only"], {
-      CEREFOX_DATABASE_URL: "",
-    });
-    expect(status).toBe(1);
-    const all = stdout + stderr;
-    expect(all).toContain("CEREFOX_DATABASE_URL");
-    expect(all).toMatch(/prerequisite|Cannot deploy/i);
+    // An empty string in the child env is not enough: the CLI calls loadEnv(),
+    // which fills unset keys from the RESOLVED config file. Run this against a
+    // scratch config dir with no .env at all, so nothing ambient can supply the
+    // value. Without it the test fails under the documented staging invocation
+    // (`CEREFOX_CONFIG_DIR=~/.cerefox/staging bun test`), because that .env
+    // legitimately defines CEREFOX_DATABASE_URL — a red test caused by the
+    // environment being correctly configured.
+    const emptyConfigDir = mkdtempSync(join(tmpdir(), "cfx-nodburl-"));
+    try {
+      const { stdout, stderr, status } = run(["server", "deploy", "--schema-only"], {
+        CEREFOX_DATABASE_URL: "",
+        CEREFOX_CONFIG_DIR: emptyConfigDir,
+      });
+      expect(status).toBe(1);
+      const all = stdout + stderr;
+      expect(all).toContain("CEREFOX_DATABASE_URL");
+      expect(all).toMatch(/prerequisite|Cannot deploy/i);
+    } finally {
+      rmSync(emptyConfigDir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/memory/test/daemon-state-dir.test.ts
+++ b/packages/memory/test/daemon-state-dir.test.ts
@@ -16,7 +16,21 @@ const HOME = "/home/tester";
 
 describe("resolveStateDir", () => {
   test("defaults to ~/.cerefox when no override is set", () => {
-    expect(resolveStateDir(undefined, HOME)).toBe(join(HOME, ".cerefox"));
+    // `override` DEFAULTS to process.env.CEREFOX_CONFIG_DIR, so passing
+    // `undefined` does not mean "unset" — it means "read the environment".
+    // The ambient value has to go for the duration, or this test fails under
+    // the documented staging invocation
+    // (`CEREFOX_CONFIG_DIR=~/.cerefox/staging bun test`), which is exactly how
+    // it was failing: a red test under the command the guides tell you to run
+    // teaches people that red is normal.
+    const saved = process.env.CEREFOX_CONFIG_DIR;
+    delete process.env.CEREFOX_CONFIG_DIR;
+    try {
+      expect(resolveStateDir(undefined, HOME)).toBe(join(HOME, ".cerefox"));
+    } finally {
+      if (saved === undefined) delete process.env.CEREFOX_CONFIG_DIR;
+      else process.env.CEREFOX_CONFIG_DIR = saved;
+    }
   });
 
   test("treats an empty or whitespace override as unset", () => {

--- a/packages/memory/test/doctor-legacy-env.test.ts
+++ b/packages/memory/test/doctor-legacy-env.test.ts
@@ -1,0 +1,135 @@
+/**
+ * `doctor`'s `legacy env` check must ask the resolver, not invent its own rules.
+ *
+ * Two bugs (iter-40, #225), both from the check hardcoding what
+ * `resolveConfigDir()` already knows:
+ *
+ *  1. It named `~/.cerefox/.env` as the shadower unconditionally, so under
+ *     `CEREFOX_CONFIG_DIR` (the staging convention) `doctor` printed a `config`
+ *     line and a `legacy env` line naming two different authorities.
+ *  2. It fired on the existence of any `<cwd>/.env`, without the `CEREFOX_*`-key
+ *     test the resolver has used since iter-24 — so running `cerefox` inside an
+ *     unrelated project named that project's `.env` and called it safe to delete.
+ *
+ * Every case here drives the resolver through `ResolverOptions` and
+ * `CEREFOX_CONFIG_DIR` rather than asserting on a literal path. That is the
+ * point: an assertion that the message says `~/.cerefox/.env` passes both
+ * before the fix and after a wrong one.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { checkLegacyShadowEnv } from "../src/cli/util/checks.ts";
+
+const roots: string[] = [];
+function tempRoot(): string {
+  const d = mkdtempSync(join(tmpdir(), "cfx-legacyenv-"));
+  roots.push(d);
+  return d;
+}
+
+const CEREFOX_ENV = "CEREFOX_SUPABASE_URL=https://example.supabase.co\n";
+const FOREIGN_ENV = "DATABASE_URL=postgres://localhost/other\nPORT=3000\n";
+
+/**
+ * Build a home dir with `~/.cerefox/.env` and a separate working dir whose
+ * `.env` contains `body`. Returns both paths.
+ */
+function scaffold(body: string): { home: string; cwd: string; homeEnv: string } {
+  const root = tempRoot();
+  const home = join(root, "home");
+  const cwd = join(root, "project");
+  mkdirSync(join(home, ".cerefox"), { recursive: true });
+  mkdirSync(cwd, { recursive: true });
+  const homeEnv = join(home, ".cerefox", ".env");
+  writeFileSync(homeEnv, CEREFOX_ENV);
+  writeFileSync(join(cwd, ".env"), body);
+  return { home, cwd, homeEnv };
+}
+
+const savedConfigDir = process.env.CEREFOX_CONFIG_DIR;
+afterEach(() => {
+  if (savedConfigDir === undefined) delete process.env.CEREFOX_CONFIG_DIR;
+  else process.env.CEREFOX_CONFIG_DIR = savedConfigDir;
+  for (const d of roots.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+describe("checkLegacyShadowEnv", () => {
+  test("reports the home env as the shadower when it is the active config", () => {
+    delete process.env.CEREFOX_CONFIG_DIR;
+    const { home, cwd, homeEnv } = scaffold(CEREFOX_ENV);
+
+    const result = checkLegacyShadowEnv({ home, cwd });
+
+    expect(result).not.toBeNull();
+    expect(result?.name).toBe("legacy env");
+    expect(result?.detail).toContain(join(cwd, ".env"));
+    expect(result?.detail).toContain(homeEnv);
+    expect(result?.hint).toContain(homeEnv);
+  });
+
+  test("names the CEREFOX_CONFIG_DIR env file, not the home one (#225)", () => {
+    const { home, cwd } = scaffold(CEREFOX_ENV);
+    const staging = join(tempRoot(), "staging");
+    mkdirSync(staging, { recursive: true });
+    const stagingEnv = join(staging, ".env");
+    writeFileSync(stagingEnv, CEREFOX_ENV);
+    process.env.CEREFOX_CONFIG_DIR = staging;
+
+    const result = checkLegacyShadowEnv({ home, cwd });
+
+    expect(result).not.toBeNull();
+    // The active config file is the one named as doing the shadowing...
+    expect(result?.detail).toContain(stagingEnv);
+    expect(result?.hint).toContain(stagingEnv);
+    // ...and the home file, which is NOT in effect, is not mentioned at all.
+    expect(result?.detail).not.toContain(join(home, ".cerefox", ".env"));
+    expect(result?.hint).not.toContain(join(home, ".cerefox", ".env"));
+  });
+
+  test("stays silent on an unrelated project's .env (#225)", () => {
+    delete process.env.CEREFOX_CONFIG_DIR;
+    const { home, cwd } = scaffold(FOREIGN_ENV);
+
+    // No CEREFOX_* key in that file, so it is not ours and we must not offer
+    // to delete it.
+    expect(checkLegacyShadowEnv({ home, cwd })).toBeNull();
+  });
+
+  test("stays silent when the CWD env IS the active config (dev mode)", () => {
+    delete process.env.CEREFOX_CONFIG_DIR;
+    const root = tempRoot();
+    const home = join(root, "home");
+    const cwd = join(root, "project");
+    // No ~/.cerefox/.env at all, so the resolver falls back to the CWD file.
+    mkdirSync(home, { recursive: true });
+    mkdirSync(cwd, { recursive: true });
+    writeFileSync(join(cwd, ".env"), CEREFOX_ENV);
+
+    expect(checkLegacyShadowEnv({ home, cwd })).toBeNull();
+  });
+
+  test("stays silent when there is no CWD env", () => {
+    delete process.env.CEREFOX_CONFIG_DIR;
+    const root = tempRoot();
+    const home = join(root, "home");
+    const cwd = join(root, "project");
+    mkdirSync(join(home, ".cerefox"), { recursive: true });
+    mkdirSync(cwd, { recursive: true });
+    writeFileSync(join(home, ".cerefox", ".env"), CEREFOX_ENV);
+
+    expect(checkLegacyShadowEnv({ home, cwd })).toBeNull();
+  });
+
+  test("the CEREFOX_* test is the resolver's, not a copy", () => {
+    delete process.env.CEREFOX_CONFIG_DIR;
+    // A file that mentions cerefox but declares no CEREFOX_ key must not count:
+    // this pins the predicate to a key match rather than a substring search,
+    // which is the shape a re-implementation would get wrong.
+    const { home, cwd } = scaffold("# cerefox notes\nOTHER=CEREFOX_SUPABASE_URL\n");
+    expect(checkLegacyShadowEnv({ home, cwd })).toBeNull();
+  });
+});

--- a/packages/memory/test/stdio-smoke.test.ts
+++ b/packages/memory/test/stdio-smoke.test.ts
@@ -15,13 +15,14 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { spawn, spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { ALL_TOOLS } from "../../../_shared/mcp-tools/index.ts";
 import { RELATION_TOOL_NAMES } from "../../../_shared/mcp-tools/feature-flags.ts";
+import { probeSupabase } from "./_live-probe.ts";
 
 // Derived, not hardcoded: a literal list here sat at 10 names while the
 // surface grew to 13 — invisible because this test probe-and-skips without
@@ -34,21 +35,12 @@ const REPO_ROOT = join(PKG_ROOT, "..", "..");
 const BIN = join(PKG_ROOT, "dist", "bin", "cerefox.js");
 const MCP_ARGS = [BIN, "mcp"];
 
-// Match the probe-and-skip pattern from read/write/lifecycle live tests:
-// spawn `cerefox list-projects --json` from REPO_ROOT (so `.env` is
-// resolved exactly as the MCP server would resolve it on a real boot).
-// Non-zero exit = no config / Supabase unreachable; skip the test.
-// CI without secrets (and a fresh dev box that hasn't run `cerefox init`
-// yet) both land here cleanly instead of timing out at 5s.
-function probeSupabase(): boolean {
-  if (!existsSync(BIN)) return false;
-  const result = spawnSync("node", [BIN, "list-projects", "--json"], {
-    cwd: REPO_ROOT,
-    env: { ...process.env },
-    timeout: 5_000,
-  });
-  return result.status === 0;
-}
+// Probe-and-skip, via the ONE shared implementation (`_live-probe.ts`). It
+// resolves `.env` from REPO_ROOT exactly as the MCP server would on a real
+// boot, so CI without secrets and a fresh dev box both skip cleanly instead of
+// timing out. This file used to carry its own copy calling the verb
+// `list-projects`, renamed in v0.9.0 — the copy read the renamed-verb husk's
+// exit code as "Supabase unreachable" and skipped every live test here.
 const LIVE_OK = probeSupabase();
 
 describe("stdio MCP server smoke", () => {

--- a/packages/memory/test/web-identity.test.ts
+++ b/packages/memory/test/web-identity.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Caller identity on `/api/v1` (iter-40, #226).
+ *
+ * The contract these tests exist to hold:
+ *
+ *  1. **Omitted means nothing changes.** A request with no identity must
+ *     resolve to exactly what the API recorded before #226 — `web-ui` / `user`
+ *     / `webapp`. Backwards compatibility is the whole design constraint, so it
+ *     gets asserted field by field rather than by spot check.
+ *  2. **`access_path` is derived, never accepted.** There is deliberately no
+ *     way to ask for a particular access path, and no test here grants one:
+ *     the only lever is whether the caller identified itself.
+ *  3. **A supplied-but-unusable value is an error, not a fallback.** Silently
+ *     recording `web-ui` for a caller that tried to name itself is precisely
+ *     the failure the feature exists to remove, so it must not be reachable
+ *     through a blank string or a wrong type.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { Context } from "hono";
+
+import {
+  DEFAULT_WEB_AUTHOR,
+  resolveCallerIdentity,
+  WEB_UI_IDENTITY,
+} from "../src/web/identity.ts";
+
+/**
+ * The resolver touches exactly one thing on the context: `c.req.header(name)`.
+ * A stub keeps these tests at the unit level; the HTTP boundary is covered by
+ * `web-integration/attribution.test.ts`.
+ */
+function ctxWith(headers: Record<string, string> = {}): Context {
+  const lower = Object.fromEntries(
+    Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v]),
+  );
+  return {
+    req: { header: (name: string) => lower[name.toLowerCase()] },
+  } as unknown as Context;
+}
+
+function unwrap(result: ReturnType<typeof resolveCallerIdentity>) {
+  if (!result.ok) throw new Error(`expected ok, got: ${result.detail}`);
+  return result.identity;
+}
+
+describe("resolveCallerIdentity — the unchanged default", () => {
+  test("no identity at all resolves to the pre-#226 behaviour", () => {
+    const id = unwrap(resolveCallerIdentity(ctxWith()));
+    expect(id).toEqual(WEB_UI_IDENTITY);
+    // Spelled out, because "equals the constant" would still pass if someone
+    // changed the constant. These four values are the compatibility promise.
+    expect(id.author).toBe("web-ui");
+    expect(id.authorType).toBe("user");
+    expect(id.requestor).toBe("web-ui");
+    expect(id.accessPath).toBe("webapp");
+    expect(id.named).toBe(false);
+  });
+
+  test("an empty body is still the default, not an identity", () => {
+    const id = unwrap(resolveCallerIdentity(ctxWith(), {}));
+    expect(id.accessPath).toBe("webapp");
+    expect(id.named).toBe(false);
+  });
+
+  test("a body with unrelated fields is still the default", () => {
+    // The web app posts title/content/metadata and nothing else. It must keep
+    // landing in `webapp`.
+    const id = unwrap(
+      resolveCallerIdentity(ctxWith(), {
+        title: "x",
+        content: "y",
+        metadata: { type: "note" },
+      }),
+    );
+    expect(id).toEqual(WEB_UI_IDENTITY);
+  });
+
+  test("an explicit null identity field reads as not supplied", () => {
+    const id = unwrap(resolveCallerIdentity(ctxWith(), { author: null }));
+    expect(id).toEqual(WEB_UI_IDENTITY);
+  });
+});
+
+describe("resolveCallerIdentity — a caller that names itself", () => {
+  test("a header author is recorded and flips the access path", () => {
+    const id = unwrap(resolveCallerIdentity(ctxWith({ "X-Cerefox-Author": "cerefox-bot" })));
+    expect(id.author).toBe("cerefox-bot");
+    expect(id.accessPath).toBe("api");
+    expect(id.named).toBe(true);
+  });
+
+  test("a body author works too", () => {
+    const id = unwrap(resolveCallerIdentity(ctxWith(), { author: "cerefox-bot" }));
+    expect(id.author).toBe("cerefox-bot");
+    expect(id.accessPath).toBe("api");
+  });
+
+  test("author and requestor stand in for each other", () => {
+    // They name one actor. MCP splits them only because reads and writes log
+    // to different tables, so a caller giving one has identified itself for
+    // both — otherwise a bot's reads would log as `web-ui` while its writes
+    // were attributed correctly, which is the split this feature removes.
+    const fromAuthor = unwrap(resolveCallerIdentity(ctxWith({ "x-cerefox-author": "bot" })));
+    expect(fromAuthor.requestor).toBe("bot");
+
+    const fromRequestor = unwrap(
+      resolveCallerIdentity(ctxWith({ "x-cerefox-requestor": "bot" })),
+    );
+    expect(fromRequestor.author).toBe("bot");
+  });
+
+  test("both supplied are kept distinct", () => {
+    const id = unwrap(
+      resolveCallerIdentity(
+        ctxWith({ "x-cerefox-author": "writer", "x-cerefox-requestor": "reader" }),
+      ),
+    );
+    expect(id.author).toBe("writer");
+    expect(id.requestor).toBe("reader");
+  });
+
+  test("a header wins over a body field", () => {
+    const id = unwrap(
+      resolveCallerIdentity(ctxWith({ "x-cerefox-author": "from-header" }), {
+        author: "from-body",
+      }),
+    );
+    expect(id.author).toBe("from-header");
+  });
+
+  test("surrounding whitespace is trimmed", () => {
+    const id = unwrap(resolveCallerIdentity(ctxWith({ "x-cerefox-author": "  bot  " })));
+    expect(id.author).toBe("bot");
+  });
+
+  test("author_type agent is honoured", () => {
+    const id = unwrap(
+      resolveCallerIdentity(ctxWith({
+        "x-cerefox-author": "bot",
+        "x-cerefox-author-type": "agent",
+      })),
+    );
+    expect(id.authorType).toBe("agent");
+  });
+
+  test("author_type defaults to user when only a name is given", () => {
+    const id = unwrap(resolveCallerIdentity(ctxWith({ "x-cerefox-author": "bot" })));
+    expect(id.authorType).toBe("user");
+  });
+
+  test("author_type alone counts as naming yourself", () => {
+    // It does not identify anyone, but it is still a caller customising its
+    // own attribution, which the bundled web app never does. Treating it as
+    // `webapp` would file an agent-authored ingest under the web UI.
+    const id = unwrap(resolveCallerIdentity(ctxWith({ "x-cerefox-author-type": "agent" })));
+    expect(id.accessPath).toBe("api");
+    expect(id.author).toBe(DEFAULT_WEB_AUTHOR);
+    expect(id.authorType).toBe("agent");
+  });
+});
+
+describe("resolveCallerIdentity — supplied but unusable is an error", () => {
+  test("an unknown author_type is refused, not coerced", () => {
+    // cerefox_audit_log CHECKs author_type IN ('user','agent'), so without
+    // this the caller gets a raw Postgres constraint error instead of a
+    // sentence naming the two valid values.
+    const result = resolveCallerIdentity(ctxWith({ "x-cerefox-author-type": "robot" }));
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.detail).toContain("user");
+    expect(result.detail).toContain("agent");
+  });
+
+  test("a blank header is refused rather than falling back to web-ui", () => {
+    const result = resolveCallerIdentity(ctxWith({ "x-cerefox-author": "   " }));
+    expect(result.ok).toBe(false);
+  });
+
+  test("a blank body field is refused", () => {
+    const result = resolveCallerIdentity(ctxWith(), { requestor: "" });
+    expect(result.ok).toBe(false);
+  });
+
+  test("a non-string body field is refused", () => {
+    const result = resolveCallerIdentity(ctxWith(), { author: 42 });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.detail).toContain("author");
+  });
+});
+
+describe("resolveCallerIdentity — access_path cannot be asked for", () => {
+  test("an access_path body field is ignored entirely", () => {
+    // Not honoured, and not an error either: it is simply not part of the
+    // contract. The value must follow from identity, so that a client cannot
+    // claim to be a different transport than it is.
+    const id = unwrap(
+      resolveCallerIdentity(ctxWith(), { access_path: "local-mcp" }),
+    );
+    expect(id.accessPath).toBe("webapp");
+    expect(id.named).toBe(false);
+  });
+
+  test("an access_path header is ignored too", () => {
+    const id = unwrap(
+      resolveCallerIdentity(ctxWith({ "x-cerefox-access-path": "cli" })),
+    );
+    expect(id.accessPath).toBe("webapp");
+  });
+
+  test("naming yourself is the ONLY way to reach the api path", () => {
+    const named = unwrap(resolveCallerIdentity(ctxWith({ "x-cerefox-requestor": "bot" })));
+    expect(named.accessPath).toBe("api");
+    const anonymous = unwrap(resolveCallerIdentity(ctxWith(), { access_path: "api" }));
+    expect(anonymous.accessPath).toBe("webapp");
+  });
+});

--- a/packages/memory/test/web-integration/_helpers.ts
+++ b/packages/memory/test/web-integration/_helpers.ts
@@ -13,7 +13,7 @@
  * destructive-endpoint coverage that was the 24L follow-up gap.
  */
 
-import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -35,19 +35,12 @@ export function freshPort(): number {
 }
 
 /**
- * Probe Supabase reachability via the same `cerefox list-projects --json`
- * call the stdio smoke uses. Returns true when the live backend answered;
- * tests gate their DB-touching assertions on this.
+ * Probe Supabase reachability. Delegates to the single shared implementation
+ * in `../_live-probe.ts` — this file used to carry its own copy calling
+ * `cerefox list-projects`, a verb renamed in v0.9.0, so every test in this
+ * directory skipped for eleven releases while reporting success.
  */
-export function probeSupabase(): boolean {
-  if (!existsSync(BIN)) return false;
-  const result = spawnSync("node", [BIN, "list-projects", "--json"], {
-    cwd: REPO_ROOT,
-    env: { ...process.env },
-    timeout: 5_000,
-  });
-  return result.status === 0;
-}
+export { probeSupabase } from "../_live-probe.ts";
 
 export interface SpawnedServer {
   child: ChildProcess;
@@ -117,46 +110,12 @@ export async function spawnWebServer(): Promise<SpawnedServer | null> {
 }
 
 /**
- * Create a test document via the deployed `cerefox-ingest` Edge
- * Function. Used by tests that need a real document_id to exercise
- * mutations against (since v0.6's web `/api/v1/ingest` returns 503).
- *
- * Reads CEREFOX_SUPABASE_URL + CEREFOX_ACCESS_TOKEN from the env (the EFs
- * validate the Cerefox access token in-function, iter-28E).
- * Returns the new document's id.
+ * (Removed in iter-40.) `ingestViaEdgeFunction()` created fixtures through the
+ * deployed `cerefox-ingest` Edge Function. It dated from v0.6, when the web
+ * `/api/v1/ingest` route was a 503 stub. That has not been true since v0.7, so
+ * the helper only bought a live Edge Function invocation per fixture — against
+ * a free-tier quota, from a suite that is not one of the two CEREFOX_LIVE_E2E
+ * suites allowed to spend it. Its only caller now ingests over HTTP like every
+ * other test here. Deleted rather than left in place: an unused helper that
+ * quietly bills is one someone reaches for again.
  */
-export async function ingestViaEdgeFunction(opts: {
-  title: string;
-  content: string;
-  author?: string;
-}): Promise<string> {
-  const url = process.env.CEREFOX_SUPABASE_URL;
-  const key = process.env.CEREFOX_ACCESS_TOKEN;
-  if (!url || !key) {
-    throw new Error("CEREFOX_SUPABASE_URL + CEREFOX_ACCESS_TOKEN required for ingestViaEdgeFunction");
-  }
-  const resp = await fetch(`${url}/functions/v1/cerefox-ingest`, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${key}`,
-      apikey: key,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      title: opts.title,
-      content: opts.content,
-      source: "test",
-      author: opts.author ?? "web-integration-test",
-    }),
-  });
-  if (!resp.ok) {
-    const text = await resp.text();
-    throw new Error(`cerefox-ingest EF returned ${resp.status}: ${text}`);
-  }
-  const body = (await resp.json()) as { document_id?: string; id?: string };
-  const id = body.document_id ?? body.id;
-  if (!id) {
-    throw new Error(`cerefox-ingest EF returned no document_id: ${JSON.stringify(body)}`);
-  }
-  return id;
-}

--- a/packages/memory/test/web-integration/attribution.test.ts
+++ b/packages/memory/test/web-integration/attribution.test.ts
@@ -249,6 +249,62 @@ describe("/api/v1 caller attribution (HTTP boundary)", () => {
     expect(body.detail).toContain("author_type");
   });
 
+  test.skipIf(!LIVE_OK)(
+    "an identified caller must present the hash to delete",
+    async () => {
+      if (!server) return;
+      const { body } = await ingest(`${TITLE_PREFIX} del ${RUN_TAG}`);
+      const id = body.document_id as string;
+
+      // Named caller, no hash: refused, the same rule MCP enforces.
+      const refused = await fetch(`${server.base}/api/v1/documents/${id}`, {
+        method: "DELETE",
+        headers: { "X-Cerefox-Author": "e2e-attr-bot" },
+      });
+      expect(refused.status).toBe(400);
+      const refusedBody = (await refused.json()) as { detail?: string };
+      expect(refusedBody.detail ?? "").toContain("CEREFOX_TOKEN_REQUIRED");
+
+      // Still there.
+      const { data: alive } = await admin!
+        .from("cerefox_documents")
+        .select("deleted_at")
+        .eq("id", id)
+        .maybeSingle();
+      expect((alive as { deleted_at: string | null } | null)?.deleted_at).toBeNull();
+
+      // With the hash it goes through.
+      const read = (await (
+        await fetch(`${server.base}/api/v1/documents/${id}`)
+      ).json()) as { content_hash: string };
+      const ok = await fetch(`${server.base}/api/v1/documents/${id}`, {
+        method: "DELETE",
+        headers: {
+          "X-Cerefox-Author": "e2e-attr-bot",
+          "X-Cerefox-Expected-Content-Hash": read.content_hash,
+        },
+      });
+      expect(ok.status).toBe(200);
+    },
+    30_000,
+  );
+
+  test.skipIf(!LIVE_OK)(
+    "an anonymous delete still works exactly as before",
+    async () => {
+      if (!server) return;
+      // The bundled web UI sends no identity and no hash; it confirms in a
+      // dialog instead. That path must not have changed.
+      const { body } = await ingest(`${TITLE_PREFIX} anondel ${RUN_TAG}`);
+      const id = body.document_id as string;
+      const resp = await fetch(`${server.base}/api/v1/documents/${id}`, {
+        method: "DELETE",
+      });
+      expect(resp.status).toBe(200);
+    },
+    30_000,
+  );
+
   test.skipIf(!LIVE_OK)("a read logs the requestor that asked for it", async () => {
     if (!server) return;
     if (!usageTracked) return; // nothing to assert with tracking off

--- a/packages/memory/test/web-integration/attribution.test.ts
+++ b/packages/memory/test/web-integration/attribution.test.ts
@@ -1,0 +1,280 @@
+/**
+ * HTTP-boundary tests for caller attribution on `/api/v1` (iter-40, #226).
+ *
+ * The unit tests in `../web-identity.test.ts` pin the resolver. These prove the
+ * part that a unit test cannot: that what the resolver decided actually reaches
+ * `cerefox_audit_log` and `cerefox_usage_log` through a real HTTP request
+ * against a real database, and that omitting the parameters writes the same
+ * rows the pre-#226 code wrote.
+ *
+ * The compatibility case is the one that matters most here. "It still works"
+ * is not the claim; the claim is that the stored row is unchanged, so the
+ * assertion is on the row, not on the response.
+ *
+ * Probe-and-skip when Supabase + OpenAI aren't both reachable, and refuses an
+ * unlabelled (production) target like every other write-bearing suite.
+ * Self-cleaning via the `[E2E web-attr]` title prefix.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+import { probeSupabase, spawnWebServer, type SpawnedServer } from "./_helpers.js";
+import { loadEnv } from "../../../../_shared/config/index.js";
+import { mayWriteToLiveTarget } from "../_live-target-guard.ts";
+
+loadEnv();
+
+const SUPABASE_URL = process.env.CEREFOX_SUPABASE_URL ?? "";
+const SUPABASE_KEY = process.env.CEREFOX_SUPABASE_KEY ?? "";
+const OPENAI_API_KEY =
+  process.env.OPENAI_API_KEY || process.env.CEREFOX_OPENAI_API_KEY || "";
+
+const LIVE_OK =
+  mayWriteToLiveTarget() &&
+  probeSupabase() &&
+  SUPABASE_URL.length > 0 &&
+  SUPABASE_KEY.length > 0 &&
+  OPENAI_API_KEY.length > 0;
+
+const TITLE_PREFIX = "[E2E web-attr]";
+const RUN_TAG = String(Date.now());
+
+interface AuditRow {
+  author: string;
+  author_type: string;
+  operation: string;
+}
+
+interface UsageRow {
+  requestor: string;
+  access_path: string;
+  operation: string;
+}
+
+describe("/api/v1 caller attribution (HTTP boundary)", () => {
+  let server: SpawnedServer | null = null;
+  let admin: SupabaseClient | null = null;
+  /** null until probed; usage logging is opt-in via cerefox_config. */
+  let usageTracked = false;
+  const created: string[] = [];
+
+  beforeAll(async () => {
+    if (!LIVE_OK) return;
+    server = await spawnWebServer();
+    admin = createClient(SUPABASE_URL, SUPABASE_KEY, {
+      auth: { persistSession: false },
+    });
+    // Usage logging is opt-in (`usage_tracking_enabled`). Read it rather than
+    // set it: flipping an operator's config to make a test pass would leave
+    // the environment changed, and the audit assertions carry the suite
+    // regardless.
+    try {
+      const { data } = await admin.rpc("cerefox_get_config", {
+        p_key: "usage_tracking_enabled",
+      });
+      usageTracked = String(data ?? "").toLowerCase() === "true";
+    } catch {
+      usageTracked = false;
+    }
+  });
+
+  afterAll(async () => {
+    if (admin) {
+      for (const id of created) {
+        try {
+          await admin.rpc("cerefox_delete_document", {
+            p_document_id: id,
+            p_author: "web-attr-test",
+            p_author_type: "user",
+          });
+          await admin.rpc("cerefox_purge_document", {
+            p_document_id: id,
+            p_author: "web-attr-test",
+            p_author_type: "user",
+          });
+        } catch {
+          /* swallow */
+        }
+      }
+    }
+    await server?.stop();
+  });
+
+  /** Ingest through the HTTP API with the given extra headers. */
+  async function ingest(
+    title: string,
+    headers: Record<string, string> = {},
+    extraBody: Record<string, unknown> = {},
+  ): Promise<{ status: number; body: Record<string, unknown> }> {
+    const resp = await fetch(`${server!.base}/api/v1/ingest`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify({
+        title,
+        content: `# ${title}\n\nAttribution fixture, run ${RUN_TAG}.\n`,
+        ...extraBody,
+      }),
+    });
+    const body = (await resp.json()) as Record<string, unknown>;
+    if (typeof body.document_id === "string") created.push(body.document_id);
+    return { status: resp.status, body };
+  }
+
+  async function auditFor(documentId: string): Promise<AuditRow[]> {
+    const { data } = await admin!
+      .from("cerefox_audit_log")
+      .select("author, author_type, operation")
+      .eq("document_id", documentId);
+    return (data ?? []) as AuditRow[];
+  }
+
+  async function usageFor(documentId: string): Promise<UsageRow[]> {
+    const { data } = await admin!
+      .from("cerefox_usage_log")
+      .select("requestor, access_path, operation")
+      .eq("document_id", documentId);
+    return (data ?? []) as UsageRow[];
+  }
+
+  test.skipIf(!LIVE_OK)(
+    "no identity supplied writes exactly the pre-#226 row",
+    async () => {
+      if (!server) return;
+      const title = `${TITLE_PREFIX} default ${RUN_TAG}`;
+      const { status, body } = await ingest(title);
+      expect(status).toBe(200);
+      const id = body.document_id as string;
+      expect(id).toBeTruthy();
+
+      const audit = await auditFor(id);
+      expect(audit.length).toBeGreaterThan(0);
+      // The compatibility promise, asserted on what was stored.
+      for (const row of audit) {
+        expect(row.author).toBe("web-ui");
+        expect(row.author_type).toBe("user");
+      }
+
+      // author_type "user" means the document is approved, not queued.
+      const { data: doc } = await admin!
+        .from("cerefox_documents")
+        .select("review_status")
+        .eq("id", id)
+        .maybeSingle();
+      expect((doc as { review_status: string } | null)?.review_status).toBe("approved");
+
+      if (usageTracked) {
+        const usage = await usageFor(id);
+        expect(usage.length).toBeGreaterThan(0);
+        for (const row of usage) {
+          expect(row.access_path).toBe("webapp");
+          expect(row.requestor).toBe("web-ui");
+        }
+      }
+    },
+  );
+
+  test.skipIf(!LIVE_OK)(
+    "a named caller is recorded as itself, on the api path",
+    async () => {
+      if (!server) return;
+      const title = `${TITLE_PREFIX} named ${RUN_TAG}`;
+      const { status, body } = await ingest(title, {
+        "X-Cerefox-Author": "e2e-attr-bot",
+        "X-Cerefox-Author-Type": "agent",
+      });
+      expect(status).toBe(200);
+      const id = body.document_id as string;
+
+      const audit = await auditFor(id);
+      expect(audit.length).toBeGreaterThan(0);
+      for (const row of audit) {
+        expect(row.author).toBe("e2e-attr-bot");
+        expect(row.author_type).toBe("agent");
+      }
+
+      // The documented consequence of author_type=agent, identical to MCP:
+      // an agent-authored ingest lands in pending_review rather than approved.
+      // Asserted because it is the behaviour most likely to surprise someone,
+      // and because it is the proof that "matches MCP semantics" is real
+      // rather than aspirational.
+      const { data: doc } = await admin!
+        .from("cerefox_documents")
+        .select("review_status")
+        .eq("id", id)
+        .maybeSingle();
+      expect((doc as { review_status: string } | null)?.review_status).toBe(
+        "pending_review",
+      );
+
+      if (usageTracked) {
+        const usage = await usageFor(id);
+        expect(usage.length).toBeGreaterThan(0);
+        for (const row of usage) {
+          expect(row.access_path).toBe("api");
+          expect(row.requestor).toBe("e2e-attr-bot");
+        }
+      }
+    },
+  );
+
+  test.skipIf(!LIVE_OK)("identity can also travel in the JSON body", async () => {
+    if (!server) return;
+    const title = `${TITLE_PREFIX} body ${RUN_TAG}`;
+    const { status, body } = await ingest(title, {}, { author: "e2e-body-bot" });
+    expect(status).toBe(200);
+    const audit = await auditFor(body.document_id as string);
+    expect(audit.length).toBeGreaterThan(0);
+    for (const row of audit) expect(row.author).toBe("e2e-body-bot");
+  });
+
+  test.skipIf(!LIVE_OK)("an invalid author_type is a 400, not a 500", async () => {
+    if (!server) return;
+    // Without boundary validation this reaches the cerefox_audit_log CHECK and
+    // surfaces as a raw Postgres error, i.e. a 500 for a caller mistake.
+    const resp = await fetch(`${server.base}/api/v1/ingest`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Cerefox-Author": "e2e-attr-bot",
+        "X-Cerefox-Author-Type": "robot",
+      },
+      body: JSON.stringify({
+        title: `${TITLE_PREFIX} invalid ${RUN_TAG}`,
+        content: "should never be stored",
+      }),
+    });
+    expect(resp.status).toBe(400);
+    const body = (await resp.json()) as { detail?: string };
+    expect(body.detail).toContain("author_type");
+  });
+
+  test.skipIf(!LIVE_OK)("a read logs the requestor that asked for it", async () => {
+    if (!server) return;
+    if (!usageTracked) return; // nothing to assert with tracking off
+    const title = `${TITLE_PREFIX} read ${RUN_TAG}`;
+    const { body } = await ingest(title);
+    const id = body.document_id as string;
+
+    const before = (await usageFor(id)).length;
+    const resp = await fetch(`${server.base}/api/v1/documents/${id}`, {
+      headers: { "X-Cerefox-Requestor": "e2e-attr-reader" },
+    });
+    expect(resp.status).toBe(200);
+
+    // Usage logging is fire-and-forget; give it a moment to land.
+    let usage: UsageRow[] = [];
+    for (let i = 0; i < 20 && usage.length <= before; i += 1) {
+      await new Promise((r) => setTimeout(r, 150));
+      usage = await usageFor(id);
+    }
+    const reads = usage.filter((r) => r.operation === "get-document");
+    expect(reads.length).toBeGreaterThan(0);
+    for (const row of reads) {
+      expect(row.requestor).toBe("e2e-attr-reader");
+      // A read is the case the old code could not express at all: it logged
+      // `webapp`/`web-ui` for every caller.
+      expect(row.access_path).toBe("api");
+    }
+  });
+});

--- a/packages/memory/test/web-integration/destructive.test.ts
+++ b/packages/memory/test/web-integration/destructive.test.ts
@@ -19,7 +19,6 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 
 import {
-  ingestViaEdgeFunction,
   probeSupabase,
   spawnWebServer,
   type SpawnedServer,
@@ -34,15 +33,35 @@ describe("destructive web endpoints (HTTP boundary)", () => {
   beforeAll(async () => {
     if (!LIVE_OK) return;
     server = await spawnWebServer();
-    docId = await ingestViaEdgeFunction({
-      title: `[E2E web-destructive] iter-24L follow-up ${Date.now()}`,
-      content:
-        "# Destructive endpoint smoke\n\n" +
-        "Created by the web-integration test suite to exercise the v0.6\n" +
-        "mutation endpoints end-to-end. Purged automatically when the\n" +
-        "test finishes.\n",
-      author: "web-destructive-test",
+    if (!server) return;
+    // Fixture created through the web API, NOT the deployed Edge Function
+    // (iter-40). The EF helper dated from v0.6, when `/api/v1/ingest` was a
+    // 503 stub; it has been a real endpoint since v0.7, so the EF round-trip
+    // bought nothing and cost free-tier invocations on every run. That went
+    // unnoticed because this whole directory had been skipping since v0.9.0
+    // (see `_live-probe.ts`) — turning the suite back on turned the billing
+    // back on with it. The live EF suites are gated behind CEREFOX_LIVE_E2E=1
+    // for exactly this reason; this suite has no business calling one.
+    const resp = await fetch(`${server.base}/api/v1/ingest`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: `[E2E web-destructive] iter-24L follow-up ${Date.now()}`,
+        content:
+          "# Destructive endpoint smoke\n\n" +
+          "Created by the web-integration test suite to exercise the\n" +
+          "mutation endpoints end-to-end. Purged automatically when the\n" +
+          "test finishes.\n",
+        author: "web-destructive-test",
+        // author_type "agent" keeps the fixture's original starting state:
+        // the Edge Function used to ingest as an agent, so the document
+        // arrived as `pending_review`, which the review-status test below
+        // depends on. Expressing that over the API is exactly what #226 added.
+        author_type: "agent",
+      }),
     });
+    const body = (await resp.json()) as { document_id?: string };
+    docId = body.document_id ?? null;
   });
 
   afterAll(async () => {
@@ -83,7 +102,7 @@ describe("destructive web endpoints (HTTP boundary)", () => {
 
   test("review-status flip: pending_review → approved → reflected in GET", async () => {
     if (!LIVE_OK || !server || !docId) return;
-    // EF-authored docs land as pending_review (author_type=agent). Confirm.
+    // agent-authored docs land as pending_review. Confirm.
     const baseline = await (
       await fetch(`${server.base}/api/v1/documents/${docId}`)
     ).json();

--- a/packages/memory/test/web-integration/ingest.test.ts
+++ b/packages/memory/test/web-integration/ingest.test.ts
@@ -189,7 +189,32 @@ describe("web ingest endpoints (HTTP boundary)", () => {
     const initialBody = (await initial.json()) as { document_id: string };
     created.push(initialBody.document_id);
 
-    // Now upload-replace.
+    // #228: this route takes the same concurrency contract as every other
+    // content update. Read the hash first, exactly as a real client would.
+    const read = (await (
+      await fetch(`${server.base}/api/v1/documents/${initialBody.document_id}`)
+    ).json()) as { content_hash: string };
+    expect(read.content_hash).toBeTruthy();
+
+    // Omitting the token is refused, not silently applied. Asserted before the
+    // happy path because the endpoint spent eleven releases in a state where
+    // NOTHING worked, and a fix that made everything work would have been just
+    // as wrong in the other direction.
+    const noToken = new FormData();
+    noToken.append(
+      "file",
+      new Blob(["# nope\n"], { type: "text/markdown" }),
+      `no-token-${RUN_TAG}.md`,
+    );
+    const refused = await fetch(
+      `${server.base}/api/v1/documents/${initialBody.document_id}/upload`,
+      { method: "POST", body: noToken },
+    );
+    const refusedBody = (await refused.json()) as { success: boolean; error?: string };
+    expect(refusedBody.success).toBe(false);
+    expect(refusedBody.error ?? "").toContain("CEREFOX_TOKEN_REQUIRED");
+
+    // Now upload-replace, with the token.
     const newText = `# v2\n\nReplacement content ${RUN_TAG}.\n`;
     const form = new FormData();
     form.append(
@@ -197,6 +222,7 @@ describe("web ingest endpoints (HTTP boundary)", () => {
       new Blob([newText], { type: "text/markdown" }),
       `replacement-${RUN_TAG}.md`,
     );
+    form.append("expected_content_hash", read.content_hash);
     const resp = await fetch(
       `${server.base}/api/v1/documents/${initialBody.document_id}/upload`,
       { method: "POST", body: form },
@@ -210,5 +236,7 @@ describe("web ingest endpoints (HTTP boundary)", () => {
     expect(body.success).toBe(true);
     expect(body.document_id).toBe(initialBody.document_id);
     expect(body.updated).toBe(true);
-  });
+    // Four round-trips (ingest, read, refused upload, upload), each embedding
+    // real content, so the default 5s is not enough.
+  }, 30_000);
 });


### PR DESCRIPTION
## Summary

Iteration 40, target **v1.11.0**. `/api/v1` was the web app's private backend and hardcoded its own identity, so no other client could be attributed — which pushed agent harnesses onto MCP purely to obtain one.

Closes #225
Closes #226
Closes #227
Closes #228

- **#226** — `/api/v1` accepts optional `author`, `requestor`, `author_type` (as `X-Cerefox-*` headers on any method, or body/form fields where a route has one; header wins). **Omitted, nothing changes**: the stored audit and usage rows are byte-identical to before, and the live test asserts the row rather than the response. `access_path` is *derived* — name yourself and it is `api`, otherwise `webapp` — never accepted, because it is the one field in the usage log the server still sets itself. The identity is **declared, not verified**: a label for attribution and record-keeping, not a credential.
- **#225** — `cerefox doctor` asks the resolver which config file is in effect instead of hardcoding `~/.cerefox/.env`, and stops offering to delete unrelated projects' `.env` files.
- **#227** — the repo-root `docker-compose.yml` publishes to `127.0.0.1`.
- **#228** — `POST /api/v1/documents/{id}/upload` has failed on **every call since v0.11.0**. Fixed.
- **New guide** `docs/guides/api.md`, opening with an unmissable statement that this surface has no authentication and is for local access only.
## The find that outgrew the feature

A new test skipped when it should have run. `probeSupabase()` shelled out to `cerefox list-projects`, a verb **renamed in v0.9.0** to a husk that exits non-zero by design; the probe read that as "backend unreachable".

**The entire `web-integration` HTTP-boundary suite and the live half of `stdio-smoke` have been reporting success while running nothing for eleven releases.** That is what hid #228: v0.9.0 broke the probe, v0.11.0 broke the endpoint, and the only test covering it had already stopped running.

The class fix is one probe that **throws** when the CLI rejects the probe command, because "the backend is down" and "that command no longer exists" are different answers and only the first justifies a skip.

Turning the suite on also turned its billing on: `destructive.test.ts` built fixtures through a live Edge Function (a v0.6 workaround), against a free-tier quota, from a suite that is not one of the two `CEREFOX_LIVE_E2E` suites permitted to spend it. It now ingests over HTTP; the helper is deleted.

## Optimistic locking, everywhere

Review feedback: *"if no hash is sent then we should block the write."* Correct, and it changed the design.

- `POST /documents/{id}/upload` takes the same contract as every other content update: `expected_content_hash`, or an explicit `last_write_wins=true`. No implicit default. There is no working caller to stay compatible with — the endpoint has been a hard error for eleven releases — so the strict semantics cost nothing.
- `DELETE /documents/{id}` now requires the hash **from an identified caller**, matching what `cerefox_delete_document` enforces over MCP. It previously passed no CAS token at all, defensible while the only caller was the web UI where a human confirms in a dialog. Identified callers have no dialog. Anonymous callers (the bundled UI) are untouched.

## Judgment calls a reviewer should disagree with cheaply

1. **Audit authorship changed** for review-status and version-archive, which recorded `author: "user"` while every other web write recorded `"web-ui"`, silently breaking `author='web-ui'` filters. Existing rows untouched.
2. **Purge is now attributable** over the API. It grants no new power — anyone reaching the port could already purge — but an agent identity can now appear on a purge row. Whether purge should be reachable over the API at all is an open question in #229.
3. **`author_type: agent` queues API ingests for review**, exactly as over MCP. Intended (that equivalence is the feature), and the most likely thing to surprise someone.
4. **`require_requestor_identity` is documented, not extended.** It is enforced by the Edge Functions only, not local MCP, not `/api/v1`, not the CLI. Adding a ninth copy of the block was the alternative; a shared helper is the right answer if it is ever made global.

## Known, filed, not fixed here

- **#229** — `/api/v1` has no authentication. Loopback binding is the entire boundary today. Proposal and open design questions on the ticket.
- **#230** — live suites freeze `LIVE_OK` at module load and one test blanks `CEREFOX_CONFIG_DIR` mid-run, so `ingest.test.ts` skips under the documented full `bun test` while passing when its directory is run. Same shape as the probe bug; the durable fix is its own change.

## Test plan

- [x] `bun run typecheck` — now includes the frontend, which it silently skipped before (`tsconfig.json` is `files: []` plus references)
- [x] `_shared`: 594 pass, 0 fail
- [x] `packages/memory` against **staging**: 215 pass, 0 fail
- [x] Playwright UI e2e against staging: **20/20**, covering both pages touched
- [x] A throwaway Cerefox Local container (own image, volume, config, port), destroyed afterwards: confirmed `api | example-bot | ingest` and `api | example-bot-reader | get-document` alongside unchanged `webapp | web-ui` rows
- [x] `doctor` against staging now names the staging config file (#225 verified in output, not just in a test)
- [x] #225 guards proven to fire independently by regressing each alone
- [x] No schema change (`access_path` is free-text `TEXT NOT NULL`, no CHECK) — `schema_version` deliberately not bumped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013PcVjtEzsfTtAxeayzga5u


