### PR TITLE
API status codes, a test suite that was skipping 47 tests, and the #229 design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,43 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
+### Changed
+
+- **The three `/api/v1` ingest routes answer with real HTTP status codes
+  (#232).** `POST /ingest`, `POST /ingest/file` and
+  `POST /documents/{id}/upload` used to catch every pipeline failure and return
+  `200` with `success: false`, including a *refused* write. A client checking
+  `resp.ok` — what `raise_for_status()`, `curl -f` and every retry wrapper do
+  by default — read a refusal as a success, and a concurrency refusal is the
+  worst case to miss. They now return `400` for a missing concurrency token,
+  `409` for a stale one (carrying `current_hash`), and `500` otherwise, which
+  is the mapping the edit route has used since v0.11.0. Response bodies keep
+  `success: false` and `error`, and gain `detail` so the message survives to
+  the UI. Invisible while the API was the web app's private backend; it matters
+  now that other clients are invited onto it.
+
+### Fixed
+
+- **Live test suites skipped in a full `bun test` run (#230).** `loadEnv()`
+  cached "already loaded" as a boolean, so the second call was a no-op forever
+  — including after `CEREFOX_CONFIG_DIR` changed. One test sets that variable
+  to a non-existent directory on purpose (proving the production-write guard
+  refuses an unlabelled target), which poisoned the cache for the rest of the
+  run: every live suite loaded afterwards saw no credentials and skipped. The
+  cache is now keyed on the resolved path. **The full package suite went from
+  215 passing with 12 skipped to 262 passing with 2 skipped** — 47 tests that
+  had been reporting success while running nothing. Same shape as the
+  renamed-probe bug fixed in v1.11.0.
+- **`cerefox server deploy` explains an upstream package-registry failure
+  instead of dumping a raw 400.** When Supabase publishes a new
+  `supabase-js` to JSR before its npm dependency lands, every Edge Function
+  fails to bundle for the length of that window; the bundler's reply is a 400
+  with a JSR stack trace, repeated once per function, which reads exactly like
+  a broken release. The deploy now recognises that signature and says what it
+  is: upstream, your deployed functions are unchanged and still serving, retry
+  in a few minutes. (Observed 2026-09-02 on a production deploy that landed in
+  a 108-second gap between the two registries.)
+
 Open roadmap.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,17 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
   the UI. Invisible while the API was the web app's private backend; it matters
   now that other clients are invited onto it.
 
+### Security
+
+- **Four high and three moderate advisories cleared** by pinning three
+  transitive dependencies to their patched versions via root `overrides`:
+  `fast-uri` (host confusion and SSRF, four advisories, reached through
+  `@modelcontextprotocol/sdk` and `eslint`), `qs` (array-limit bypass and DoS,
+  through `@modelcontextprotocol/sdk`), and `@xmldom/xmldom` (XML fragment
+  injection, through `mammoth`). All were published upstream after v1.11.0 was
+  cut and none is reachable from a direct dependency; `bun update` could not
+  resolve past them because the intermediate packages' ranges pin them.
+
 ### Fixed
 
 - **Live test suites skipped in a full `bun test` run (#230).** `loadEnv()`

--- a/_shared/config/env.ts
+++ b/_shared/config/env.ts
@@ -35,16 +35,35 @@ function parseDotenv(content: string): Record<string, string> {
   return result;
 }
 
-let _loaded = false;
+/**
+ * Which env file this process has already loaded, or null for none.
+ *
+ * Keyed on the resolved PATH rather than a boolean (#230). A boolean made
+ * `loadEnv()` a no-op forever after the first call, including after
+ * `CEREFOX_CONFIG_DIR` changed — so a process that loaded one environment and
+ * then pointed at another silently kept the first one's values, or kept
+ * nothing at all if the first path did not exist.
+ *
+ * That is not a hypothetical either: `live-write-guard-coverage.test.ts` sets
+ * `CEREFOX_CONFIG_DIR` to a deliberately non-existent directory to prove the
+ * production-write guard refuses an unlabelled target. Under a boolean flag
+ * that one assertion poisoned the cache for the rest of the run, and every
+ * live suite loaded afterwards saw no credentials and skipped — passing, while
+ * running nothing. Same failure shape as the renamed-probe bug in v1.11.0.
+ *
+ * Still idempotent for the normal case (repeated calls resolving the same
+ * path do no work); it just stops lying when the question changes.
+ */
+let _loadedPath: string | null = null;
 
 export function loadEnv(opts: ResolverOptions = {}): { path: string; vars: number } {
-  // Idempotent: loading twice in one process is a no-op.
-  if (_loaded) {
+  const envPath = resolveEnvFile(opts);
+  // Idempotent per resolved path: loading the SAME file twice is a no-op.
+  if (_loadedPath === envPath) {
     return { path: "(already loaded)", vars: 0 };
   }
-  _loaded = true;
+  _loadedPath = envPath;
 
-  const envPath = resolveEnvFile(opts);
   let content: string;
   try {
     content = readFileSync(envPath, "utf8");

--- a/bun.lock
+++ b/bun.lock
@@ -69,7 +69,7 @@
     },
     "packages/memory": {
       "name": "@cerefox/memory",
-      "version": "1.1.1",
+      "version": "1.11.0",
       "bin": {
         "cerefox": "dist/bin/cerefox.js",
       },
@@ -100,6 +100,11 @@
         "onnxruntime-node": "^1.21.0",
       },
     },
+  },
+  "overrides": {
+    "@xmldom/xmldom": "^0.8.15",
+    "fast-uri": "^3.1.7",
+    "qs": "^6.16.0",
   },
   "packages": {
     "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
@@ -508,7 +513,7 @@
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.5", "", { "dependencies": { "@rolldown/pluginutils": "^1.0.1" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-BOVzne/NL162sMdResB25mUv+vWMF5NoAjNf09TeGlE7ZpszZWSD3winycicLJw72yeVsoCn/2kOhEuCvEShMA=="],
 
-    "@xmldom/xmldom": ["@xmldom/xmldom@0.8.13", "", {}, "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw=="],
+    "@xmldom/xmldom": ["@xmldom/xmldom@0.8.15", "", {}, "sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
@@ -774,7 +779,7 @@
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
 
-    "fast-uri": ["fast-uri@3.1.5", "", {}, "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="],
+    "fast-uri": ["fast-uri@3.1.7", "", {}, "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
@@ -1172,7 +1177,7 @@
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
-    "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
+    "qs": ["qs@6.16.0", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA=="],
 
     "range-parser": ["range-parser@1.3.0", "", {}, "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw=="],
 

--- a/docs/guides/api.md
+++ b/docs/guides/api.md
@@ -183,8 +183,18 @@ honour the identity headers. `/version` needs nothing.
 Cerefox uses optimistic locking, and this API is no exception. A content update
 requires the `content_hash` you read the document at, as
 `expected_content_hash`, or an explicit `last_write_wins`. A stale hash returns
-`409`; sending neither returns `400` with `CEREFOX_TOKEN_REQUIRED`. Read, then
-modify, then write with the token you read.
+`409` (with `current_hash`, so you can re-read without a second round trip);
+sending neither returns `400` with `CEREFOX_TOKEN_REQUIRED`. Read, then modify,
+then write with the token you read.
+
+**Check the status code, not just the body.** Every refusal is a real HTTP
+status: `400` for a malformed or incomplete request, `409` for a concurrency
+conflict, `404` for a missing document, `503` when the embedder is
+unavailable. The reason is in the body's `detail` (and, on the ingest routes,
+also in `error`, which they have always used). Before v1.12.0 the three ingest
+routes answered `200` with `success: false` for a *refused* write, so a client
+checking only `resp.ok` read a refusal as a success; that is fixed, and it is
+the one response-shape change in v1.12.0.
 
 `POST /documents/{id}/upload` takes the same contract: pass
 `expected_content_hash` as a form field, or `last_write_wins=true` if the file

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -28,21 +28,44 @@
 ---
 ## Current Focus
 
-**2026-09-01 — Iteration 40 IMPLEMENTATION COMPLETE on
-`feat/v1.11.0-api-attribution`, target v1.11.0, awaiting review + release.
-Optional `author`/`requestor`/`author_type` on `/api/v1` (#226), the `doctor`
-config-dir misreport (#225), the repo-root compose bind (#227), and #228 —
-`POST /documents/{id}/upload`, broken since v0.11.0 and found only because the
-same work revealed that the web-integration suite had been skipping since
-v0.9.0. No schema change. Verified on staging (215 pass / 0 fail) and in a
-throwaway Cerefox Local container. Detail:
-[iteration 40](plans/iteration-40-api-attribution.md).**
+**2026-09-02 — v1.11.0 SHIPPED and verified on ALL THREE instances**
+(staging, production, Cerefox Local). Iteration 40 delivered optional
+`author`/`requestor`/`author_type` on `/api/v1` (#226), the `doctor` config-dir
+misreport (#225), the repo-root compose bind (#227), and #228 — `POST
+/documents/{id}/upload`, broken since v0.11.0 and found only because the same
+work revealed the web-integration suite had been skipping since v0.9.0. No
+schema change. #225–#228 closed by PR #231. Detail:
+[iteration 40](plans/iteration-40-api-attribution.md).
 
-**v1.11.0 is this work, NOT the Node baseline drop.** #154 (commander 15,
-Node ≥ 22.12, installer detection) moves to **v1.12.0** — decision
-2026-09-01. The two want opposite announcements: one says "check your Node
-version before upgrading", the other says "here is a new optional
-parameter", and bundling them buries the warning.
+**Live verification** (2026-09-02): production `doctor` all-green on EF v1.11.0;
+attributed reads confirmed logging `access_path=api` on the shared Cerefox Local
+instance (the bot harness's own backend); MCP read path unaffected. The
+production EF deploy first failed on an upstream registry race — JSR published
+`supabase-js@2.113.0` at 06:03:13Z, npm published its `auth-js` dependency at
+06:05:01Z, and the deploy landed in that 108-second window. Staging had deployed
+before 06:03 and resolved 2.112.4, which is why the same command worked there.
+Retrying after the window closed succeeded. **Pinning the `jsr:@supabase/
+supabase-js@2` specifier was considered and REJECTED** (2026-09-02): the failure
+is rare, loud, leaves the previous functions live, and self-heals on retry, so a
+permanent manual-bump burden across 9 files is the worse trade. What it does
+justify is a readable error message (see iteration 41).
+
+**2026-09-02 — Iteration 41 OPEN, target v1.12.0.** Authentication for
+`/api/v1` (#229, design-first), the ingest routes' HTTP-status inconsistency
+(#232), live suites skipping in a full `bun test` (#230), and the deploy-error
+message above. Detail: [iteration 41](plans/iteration-41-api-auth.md).
+
+**Release lineage decided 2026-09-02**: v1.12.0 is this batch; **#154**
+(commander 15, Node ≥ 22.12, installer detection) moves to **v1.13.0**. Both are
+"your setup may need attention" releases, and landing an auth change and a
+platform-baseline drop together makes "what broke?" ambiguous for anyone who
+hits a problem. #154 has now moved twice (v1.11.0 → v1.12.0 → v1.13.0), which is
+acceptable because each move was made to protect a clearer announcement, not to
+avoid the work.
+
+**Unreleased on `main`**: `00e37ca` (test-only — the `ingest-dir` live test had
+no timeout and inherited bun's 5s default, failing at 22s during the v1.11.0
+staging pass). Rides the next cut.
 
 Previously: **v1.10.0 + v1.10.1 SHIPPED** (2026-08-22) and verified on BOTH
 staging and production. Production jumped 1.9.1 → 1.10.1 in one hop

--- a/docs/plans/iteration-41-api-auth.md
+++ b/docs/plans/iteration-41-api-auth.md
@@ -57,8 +57,13 @@ releases; landing an auth change and a platform-baseline drop together makes
       still serving, retry in a few minutes. Output is now captured rather
       than inherited so the reply can be read, and printed verbatim so nothing
       is hidden.
-- [ ] **#229 — authentication for the local surface. DESIGN WRITTEN, awaiting
-      four decisions.** `docs/specs/api-auth-design.md`.
+- [ ] **#229 — authentication for the local surface. DESIGN APPROVED
+      2026-09-02, ready to build.** `docs/specs/api-auth-design.md`. Decided:
+      loopback-exempt with a key for every other interface; `X-Forwarded-For`
+      never consulted, **enforced by a test**, not by a sentence in a guide;
+      `/api/v1/version` gated with everything else (verified: no local caller
+      is affected, because the CLI never talks to the web server); purge stays
+      reachable; ships in v1.12.0 alongside #232, as a second PR.
 - [ ] Live regression against staging + Playwright.
 - [ ] CHANGELOG, guides.
 

--- a/docs/plans/iteration-41-api-auth.md
+++ b/docs/plans/iteration-41-api-auth.md
@@ -1,0 +1,101 @@
+# Iteration 41 — the local surface, made honest (v1.12.0)
+
+**Status: IN PROGRESS** (opened 2026-09-02). Branch:
+`feat/v1.12.0-api-auth`. Target: **v1.12.0**. No schema change so far.
+
+Addresses [#232](https://github.com/fstamatelopoulos/cerefox/issues/232),
+[#230](https://github.com/fstamatelopoulos/cerefox/issues/230), the
+deploy-error message from the 2026-09-02 production incident, and
+[#229](https://github.com/fstamatelopoulos/cerefox/issues/229) (**design
+only** — see `docs/specs/api-auth-design.md`; four decisions are the
+maintainer's).
+
+## Why these together
+
+v1.11.0 opened `/api/v1` to clients other than the bundled web app. This
+iteration deals with what that exposed: the surface has no authentication
+(#229), it answers a refused write with a success status (#232), and the tests
+that would have caught either were not all running (#230).
+
+## Release lineage
+
+v1.12.0 is this work. **#154** (commander 15, Node ≥ 22.12) moves to
+**v1.13.0** — decision 2026-09-02. Both are "your setup may need attention"
+releases; landing an auth change and a platform-baseline drop together makes
+"what broke?" ambiguous for anyone who hits a problem.
+
+## Steps
+
+- [x] **#232 — the ingest routes answer with real status codes.** All three
+      caught every pipeline failure and returned `200 {success:false, error}`.
+      The mapping is not invented here: `documents-write.ts` has mapped the
+      same two typed errors to 400/409 since iter-32, so this brings the
+      ingest routes onto the existing convention.
+      - Bodies keep `success:false` and `error` (nothing reading them breaks)
+        and **gain `detail`** — because `ApiError` in the frontend reads
+        `detail` and would otherwise show a bare "API error 400", silently
+        losing the reason on the one surface it was written for.
+      - `409` now carries `current_hash`, matching the edit route.
+      - **Frontend, found in recon**: `IngestPage.tsx:89` posts FormData with
+        raw `fetch` and threw `Upload failed: ${status}` with no message. New
+        `uploadFailureMessage()` in `api/client.ts` reads `detail`/`error`.
+        Without this the fix would have *removed* information from the UI.
+- [x] **#230 — `loadEnv()` caches by resolved path, not a boolean.** A boolean
+      made the second call a no-op forever, including after
+      `CEREFOX_CONFIG_DIR` changed. `live-write-guard-coverage.test.ts` sets it
+      to a non-existent directory on purpose (proving the production-write
+      guard refuses an unlabelled target), which poisoned the cache for the
+      whole run: every live suite loaded afterwards saw no credentials and
+      skipped. **Effect: the full suite went from 215 pass / 12 skip to 262
+      pass / 2 skip** — 47 tests that reported success while running nothing.
+      Same shape as the v1.11.0 renamed-probe bug.
+- [x] **Deploy-error message for the upstream registry race.** The
+      2026-09-02 production deploy failed nine times with a raw
+      `unexpected deploy status 400` and a JSR stack trace, which reads as
+      "your release is broken". `upstreamRegistryRace()` detects the bundler's
+      phrasing and explains it: upstream, your functions are unchanged and
+      still serving, retry in a few minutes. Output is now captured rather
+      than inherited so the reply can be read, and printed verbatim so nothing
+      is hidden.
+- [ ] **#229 — authentication for the local surface. DESIGN WRITTEN, awaiting
+      four decisions.** `docs/specs/api-auth-design.md`.
+- [ ] Live regression against staging + Playwright.
+- [ ] CHANGELOG, guides.
+
+## Found during recon
+
+**The port serves more than `/api/v1`.** `registerPostgrestProxy`
+(`web/routes/postgrest-proxy.ts:31`) mounts `/rest/v1/*` on the same port and
+forwards caller headers verbatim to PostgREST. It self-gates on
+`CEREFOX_POSTGREST_UPSTREAM`, so it is live **on Cerefox Local specifically** —
+the deployment most likely to run unattended. Any auth gate that covers only
+`/api/v1` moves the hole rather than closing it. This is recorded here because
+it is the single most likely way #229 ships half-done.
+
+**Handing a key to the browser is the whole difficulty.** `index.html` is read
+once at boot and served verbatim (`web/server.ts:160-161`). Injecting a key
+there would mean anything that can `GET /app/` can read it — which is exactly
+the attacker the key defends against. A key embedded in an unauthenticated
+page is not a secret. The design's loopback-exempt recommendation exists to
+dissolve this rather than work around it.
+
+**`cerefox-local` never crosses the published port.** Every CLI verb runs
+inside the container over `docker exec` (`docker/local/cerefox-local:424-432`);
+the only network egress is a GitHub call to resolve the newest release tag. So
+the wrapper needs no key, and the container's own secret boundary is preserved.
+
+## Rejected: pinning `jsr:@supabase/supabase-js@2`
+
+Considered on 2026-09-02 after the production deploy failed, and **rejected**.
+The failure is rare, loud, leaves the previous functions serving, and
+self-heals on retry. A permanent manual-bump burden across 9 functions is the
+worse trade, and pinning would move the trust decision rather than remove it —
+you would make the same call by hand on your own schedule. What the incident
+justified was a readable error message, which is what shipped.
+
+Evidence, since it is the kind of thing that gets re-litigated: JSR published
+`supabase-js@2.113.0` at 06:03:13Z; npm published `supabase-js@2.113.0` at
+06:04:34Z and its `auth-js@2.113.0` dependency at 06:05:01Z. The production
+deploy landed inside that 108-second window. Staging had deployed earlier and
+resolved 2.112.4, which is why the same command on the same version worked
+there and not here.

--- a/docs/specs/api-auth-design.md
+++ b/docs/specs/api-auth-design.md
@@ -1,0 +1,193 @@
+# Authenticating the local HTTP surface (#229)
+
+**Status: DESIGN, awaiting maintainer decisions.** Target: v1.12.0
+(iteration 41). Nothing below is implemented yet. Four questions marked
+**DECISION** need answering before code; everything else follows from them.
+
+## The problem, stated precisely
+
+`cerefox web` serves an unauthenticated JSON API. Anything that can open a TCP
+connection to the port can read every document, edit them, delete them, and
+permanently purge them. Today the only boundary is that every shipped path
+binds loopback: `cerefox web` defaults `--host 127.0.0.1`
+(`cli/commands/web.ts:96`), and Cerefox Local publishes to `127.0.0.1`
+(`docker/local/install-local.sh:30`, `docker/local/cerefox-local:101`).
+
+That was adequate while the API was the bundled UI's private backend. #226
+invited other local clients onto it, and the boundary is one `--host 0.0.0.0`
+or one `CEREFOX_LOCAL_BIND=0.0.0.0` away from being absent.
+`docs/guides/api.md` says so in the strongest terms available, and a warning in
+a guide is not a control.
+
+**Threat model, so the design can be judged against something.** The attacker
+is a process or person that can reach the port but has **no read access to the
+host filesystem**: another machine on the LAN or a coffee-shop network after
+someone widened the bind, a container on a shared Docker network, a malicious
+page attempting cross-origin requests. The attacker who already has filesystem
+access is explicitly **out of scope**: they can read the key file, the `.env`,
+and the Postgres credentials, so no key defends against them. Any design that
+only stops the second attacker is theatre.
+
+## Two findings that shape the answer
+
+**1. The port serves more than `/api/v1`.** `registerPostgrestProxy`
+(`web/routes/postgrest-proxy.ts:31`) mounts `/rest/v1/*` on the same port and
+forwards the caller's headers verbatim to PostgREST. It self-gates on
+`CEREFOX_POSTGREST_UPSTREAM`, so it is live on **Cerefox Local specifically** —
+the deployment most likely to be running unattended. Gating `/api/v1` and
+leaving this open would move the hole, not close it. **Any auth gate must cover
+both surfaces.**
+
+**2. Handing the key to the browser is the whole difficulty.** The SPA is
+static: `index.html` is read once at boot and served verbatim
+(`web/server.ts:160-161`). Injecting the key into that HTML would mean anything
+that can `GET /app/` can read the key — which is exactly the attacker we are
+defending against. **A key embedded in an unauthenticated page is not a
+secret.** Every design below is really a different answer to "how does the
+browser prove itself".
+
+## The recommendation: authenticate by network origin, with a key for everything else
+
+Requests arriving on the **loopback interface** are allowed without a
+credential. Requests arriving on any other interface must present the key.
+
+This matches the threat model exactly. The in-scope attacker is by definition
+not on loopback; the out-of-scope attacker (local filesystem access) could read
+the key anyway, so requiring one from them buys nothing. Loopback access and
+key-file access are the same trust boundary on a single-user machine, which is
+what Cerefox is.
+
+What it means in practice:
+
+- **The browser keeps working with no key and no prompt.** No injection into
+  `index.html`, no `localStorage`, no session mechanism, nothing to leak.
+- **Local agents keep working unchanged.** The bot harness on 127.0.0.1 needs
+  no code change, which matters because #226 just landed and its whole promise
+  was "omitted, nothing changes".
+- **`cerefox-local` needs nothing at all.** Confirmed in recon: every CLI verb
+  runs *inside* the container over `docker exec`
+  (`docker/local/cerefox-local:424-432`) and never crosses the published port.
+- **`--host 0.0.0.0` stops being a hole.** Widening the bind now exposes a
+  surface that demands a credential, which is the entire point of the ticket.
+- **Default-on is safe**, because on every existing install nothing changes.
+  That dissolves the upgrade problem in the ticket's question 2: there is no
+  grace mode to design, because no working setup breaks.
+
+### The caveat this design must document, loudly
+
+**A same-host reverse proxy makes every request look like loopback.** Someone
+who puts nginx or Caddy in front of `cerefox web` on the same machine
+terminates the connection and reconnects from 127.0.0.1, so every forwarded
+request is exempt. `X-Forwarded-For` must **never** be consulted to recover the
+original address: it is caller-supplied, so trusting it would let any client
+claim any origin and would be strictly worse than having no gate.
+
+The answer is an explicit opt-out for that topology: `CEREFOX_API_REQUIRE_KEY=1`
+(or `--require-key`) forces the key on every request including loopback. The
+guide tells anyone fronting Cerefox with a proxy to set it. The default stays
+the one that is right for the 99% who run it directly.
+
+### Alternatives considered
+
+**Key on every request, including the browser.** Rejected on the browser
+problem above: it forces either an injected-key page (not a secret) or a prompt
+the user must answer with a value they must first go find. It also breaks every
+existing local client on upgrade, converting a security improvement into a
+support burden, and the pressure would then be to default it off — which
+reproduces today's state for everyone who does not opt in.
+
+**Session cookie issued to the browser.** Real, and strictly more machinery:
+something must authenticate the human before issuing the cookie, and on a
+single-user local tool the only available proof is "you reached loopback". It
+arrives at the same trust decision with a login flow bolted on.
+
+**Origin/CSRF checks only.** Necessary but not sufficient. They stop a
+malicious web page driving the API from a victim's browser, and stop nothing
+arriving from another host. Worth adding regardless (see below), not as the
+gate.
+
+## What gets built
+
+**Reuse the existing auth primitive; do not write a second one.**
+`_shared/ef-auth/index.ts` is deliberately runtime-portable (Web Platform
+globals only, documented at `ef-auth/index.ts:1-20`) and already does the hard
+parts: `parseAccessTokens` for a comma-separated accept-set,
+`checkAccessToken` comparing against every token **without short-circuiting**
+so timing leaks nothing (`ef-auth/index.ts:93-96`), fail-closed on an empty
+token set, and a 401 with `WWW-Authenticate: Bearer`. It imports
+`constantTimeEqual` from `_shared/mcp-auth/index.ts:141`, the single audited
+compare in the codebase. A Hono middleware can return `efAuthGate`'s `Response`
+directly.
+
+One auth implementation covering Edge Functions and the local server is worth
+more than a marginally better second one.
+
+**Insertion point.** `web/server.ts:82`, after the logger and before
+`registerMetaRoutes`. One `app.use()` covering `/api/v1/*` and `/rest/v1/*`.
+
+**Credential.** `Authorization: Bearer <key>`, matching the Edge Functions and
+every HTTP client's defaults. Prefix `cfx_lak_` ("local api key") so it is
+visually distinct from `cfx_pat_` in a log or a paste. Minted with
+`randomBytes(32).toString("base64url")`, the same as
+`cli/commands/token.ts:37-39`.
+
+**Where it lives.**
+
+- `cerefox web`: `CEREFOX_API_KEY` in the resolved `.env`, written with the
+  existing `upsertEnvVar` (`cli/util/env-file.ts:35`). Minted on demand by a
+  new `cerefox api-key generate|show|rotate`, modelled on `token.ts`.
+- Cerefox Local: minted in `s6/scripts/db-init` beside the JWT secret, using
+  the same env-override → persisted-file → generate ladder (`db-init:11-13`),
+  persisted `chmod 600` on the data volume, and emitted into
+  `/run/cerefox-runtime.env` (`db-init:18`) so the server reads it from the
+  environment. A new host verb (`cerefox-local api-key`) surfaces it, since the
+  wrapper deliberately keeps container secrets in the container
+  (`cerefox-local:8-9`).
+
+**Not a `cerefox_config` row.** The toggle would live behind the surface it
+protects, and a request that fails auth would still need a database read to
+learn whether auth applies. Boot-time environment, self-gating like
+`CEREFOX_POSTGREST_UPSTREAM` (`postgrest-proxy.ts:32-35`), avoids the ordering
+problem entirely.
+
+**Ride-along hardening**, cheap once the middleware exists: reject
+cross-origin requests carrying an `Origin` header that is not the server's own,
+so a malicious page in the user's browser cannot drive the API even though the
+browser is on loopback. This is the one real gap the loopback design leaves,
+and it closes it.
+
+## Open decisions
+
+**DECISION 1 — Is loopback-exempt the right call?** The recommendation above,
+or key-always with a browser story. This is the load-bearing choice; everything
+else follows.
+
+**DECISION 2 — Does `/api/v1/version` stay open?** It is how a client learns
+the server is up and what it is, and `doctor`/`checks.ts` rely on it. Standing
+maintainer preference is to gate rather than expose when a credential is at
+hand. Under the loopback design this matters less than it looks: a local caller
+is exempt anyway, so the question is only whether a *remote* caller can probe
+liveness without a key. Recommendation: gate it, and let liveness be answered
+by a TCP connect.
+
+**DECISION 3 — Does purge stay reachable over the API?** Raised on the ticket
+and unchanged by this design. A key makes purge *safer*, not *intended*. The
+route cannot simply be deleted: the web UI's own trash-purge button calls it.
+Options are keep it, gate it behind an additional flag, or require a
+confirmation token. Worth deciding on its own merits, not folded into the auth
+change.
+
+**DECISION 4 — Does this ship with #232 in v1.12.0, or on its own?** It is the
+larger and more security-relevant half. Splitting would let #232 and the
+smaller fixes ship immediately.
+
+## Testing
+
+- Unit: the middleware's decision table (loopback vs not, key present/absent/
+  wrong, force-key on, `Origin` mismatch), and that `X-Forwarded-For` changes
+  nothing. The last one is a **regression test against a plausible future
+  "fix"**, which is the reason to write it now.
+- Integration: the existing `web-integration` suite spawns a real server, so it
+  can assert a keyless remote-shaped request is refused and a keyed one is not.
+- Explicitly: a test that `/rest/v1/*` is gated too, since forgetting it is the
+  most likely way this ships half-done.

--- a/docs/specs/api-auth-design.md
+++ b/docs/specs/api-auth-design.md
@@ -1,8 +1,8 @@
 # Authenticating the local HTTP surface (#229)
 
-**Status: DESIGN, awaiting maintainer decisions.** Target: v1.12.0
-(iteration 41). Nothing below is implemented yet. Four questions marked
-**DECISION** need answering before code; everything else follows from them.
+**Status: DESIGN APPROVED 2026-09-02, ready to build.** Target: v1.12.0
+(iteration 41). The four open questions were decided by the maintainer on
+2026-09-02 and are recorded under "Decisions" below.
 
 ## The problem, stated precisely
 
@@ -46,7 +46,7 @@ defending against. **A key embedded in an unauthenticated page is not a
 secret.** Every design below is really a different answer to "how does the
 browser prove itself".
 
-## The recommendation: authenticate by network origin, with a key for everything else
+## The design: authenticate by network origin, with a key for everything else
 
 Requests arriving on the **loopback interface** are allowed without a
 credential. Requests arriving on any other interface must present the key.
@@ -156,37 +156,79 @@ so a malicious page in the user's browser cannot drive the API even though the
 browser is on loopback. This is the one real gap the loopback design leaves,
 and it closes it.
 
-## Open decisions
+## Decisions
 
-**DECISION 1 — Is loopback-exempt the right call?** The recommendation above,
-or key-always with a browser story. This is the load-bearing choice; everything
-else follows.
+Settled with the maintainer 2026-09-02.
 
-**DECISION 2 — Does `/api/v1/version` stay open?** It is how a client learns
-the server is up and what it is, and `doctor`/`checks.ts` rely on it. Standing
-maintainer preference is to gate rather than expose when a credential is at
-hand. Under the loopback design this matters less than it looks: a local caller
-is exempt anyway, so the question is only whether a *remote* caller can probe
-liveness without a key. Recommendation: gate it, and let liveness be answered
-by a TCP connect.
+**1 — Loopback-exempt is the design.** Requests on the loopback interface are
+allowed without a credential; every other interface must present the key.
 
-**DECISION 3 — Does purge stay reachable over the API?** Raised on the ticket
-and unchanged by this design. A key makes purge *safer*, not *intended*. The
-route cannot simply be deleted: the web UI's own trash-purge button calls it.
-Options are keep it, gate it behind an additional flag, or require a
-confirmation token. Worth deciding on its own merits, not folded into the auth
-change.
+**`X-Forwarded-For` is never consulted, and that is enforced in code, not
+prose.** A documented rule that some future change could quietly violate is
+kicking the can down the road: the header is caller-supplied, so trusting it
+would let any client claim any origin and would be strictly worse than no gate
+at all. Build requirements: the middleware reads only the transport-level
+remote address; a test asserts a request carrying
+`X-Forwarded-For: 127.0.0.1` from a non-loopback address is still refused; the
+test says in its own comment that it exists to fail a plausible future "fix".
 
-**DECISION 4 — Does this ship with #232 in v1.12.0, or on its own?** It is the
-larger and more security-relevant half. Splitting would let #232 and the
-smaller fixes ship immediately.
+**2 — `/api/v1/version` is gated with everything else. No exceptions.**
+Verified before deciding: **nothing local is affected.** The CLI never calls
+the local web API at all — it talks to the Supabase Data API directly
+(`${supabaseUrl}/rest/v1/...`, `cli/util/checks.ts:183-189`), and the only CLI
+references to `/api/v1` are doc comments plus the URL `cerefox web` prints.
+`doctor`'s peer-version aggregator is a *different* endpoint on the Edge
+Function host, authenticated with the Cerefox access token. The browser is on
+loopback. The one contributor script that curls `/version`
+(`scripts/capture_python_parity.sh:27`) runs against localhost.
+
+So the only caller a gate affects is a **remote** one, and a remote caller
+probing liveness without a credential is precisely what this ticket exists to
+stop. One rule with no exceptions is also easier to reason about than one rule
+plus a carve-out, and liveness can still be answered by a TCP connect.
+
+**3 — Purge stays reachable over the API.** It cannot be removed without
+breaking the web UI's own trash-purge button, and the maintainer wants it
+reachable from both surfaces. Hiding it was a defensive measure against
+hallucinating models; soft-delete-then-purge is two deliberate steps, which is
+friction enough, and agents overwhelmingly reach Cerefox through MCP rather
+than the API or CLI. No additional flag, no confirmation token.
+
+**4 — #229 ships in v1.12.0 alongside #232.** The question was badly framed on
+my part: a PR is not a release. #233 (#232 + #230 + the deploy message) merges
+as soon as it is reviewed, #229 lands as a second PR, and v1.12.0 is cut when
+both are in. There is no reason to hold finished work behind unbuilt work, and
+no reason to split the release. The only case for revisiting is if #229 grows a
+long tail in review, in which case v1.12.0 cuts with what is ready and #229
+becomes v1.13.0 — a decision to defer, not to make now.
+
+## What this does NOT do: mint a key when the page loads
+
+Worth stating because it is the intuitive reading and it is the design that was
+rejected. There is **no** flow where the SPA loads, triggers minting, and
+receives a key. The browser never holds the key, is never sent it, and never
+asks for it.
+
+The key is minted by an explicit action, never as a side effect of a page load:
+
+- `cerefox api-key generate` (or `rotate`), modelled on `token.ts`, writing to
+  the resolved `.env` via `upsertEnvVar`.
+- Cerefox Local mints it at container boot in `s6/scripts/db-init`, beside the
+  JWT secret it already mints, persisted on the data volume.
+
+The browser works because it is on loopback, not because it holds a credential.
+And the CLI is untouched by any of this: it never talks to the web server, so
+there is nothing for it to read or present.
 
 ## Testing
 
 - Unit: the middleware's decision table (loopback vs not, key present/absent/
-  wrong, force-key on, `Origin` mismatch), and that `X-Forwarded-For` changes
-  nothing. The last one is a **regression test against a plausible future
-  "fix"**, which is the reason to write it now.
+  wrong, force-key on, `Origin` mismatch).
+- **`X-Forwarded-For` changes nothing.** A non-loopback request carrying
+  `X-Forwarded-For: 127.0.0.1` is still refused. This is a regression test
+  against a plausible future "fix" — someone adding proxy support without
+  realising the header is caller-supplied — and the test comment says so, so
+  the next reader does not delete it as redundant.
 - Integration: the existing `web-integration` suite spawns a real server, so it
   can assert a keyless remote-shaped request is refused and a keyed one is not.
 - Explicitly: a test that `/rest/v1/*` is gated too, since forgetting it is the

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -122,6 +122,33 @@ export async function detectV07FromResponse(
   return v07 ? new V07IngestionDeferredError(body, v07) : null;
 }
 
+/**
+ * Human-readable reason for a failed raw-`fetch` upload (#232).
+ *
+ * The ingest routes answer 400/409 for a refused write and put the reason in
+ * the body's `detail` (and `error`). `apiFetch` call sites get that for free
+ * via `ApiError`; the FormData upload paths use raw `fetch` and would
+ * otherwise show only a status code. Safe to call after
+ * `detectV07FromResponse` returned null: that only consumes the body on a 503.
+ */
+export async function uploadFailureMessage(resp: Response): Promise<string> {
+  let body = "";
+  try {
+    body = await resp.text();
+  } catch {
+    /* body already consumed or unreadable — fall through to the status */
+  }
+  try {
+    const parsed = JSON.parse(body) as { detail?: unknown; error?: unknown };
+    for (const field of [parsed.detail, parsed.error]) {
+      if (typeof field === "string" && field.trim()) return field;
+    }
+  } catch {
+    /* non-JSON body */
+  }
+  return `Upload failed: ${resp.status}`;
+}
+
 /** Build a query string from a params object, omitting empty values. */
 export function buildQueryString(
   params: Record<string, string | number | undefined>,

--- a/frontend/src/pages/IngestPage.tsx
+++ b/frontend/src/pages/IngestPage.tsx
@@ -4,7 +4,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
-import { detectV07FromResponse } from "../api/client";
+import { detectV07FromResponse, uploadFailureMessage } from "../api/client";
 import { checkFilename, ingestPaste } from "../api/documents";
 import type { FilenameCheckResponse, IngestResponse } from "../api/types";
 import { invalidateDocumentViews } from "../lib/invalidate";
@@ -90,7 +90,11 @@ export function IngestPage() {
       if (!resp.ok) {
         const v07 = await detectV07FromResponse(resp);
         if (v07) throw v07;
-        throw new Error(`Upload failed: ${resp.status}`);
+        // Since #232 these routes answer 400/409 for a refused write and put
+        // the reason in the body. A bare `Upload failed: 400` would drop the
+        // one thing the user needs (this path does NOT go through apiFetch,
+        // so it gets no ApiError message for free).
+        throw new Error(await uploadFailureMessage(resp));
       }
       return resp.json() as Promise<IngestResponse>;
     },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cerefox-workspace",
   "version": "0.0.0-unreleased",
-  "description": "Repo-root npm workspace covering all Cerefox TypeScript surfaces — published packages (packages/*), shared internal modules (_shared), the React web UI (frontend), and ad-hoc TS scripts (scripts/*.ts). The package itself is not published; the workspace pattern lets `bun install` at the repo root hoist deps for every member.",
+  "description": "Repo-root npm workspace covering all Cerefox TypeScript surfaces \u2014 published packages (packages/*), shared internal modules (_shared), the React web UI (frontend), and ad-hoc TS scripts (scripts/*.ts). The package itself is not published; the workspace pattern lets `bun install` at the repo root hoist deps for every member.",
   "private": true,
   "type": "module",
   "workspaces": [
@@ -12,6 +12,11 @@
   "dependencies": {
     "ora": "^9.4.0",
     "postgres": "^3.4.9"
+  },
+  "overrides": {
+    "fast-uri": "^3.1.7",
+    "qs": "^6.16.0",
+    "@xmldom/xmldom": "^0.8.15"
   },
   "scripts": {
     "test": "cd _shared && bun test",

--- a/packages/memory/src/cli/commands/deploy-server.ts
+++ b/packages/memory/src/cli/commands/deploy-server.ts
@@ -340,6 +340,8 @@ async function action(options: DeployServerOptions): Promise<void> {
     println(c.bold(`\n▶  Deploying ${efNames.length} Edge Function(s)…`));
     let efOk = 0;
     const efFailed: string[] = [];
+    /** Captured output of the failed deploys, for cause detection below. */
+    const efOutput: string[] = [];
     for (const ef of efNames) {
       info(`   deploying ${ef}…`);
       // Run with cwd = the assets root's supabase parent so the CLI finds
@@ -363,18 +365,47 @@ async function action(options: DeployServerOptions): Promise<void> {
         args.push("--no-verify-jwt");
         info(`     (${ef}: --no-verify-jwt — in-function auth)`);
       }
+      // stdout/stderr are captured rather than inherited so we can READ the
+      // bundler's reply and explain it (see `upstreamRegistryRace` below).
+      // Everything captured is printed verbatim immediately after, so nothing
+      // is hidden — the only change is that a function's output appears when
+      // it finishes instead of while it runs.
       const r = spawnSync("npx", args, {
         encoding: "utf8",
-        stdio: "inherit",
+        stdio: ["inherit", "pipe", "pipe"],
         cwd: workdir,
         timeout: 120_000,
       });
+      if (r.stdout) process.stdout.write(r.stdout);
+      if (r.stderr) process.stderr.write(r.stderr);
       if (r.status === 0) efOk++;
-      else efFailed.push(ef);
+      else {
+        efFailed.push(ef);
+        efOutput.push(`${r.stdout ?? ""}\n${r.stderr ?? ""}`);
+      }
     }
     if (efFailed.length > 0) {
       eprintln(c.red(`\n✗ ${efFailed.length} Edge Function(s) failed: ${efFailed.join(", ")}`));
-      eprintln(c.dim("   Re-run `cerefox server deploy --functions-only` after fixing the cause."));
+      if (upstreamRegistryRace(efOutput.join("\n"))) {
+        // Observed 2026-09-02: JSR published supabase-js 2.113.0 at 06:03:13Z
+        // and npm published the auth-js it depends on at 06:05:01Z. A deploy
+        // inside that 108-second window resolves a JSR package whose npm
+        // dependency does not exist yet, and every function fails to bundle.
+        // The raw reply is a 400 with a JSR stack trace, which reads exactly
+        // like "your release is broken" — hence this block.
+        eprintln("");
+        eprintln(c.yellow("   This looks like an UPSTREAM package-registry race, not a problem"));
+        eprintln(c.yellow("   with your Cerefox install:"));
+        eprintln(c.dim("     The Edge Functions import `jsr:@supabase/supabase-js@2`. When Supabase"));
+        eprintln(c.dim("     publishes a new version, JSR and npm do not land at the same instant;"));
+        eprintln(c.dim("     a deploy in that gap resolves a JSR package whose npm dependency is not"));
+        eprintln(c.dim("     published yet, and bundling fails."));
+        eprintln(c.dim("     Your deployed functions were NOT changed — the previous version is"));
+        eprintln(c.dim("     still serving, so nothing is down."));
+        eprintln(c.cyan("   → Wait a few minutes, then re-run: cerefox server deploy --functions-only"));
+      } else {
+        eprintln(c.dim("   Re-run `cerefox server deploy --functions-only` after fixing the cause."));
+      }
       process.exit(1);
     }
     println(c.green(`   ✓ Deployed ${efOk} Edge Function(s).`));
@@ -423,6 +454,29 @@ async function action(options: DeployServerOptions): Promise<void> {
   // are both on this release (self-update used to fire it pre-deploy, where a
   // schema-requiring release cannot ingest — see self-update.ts).
   println(c.dim("Refresh the bundled guides: cerefox guides ingest"));
+}
+
+/**
+ * Does this failed-deploy output look like an upstream package-registry race
+ * rather than a Cerefox problem? (#232 companion, observed 2026-09-02.)
+ *
+ * Supabase's Edge Function bundler resolves `jsr:@supabase/supabase-js@2` at
+ * deploy time. JSR and npm publishes are not atomic with respect to each
+ * other, so there is a window in which the JSR package exists and the npm
+ * dependency it names does not. Every function then fails with a 400 whose
+ * body says `Could not find npm package '<name>' matching '<version>'`.
+ *
+ * Deliberately matched on the bundler's phrasing rather than on a package
+ * name: the same race can happen with any transitive dependency, and pinning
+ * the specifier to dodge it was considered and rejected (the failure is rare,
+ * loud, leaves the previous functions serving, and self-heals on retry — a
+ * standing manual-bump burden across 9 functions is the worse trade).
+ */
+export function upstreamRegistryRace(output: string): boolean {
+  return (
+    /Failed to bundle the function/i.test(output) &&
+    /Could not find npm package/i.test(output)
+  );
 }
 
 export function registerDeployServer(program: Command): void {

--- a/packages/memory/src/web/routes/ingest.ts
+++ b/packages/memory/src/web/routes/ingest.ts
@@ -25,6 +25,10 @@ import { Hono } from "hono";
 
 import { fileToMarkdown } from "../../ingestion/file-to-markdown.ts";
 import { IngestionPipeline } from "../../ingestion/pipeline.ts";
+import {
+  ConcurrencyConflictError,
+  ConcurrencyTokenRequiredError,
+} from "../../ingestion/types.ts";
 import type { WebContext } from "../context.ts";
 import { logWebUsage } from "../usage.ts";
 import { resolveCallerIdentity } from "../identity.ts";
@@ -37,10 +41,52 @@ interface IngestResponse {
   updated?: boolean;
   note?: string;
   error?: string;
+  /** Present on a 409 so the caller can re-read without a second round trip —
+   *  the same field `documents-write.ts` returns on an edit conflict. */
+  current_hash?: string;
+  /** Same text as `error`. Present because the rest of `/api/v1` puts its
+   *  human-readable reason in `detail`, and the frontend's `ApiError` reads
+   *  exactly that field to build its message (`api/client.ts`). Emitting only
+   *  `error` on a non-2xx would show the user a bare "API error 400". */
+  detail?: string;
 }
 
 function notReady(error: string): IngestResponse {
-  return { success: false, error };
+  return { success: false, error, detail: error };
+}
+
+/**
+ * Map a pipeline failure to its HTTP status (#232).
+ *
+ * These routes used to answer `200 {success:false, error}` for EVERY pipeline
+ * failure, including a refused write. That was survivable while the only
+ * caller was the bundled UI, which reads `success`. #226 opened the surface to
+ * other clients, and an HTTP client that checks `resp.ok` — what
+ * `raise_for_status()`, `curl -f` and every retry wrapper do by default —
+ * would read a refused write as a successful one. A concurrency refusal is the
+ * worst case to miss, because the caller's next move depends on knowing.
+ *
+ * The mapping is not invented here: `documents-write.ts` has mapped these same
+ * two typed errors to 400/409 since iter-32. This brings the three ingest
+ * routes onto that existing convention rather than adding a second one.
+ *
+ * `success: false` and `error` stay in the body, so a client reading either of
+ * them keeps working; only the status (and the added `detail`) are new.
+ */
+function ingestFailure(err: unknown): [IngestResponse, 400 | 409 | 500] {
+  if (err instanceof ConcurrencyConflictError) {
+    return [
+      {
+        ...notReady(err.message),
+        ...(err.currentHash ? { current_hash: err.currentHash } : {}),
+      },
+      409,
+    ];
+  }
+  if (err instanceof ConcurrencyTokenRequiredError) {
+    return [notReady(err.message), 400];
+  }
+  return [notReady(err instanceof Error ? err.message : String(err)), 500];
 }
 
 export function registerIngestRoutes(app: Hono, ctx: WebContext): void {
@@ -100,10 +146,8 @@ export function registerIngestRoutes(app: Hono, ctx: WebContext): void {
       });
       return c.json(resp, 200);
     } catch (err) {
-      return c.json(
-        notReady(err instanceof Error ? err.message : String(err)),
-        200,
-      );
+      const [body, status] = ingestFailure(err);
+      return c.json(body, status);
     }
   });
 
@@ -190,10 +234,8 @@ export function registerIngestRoutes(app: Hono, ctx: WebContext): void {
         200,
       );
     } catch (err) {
-      return c.json(
-        notReady(err instanceof Error ? err.message : String(err)),
-        200,
-      );
+      const [body, status] = ingestFailure(err);
+      return c.json(body, status);
     }
   });
 
@@ -288,10 +330,8 @@ export function registerIngestRoutes(app: Hono, ctx: WebContext): void {
         200,
       );
     } catch (err) {
-      return c.json(
-        notReady(err instanceof Error ? err.message : String(err)),
-        200,
-      );
+      const [body, status] = ingestFailure(err);
+      return c.json(body, status);
     }
   });
 }

--- a/packages/memory/test/deploy-registry-race.test.ts
+++ b/packages/memory/test/deploy-registry-race.test.ts
@@ -1,0 +1,80 @@
+/**
+ * `upstreamRegistryRace()` — the predicate behind the deploy-failure hint.
+ *
+ * The input strings here are not invented: the first is the verbatim reply
+ * from the 2026-09-02 production deploy, which failed because JSR published
+ * `supabase-js@2.113.0` at 06:03:13Z and npm published its `auth-js`
+ * dependency at 06:05:01Z. A deploy inside that 108-second window resolves a
+ * JSR package whose npm dependency does not exist yet.
+ *
+ * The predicate's job is to tell that transient, self-healing, upstream
+ * condition apart from a real deploy failure, because the two need opposite
+ * advice: "wait and re-run" versus "fix the cause".
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { upstreamRegistryRace } from "../src/cli/commands/deploy-server.ts";
+
+const REAL_FAILURE_2026_09_02 =
+  'unexpected deploy status 400: {"message":"Failed to bundle the function ' +
+  "(reason: Could not find npm package '@supabase/auth-js' matching " +
+  "'2.113.0'.\\n    at https://jsr.io/@supabase/supabase-js/2.113.0/src/lib/" +
+  'types.ts:1:37)."}\nTry rerunning the command with --debug to troubleshoot the error.';
+
+describe("upstreamRegistryRace", () => {
+  test("recognises the verbatim 2026-09-02 production failure", () => {
+    expect(upstreamRegistryRace(REAL_FAILURE_2026_09_02)).toBe(true);
+  });
+
+  test("recognises the same race on a different dependency", () => {
+    // Matched on the bundler's phrasing, not on a package name: the race can
+    // happen with any transitive dependency, so pinning one name would make
+    // the hint silently stop firing.
+    expect(
+      upstreamRegistryRace(
+        'Failed to bundle the function (reason: Could not find npm package ' +
+          "'@supabase/realtime-js' matching '2.99.0'.)",
+      ),
+    ).toBe(true);
+  });
+
+  test("fires when several functions failed and their output is concatenated", () => {
+    // The real call site joins every failed function's output; a deploy of 9
+    // functions produces 9 copies.
+    const joined = Array.from({ length: 9 }, () => REAL_FAILURE_2026_09_02).join("\n");
+    expect(upstreamRegistryRace(joined)).toBe(true);
+  });
+
+  test("does NOT fire on an unrelated bundling failure", () => {
+    // A genuine code error also says "Failed to bundle" — showing "wait a few
+    // minutes and re-run" here would send someone to wait out a syntax error.
+    expect(
+      upstreamRegistryRace(
+        "Failed to bundle the function (reason: The module's source code could " +
+          "not be parsed: Expected ';', got '}' at file:///src/index.ts:42:1)",
+      ),
+    ).toBe(false);
+  });
+
+  test("does NOT fire on an auth or permission failure", () => {
+    expect(
+      upstreamRegistryRace("unexpected deploy status 401: {\"message\":\"Unauthorized\"}"),
+    ).toBe(false);
+  });
+
+  test("does NOT fire on a missing-package message without a bundling failure", () => {
+    // Both halves are required: "could not find npm package" alone shows up in
+    // unrelated npm/npx chatter, and reaching for the hint there would be a
+    // confident wrong answer.
+    expect(
+      upstreamRegistryRace("npm warn Could not find npm package 'left-pad' matching '1.0.0'"),
+    ).toBe(false);
+  });
+
+  test("is empty-safe", () => {
+    // spawnSync can return null stdout/stderr on a timeout; the call site
+    // joins them into "" rather than crashing the error path.
+    expect(upstreamRegistryRace("")).toBe(false);
+  });
+});

--- a/packages/memory/test/web-integration/ingest.test.ts
+++ b/packages/memory/test/web-integration/ingest.test.ts
@@ -210,9 +210,46 @@ describe("web ingest endpoints (HTTP boundary)", () => {
       `${server.base}/api/v1/documents/${initialBody.document_id}/upload`,
       { method: "POST", body: noToken },
     );
-    const refusedBody = (await refused.json()) as { success: boolean; error?: string };
+    // #232: the REFUSAL IS A 400, not a 200 carrying success:false. A client
+    // that checks `resp.ok` (raise_for_status, curl -f, most retry wrappers)
+    // read the old shape as a successful write. Asserting the status is the
+    // whole point of this line — the body assertions below would pass either
+    // way, which is exactly how the old behaviour survived.
+    expect(refused.status).toBe(400);
+    const refusedBody = (await refused.json()) as {
+      success: boolean;
+      error?: string;
+      detail?: string;
+    };
     expect(refusedBody.success).toBe(false);
     expect(refusedBody.error ?? "").toContain("CEREFOX_TOKEN_REQUIRED");
+    // `detail` carries the same text: the frontend's ApiError reads that field
+    // and nothing else, so omitting it would show the user a bare
+    // "API error 400" and lose the remediation.
+    expect(refusedBody.detail ?? "").toContain("CEREFOX_TOKEN_REQUIRED");
+
+    // A STALE token is a 409, and carries the current hash so a caller can
+    // re-read without a second round trip.
+    const staleForm = new FormData();
+    staleForm.append(
+      "file",
+      new Blob(["# stale\n"], { type: "text/markdown" }),
+      `stale-${RUN_TAG}.md`,
+    );
+    staleForm.append("expected_content_hash", "0".repeat(64));
+    const stale = await fetch(
+      `${server.base}/api/v1/documents/${initialBody.document_id}/upload`,
+      { method: "POST", body: staleForm },
+    );
+    expect(stale.status).toBe(409);
+    const staleBody = (await stale.json()) as {
+      success: boolean;
+      detail?: string;
+      current_hash?: string;
+    };
+    expect(staleBody.success).toBe(false);
+    expect(staleBody.detail ?? "").toContain("CEREFOX_CONFLICT");
+    expect(staleBody.current_hash).toBe(read.content_hash);
 
     // Now upload-replace, with the token.
     const newText = `# v2\n\nReplacement content ${RUN_TAG}.\n`;
@@ -236,7 +273,7 @@ describe("web ingest endpoints (HTTP boundary)", () => {
     expect(body.success).toBe(true);
     expect(body.document_id).toBe(initialBody.document_id);
     expect(body.updated).toBe(true);
-    // Four round-trips (ingest, read, refused upload, upload), each embedding
-    // real content, so the default 5s is not enough.
+    // Five round-trips (ingest, read, refused upload, stale upload, upload),
+    // each embedding real content, so the default 5s is not enough.
   }, 30_000);
 });


### PR DESCRIPTION
## Summary

Iteration 41, target **v1.12.0**. v1.11.0 opened `/api/v1` to clients other than the bundled web app; this deals with what that exposed.

Closes #230
Closes #232

**#229 is DESIGN ONLY in this PR** (`docs/specs/api-auth-design.md`), now **approved** — all four open questions were decided 2026-09-02 and are recorded in the doc. The implementation lands as a separate PR, also in v1.12.0.

## #232 — a refused write no longer answers 200

All three ingest routes caught every pipeline failure and returned `200 {success:false, error}`, including a *refused* write. A client checking `resp.ok` — what `raise_for_status()`, `curl -f` and every retry wrapper do by default — read a refusal as a success. A concurrency refusal is the worst case to miss, because the caller's next move depends on knowing.

The mapping is not invented here: `documents-write.ts` has mapped the same two typed errors to 400/409 since iter-32. This brings the ingest routes onto the existing convention rather than adding a second one.

Two things a reviewer should check, because both would have quietly made the UI worse:

- Bodies keep `success:false` and `error` (nothing reading them breaks) and **gain `detail`** — the frontend's `ApiError` reads `detail` and nothing else, so a status change alone would have replaced the remediation text with a bare "API error 400".
- `IngestPage.tsx:89` posts FormData with raw `fetch` and threw `Upload failed: ${status}` with **no message at all**. New `uploadFailureMessage()` reads `detail`/`error`. Without it this "fix" would have removed information from the one surface the message was written for.

## #230 — 47 tests were reporting success while running nothing

`loadEnv()` cached "already loaded" as a boolean, so the second call was a no-op forever, including after `CEREFOX_CONFIG_DIR` changed. `live-write-guard-coverage.test.ts` sets that variable to a non-existent directory **on purpose** (proving the production-write guard refuses an unlabelled target), which poisoned the cache for the rest of the run: every live suite loaded afterwards saw no credentials and skipped.

The cache is now keyed on the resolved path. Still idempotent for the normal case; it just stops lying when the question changes.

**Full package suite against staging: 215 pass / 12 skip → 262 pass / 2 skip.** The 2 remaining skips are legitimate (a config key that is unset on that store). This is the same failure shape as the renamed-probe bug fixed in v1.11.0, and it is the third instance of "a green suite running nothing" on this project.

## Deploy errors that say what happened

The 2026-09-02 production deploy failed nine times with a raw `unexpected deploy status 400` and a JSR stack trace. Nothing said it was upstream, transient, or that the deployed functions were untouched, so it read as a broken release.

`upstreamRegistryRace()` detects the bundler's phrasing and explains it. Output is now captured rather than inherited so the reply can be read, and printed verbatim so nothing is hidden.

**Pinning `jsr:@supabase/supabase-js@2` was considered and rejected** (rationale in the iteration plan): the failure is rare, loud, leaves the previous functions serving, and self-heals on retry, so a permanent manual-bump burden across 9 functions is the worse trade. Evidence: JSR published `supabase-js@2.113.0` at 06:03:13Z, npm published its `auth-js` dependency at 06:05:01Z, and the deploy landed inside that 108-second window. Staging had deployed earlier and resolved 2.112.4, which is why the same command on the same version worked there.

## #229 design — two findings that shaped it

- **The port serves more than `/api/v1`.** `registerPostgrestProxy` mounts `/rest/v1/*` on the same port and forwards caller headers verbatim to PostgREST. It self-gates on `CEREFOX_POSTGREST_UPSTREAM`, so it is live **on Cerefox Local specifically**. A gate covering only `/api/v1` moves the hole rather than closing it.
- **A key embedded in an unauthenticated page is not a secret.** `index.html` is read once at boot and served verbatim, so injecting the key would mean anything that can `GET /app/` can read it — precisely the attacker it defends against.

**The decision is to authenticate by network origin**: loopback is exempt, everything else needs the key. That matches the threat model (the in-scope attacker is not on loopback; the out-of-scope one can read the key file anyway), keeps the browser and every existing local client working unchanged, makes default-on safe, and turns `--host 0.0.0.0` from a hole into a gate.

The caveat is that a same-host reverse proxy makes every request look like loopback. **`X-Forwarded-For` is never consulted, and that is enforced in code rather than prose**: the middleware reads only the transport-level remote address, and a test asserts that a non-loopback request carrying `X-Forwarded-For: 127.0.0.1` is still refused. A documented rule a future change could quietly violate would be kicking the can down the road.

Also decided: `/api/v1/version` is gated with everything else (verified first — **no local caller is affected**, because the CLI never talks to the web server; it goes straight to the Supabase Data API), and purge stays reachable over the API.

## Folded in: seven dependency advisories

Unrelated to this branch's subject, included because it **blocked the merge** and was pre-existing on `main` (verified: `origin/main` fails the same audit identically).

Four high and three moderate advisories were published upstream after v1.11.0 was cut, all transitive: `fast-uri` (host confusion + SSRF, four advisories, via `@modelcontextprotocol/sdk` and `eslint`), `qs` (array-limit bypass + DoS, same sdk), `@xmldom/xmldom` (XML fragment injection, via `mammoth`). `bun update` cannot reach the patched versions because the intermediate packages' ranges pin them, so root `overrides` are the lever.

Tested in a throwaway worktree off `origin/main` before touching this branch: typecheck clean on all three projects, 594 `_shared` tests, 28 smoke tests, bundle builds.

## Test plan

- [x] `_shared`: 594 pass, 0 fail
- [x] `packages/memory` against **staging**: 262 pass, 2 skip, 0 fail
- [x] `web-integration` alone: 25 pass, 0 fail
- [x] Playwright UI e2e against staging: 20/20
- [x] `bun run typecheck` (all three projects)
- [x] 7 unit tests for `upstreamRegistryRace()`, built on the **verbatim** 2026-09-02 failure text, including negatives for a real syntax error and an auth failure so the hint cannot fire on those
- [x] Live curl verification against a server built from this branch: 400 with `detail` on a missing token, 409 with `current_hash` on a stale one, 200 on success, 200 on a normal paste ingest. Fixtures purged.
- [x] No schema change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013PcVjtEzsfTtAxeayzga5u


