### PR TITLE
Hotfix: Cerefox Local was completely inaccessible on v1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,47 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
+### Fixed
+
+- **Cerefox Local was completely inaccessible on v1.12.0 — every request
+  returned `401`, including the web UI.** v1.12.0 injected an API key into the
+  container unconditionally, and **Docker's port publishing rewrites the source
+  address**: a request from the host to `127.0.0.1:<port>` reaches the server
+  inside the container appearing to come from the bridge gateway, never from
+  `127.0.0.1`. The loopback exemption could therefore never match. **Upgrade
+  to v1.12.1 if you run Cerefox Local.**
+
+  The fix is not only wiring. Inside a bridge-networked container the server
+  **cannot** distinguish a host-loopback caller from one that crossed the
+  network, because Docker NATs both to the same address — so the loopback-exempt
+  middle ground is not implementable there, and v1.12.0 was pretending
+  otherwise. In a container the gate is now all-or-nothing, and which one is
+  decided on the **host**, where the publish address is actually known:
+  published on `127.0.0.1` (the default) → gate off, the bind is the boundary,
+  exactly as pre-1.12.0; published wider → gate on for every caller.
+  `cerefox-local` derives this from `CEREFOX_LOCAL_BIND`; an explicit
+  `CEREFOX_API_REQUIRE_KEY=1` still forces it on.
+
+  Two guards so this cannot recur: `cerefox web` now **warns at boot** when a
+  key is configured inside a container without require-mode (the exact broken
+  configuration), and `docker/local/smoke-auth.sh` builds the real image,
+  publishes a real port and makes real requests from the host — verified to
+  fail on the v1.12.0 behaviour and pass on the fix. The original bug was
+  invisible to every unit test and to a native `cerefox web` run, because the
+  mechanism was right and only the packaging was wrong.
+
+- **`cerefox-local api-key` says whether the key is actually enforced.**
+  Printing a key while implying it gates something, when it does not, is worse
+  than printing nothing.
+- **Two more live tests given realistic time budgets** (`pipeline-update`,
+  `doctor --json`). They make several real Supabase/OpenAI round trips while
+  inheriting bun's 5-second default, so they failed on a slow API day. The
+  systematic version — ~130 live tests across 16 files with almost no explicit
+  budgets — is tracked as
+  [#235](https://github.com/fstamatelopoulos/cerefox/issues/235); note there
+  that `bunfig.toml`'s `[test] timeout` is **not** honored by bun 1.3.13, which
+  was verified rather than assumed.
+
 Open roadmap.
 
 ---

--- a/docker/local/cerefox-local
+++ b/docker/local/cerefox-local
@@ -106,6 +106,19 @@ recreate() {
   # shellcheck disable=SC1090
   PORT="$(. "$ENV_FILE"; echo "${CEREFOX_LOCAL_PORT:-8000}")"
   BIND_ADDR="$(. "$ENV_FILE"; echo "${CEREFOX_LOCAL_BIND:-127.0.0.1}")"
+  # The API-key gate is decided HERE, on the host, because only the host knows
+  # the publish address (v1.12.1). Inside the container Docker has already
+  # NAT'd every request to the bridge gateway, so the server cannot tell a
+  # host-loopback caller from a LAN one — the loopback exemption that works for
+  # a native `cerefox web` is not implementable there.
+  #   published on loopback → gate off (the bind is the boundary)
+  #   published wider       → gate on, every caller presents the key
+  # An explicit CEREFOX_API_REQUIRE_KEY in $ENV_FILE always wins (it is on the
+  # passthrough allowlist), so an operator can force the gate on regardless.
+  case "$BIND_ADDR" in
+    127.0.0.1|localhost|::1) GATE_ARGS="" ;;
+    *) GATE_ARGS=" -e CEREFOX_API_REQUIRE_KEY=1" ;;
+  esac
   OPENAI_API_KEY="$(. "$ENV_FILE"; echo "${OPENAI_API_KEY:-}")"
   # Ensure the image is available BEFORE removing the running container, so a failed pull
   # (offline, or a tag that doesn't exist yet) can't leave us with no container at all.
@@ -126,6 +139,7 @@ recreate() {
     --restart unless-stopped \
     -v "$VOLUME:/var/lib/postgresql/data" \
     ${OPENAI_API_KEY:+-e OPENAI_API_KEY=$OPENAI_API_KEY} \
+    $GATE_ARGS \
     $(config_env_args) \
     "$IMAGE" >/dev/null
   echo "✓ container (re)started → http://localhost:$PORT/app/"
@@ -330,8 +344,20 @@ case "$cmd" in
         echo "⚠ The previous key no longer works. Update every remote client." >&2
         ;;
       "")
-        docker exec "$CONTAINER" cat /var/lib/postgresql/data/.cerefox_api_key 2>/dev/null \
-          || die "no API key found — this image predates v1.12.0 (run: cerefox-local upgrade)"
+        _key="$(docker exec "$CONTAINER" cat /var/lib/postgresql/data/.cerefox_api_key 2>/dev/null || true)"
+        [ -n "$_key" ] || die "no API key found — this image predates v1.12.0 (run: cerefox-local upgrade)"
+        echo "$_key"
+        # Print the key, but never let someone believe it is being enforced
+        # when it is not. On a loopback publish the gate is OFF by design (the
+        # bind is the boundary) and this key is simply not in play.
+        if docker exec "$CONTAINER" grep -q '^CEREFOX_API_KEY=' /run/cerefox-runtime.env 2>/dev/null; then
+          echo "ℹ The gate is ON: every caller must send this key." >&2
+        else
+          echo "ℹ The gate is OFF — this container publishes on loopback, so the bind is" >&2
+          echo "  the boundary and this key is not currently required by anything." >&2
+          echo "  It turns on automatically if you widen CEREFOX_LOCAL_BIND, or now with:" >&2
+          echo "    echo CEREFOX_API_REQUIRE_KEY=1 >> $ENV_FILE && cerefox-local restart" >&2
+        fi
         ;;
       *) die "unknown api-key option: $1 (use --rotate, or no argument to print)" ;;
     esac

--- a/docker/local/s6/scripts/db-init
+++ b/docker/local/s6/scripts/db-init
@@ -20,21 +20,55 @@ else SECRET="$(bun -e 'process.stdout.write(require("node:crypto").randomBytes(3
 
 # Local API key: injected env > persisted (volume) > generate. Same ladder as
 # the JWT secret above, for the same reasons.
-#
-# Note what this key is NOT for: callers on the host reach the published port
-# over loopback and need no credential at all, which is why the web UI and any
-# harness using host networking keep working with no configuration. It is for a
-# caller arriving from somewhere that is not this machine — a container on a
-# Docker network, or a deliberately widened CEREFOX_LOCAL_BIND. Read it from
-# the host with `cerefox-local api-key`.
 if [ -n "${CEREFOX_API_KEY:-}" ]; then API_KEY="$CEREFOX_API_KEY"; log "using injected API key";
 elif [ -f "$API_KEY_FILE" ]; then API_KEY="$(cat "$API_KEY_FILE")"; log "loaded persisted API key";
 else API_KEY="cfx_lak_$(bun -e 'process.stdout.write(require("node:crypto").randomBytes(32).toString("base64url"))')"; printf '%s' "$API_KEY" > "$API_KEY_FILE"; chmod 600 "$API_KEY_FILE" || true; log "generated API key"; fi
 
+# ── Whether the gate is ON is decided on the HOST, not here (v1.12.1) ────────
+#
+# v1.12.0 injected the key unconditionally, which broke every containerised
+# install: Docker's port publishing NATs the source address, so a request from
+# the host to 127.0.0.1:<port> reaches this process appearing to come from the
+# bridge gateway, NOT from 127.0.0.1. The server's loopback exemption therefore
+# never matched and every caller — the web UI included — got a 401.
+#
+# The deeper point, which is why this is not just a wiring fix: inside a
+# bridge-networked container the server CANNOT distinguish a host-loopback
+# request from a LAN request. Docker NATs both to the same address. So the
+# loopback-exempt middle ground is not implementable here, and pretending
+# otherwise is what produced the bug.
+#
+# Hence: in a container the gate is either fully OFF or fully ON (every caller
+# presents the key). Which one is a property of the PUBLISH address, and only
+# the host knows that at `docker run` time — so `cerefox-local` passes the
+# decision in as CEREFOX_API_REQUIRE_KEY.
+#
+#   default publish (127.0.0.1)  → no key injected → gate off; the host's own
+#                                  bind is the boundary, exactly as pre-1.12.0
+#   wider publish, or an operator-supplied key → key injected + require mode
+#
+# The key is still minted and persisted above either way, so
+# `cerefox-local api-key` always has something to print and turning the gate on
+# never changes the value clients were given.
+API_KEY_LINE=""
+if [ "${CEREFOX_API_REQUIRE_KEY:-}" = "1" ] || [ -n "${CEREFOX_API_KEY:-}" ]; then
+  API_KEY_LINE="CEREFOX_API_KEY=$API_KEY"
+  log "API key gate ENABLED (every caller must present the key)"
+else
+  log "API key gate off (published on loopback; the host bind is the boundary)"
+fi
+
 # mint the service_role JWT and hand both to the longrun services via a /run env file
 JWT="$(SECRET="$SECRET" bun -e 'const c=require("node:crypto");const b=o=>Buffer.from(JSON.stringify(o)).toString("base64url");const h=b({alg:"HS256",typ:"JWT"});const p=b({role:"service_role"});process.stdout.write(h+"."+p+"."+c.createHmac("sha256",process.env.SECRET).update(h+"."+p).digest("base64url"))')"
 umask 077
-{ printf 'PGRST_JWT_SECRET=%s\n' "$SECRET"; printf 'CEREFOX_SUPABASE_KEY=%s\n' "$JWT"; printf 'CEREFOX_API_KEY=%s\n' "$API_KEY"; } > "$RUNTIME_ENV"
+{
+  printf 'PGRST_JWT_SECRET=%s\n' "$SECRET"
+  printf 'CEREFOX_SUPABASE_KEY=%s\n' "$JWT"
+  # Empty unless the gate is on — see the block above. When it IS on, force
+  # require-mode too: a key without it would rely on the loopback exemption,
+  # which cannot work behind Docker's NAT.
+  [ -n "$API_KEY_LINE" ] && { printf '%s\n' "$API_KEY_LINE"; printf 'CEREFOX_API_REQUIRE_KEY=1\n'; }
+} > "$RUNTIME_ENV"
 
 log "deploying schema + RPCs (idempotent)…"
 echo y | bun /opt/cerefox/dist/bin/cerefox.js server deploy --schema-only

--- a/docker/local/smoke-auth.sh
+++ b/docker/local/smoke-auth.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env sh
+# Container auth smoke test (v1.12.1) — the check whose ABSENCE shipped the
+# v1.12.0 bug that broke every Cerefox Local install.
+#
+# What that bug was: Docker's port publishing NATs the source address, so a
+# request from the host to a published port reaches the server inside the
+# container appearing to come from the bridge gateway, not 127.0.0.1. The
+# loopback exemption therefore never matched and EVERY caller got a 401,
+# including the web UI. It was invisible to every unit test and to a native
+# `cerefox web` run, because the mechanism was right and only the PACKAGING
+# was wrong.
+#
+# So this test can only be done one way: build the real image, publish a real
+# port, and make real requests from the host.
+#
+# Usage:
+#   sh docker/local/smoke-auth.sh                 # build + test
+#   CEREFOX_SMOKE_IMAGE=<ref> sh …/smoke-auth.sh  # test an existing image
+#
+# Self-cleaning: removes its own container + volume on exit, and never touches
+# a container or volume named `cerefox-local`.
+set -eu
+
+NAME="cerefox-smoke-auth-$$"
+VOL="${NAME}-data"
+PORT="${CEREFOX_SMOKE_PORT:-18441}"
+IMAGE="${CEREFOX_SMOKE_IMAGE:-cerefox-smoke-auth:local}"
+REPO_ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+
+cleanup() {
+  docker rm -f "$NAME" >/dev/null 2>&1 || true
+  docker volume rm "$VOL" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT INT TERM
+
+fail() { echo "SMOKE-AUTH FAIL: $1"; exit 1; }
+ok()   { echo "  ✓ $1"; }
+
+code() { curl -s -m 8 -o /dev/null -w '%{http_code}' "$@" 2>/dev/null || echo 000; }
+
+wait_ready() {
+  i=0
+  while [ "$i" -lt 90 ]; do
+    c=$(code "http://127.0.0.1:$PORT/api/v1/version")
+    # 200 (gate off) and 401 (gate on) both mean "serving"; only 000 means down.
+    [ "$c" = "200" ] || [ "$c" = "401" ] && return 0
+    i=$((i + 2)); sleep 2
+  done
+  echo "--- container logs ---"; docker logs "$NAME" 2>&1 | tail -30
+  fail "container never became ready on port $PORT"
+}
+
+if [ -z "${CEREFOX_SMOKE_IMAGE:-}" ]; then
+  echo "Building $IMAGE (this takes a few minutes)…"
+  docker build -q -f "$REPO_ROOT/docker/local/Dockerfile" -t "$IMAGE" "$REPO_ROOT" >/dev/null \
+    || fail "image build failed"
+fi
+
+# ── Case 1: default publish (loopback). The gate must be OFF. ────────────────
+# This is the case v1.12.0 got wrong, and it is the one every existing user is
+# in. A 401 here is the exact regression.
+echo "Case 1: published on 127.0.0.1 — gate must be OFF"
+docker run -d --name "$NAME" -p "127.0.0.1:$PORT:8000" -v "$VOL:/var/lib/postgresql/data" \
+  "$IMAGE" >/dev/null || fail "docker run failed"
+wait_ready
+c=$(code "http://127.0.0.1:$PORT/api/v1/version")
+[ "$c" = "200" ] || fail "host request got $c, expected 200 (this IS the v1.12.0 bug)"
+ok "host → 200 without a credential"
+c=$(code "http://127.0.0.1:$PORT/app/")
+[ "$c" = "200" ] || fail "web UI page got $c, expected 200"
+ok "web UI page → 200"
+# The key still exists, ready for the day it is needed.
+docker exec "$NAME" test -f /var/lib/postgresql/data/.cerefox_api_key \
+  || fail "no key was minted/persisted"
+ok "key minted + persisted (not enforced, by design)"
+
+# ── Case 2: require-mode. The gate must be ON for everyone. ──────────────────
+# What `cerefox-local` passes automatically when CEREFOX_LOCAL_BIND is widened.
+echo "Case 2: CEREFOX_API_REQUIRE_KEY=1 — gate must be ON"
+KEY=$(docker exec "$NAME" cat /var/lib/postgresql/data/.cerefox_api_key)
+docker rm -f "$NAME" >/dev/null 2>&1
+docker run -d --name "$NAME" -p "127.0.0.1:$PORT:8000" -v "$VOL:/var/lib/postgresql/data" \
+  -e CEREFOX_API_REQUIRE_KEY=1 "$IMAGE" >/dev/null || fail "docker run failed"
+wait_ready
+c=$(code "http://127.0.0.1:$PORT/api/v1/version")
+[ "$c" = "401" ] || fail "unauthenticated request got $c, expected 401"
+ok "no credential → 401"
+c=$(code -H "Authorization: Bearer $KEY" "http://127.0.0.1:$PORT/api/v1/version")
+[ "$c" = "200" ] || fail "request WITH the key got $c, expected 200"
+ok "correct key → 200"
+c=$(code -H "Authorization: Bearer cfx_lak_wrong" "http://127.0.0.1:$PORT/api/v1/version")
+[ "$c" = "401" ] || fail "wrong key got $c, expected 401"
+ok "wrong key → 401"
+# The key survived the recreate, because it lives on the volume. A key that
+# changed on every recreate would silently break every configured client.
+KEY2=$(docker exec "$NAME" cat /var/lib/postgresql/data/.cerefox_api_key)
+[ "$KEY" = "$KEY2" ] || fail "key changed across recreate — clients would break"
+ok "key stable across container recreate"
+
+echo "SMOKE-AUTH PASS"

--- a/docs/guides/securing-local-access.md
+++ b/docs/guides/securing-local-access.md
@@ -22,21 +22,53 @@ Introduced in **v1.12.0** ([#229](https://github.com/fstamatelopoulos/cerefox/is
 
 ## Do you need a key?
 
+**It depends on how Cerefox itself is running**, so start there.
+
+### If you run Cerefox Local (Docker)
+
+| Your publish address | Gate | You do |
+|---|---|---|
+| `127.0.0.1` (the default) | **Off** | Nothing. Every caller that can reach the published port is allowed, and the port is only reachable from this machine. |
+| Anything wider (`CEREFOX_LOCAL_BIND=0.0.0.0`) | **On, for everyone** | Give the key to every client, including your own browser. |
+
+There is no middle setting here, and that is deliberate rather than a
+limitation we forgot to lift. **Docker rewrites the source address of every
+request that comes through a published port**, so a server inside a container
+cannot tell a request from your own machine apart from one that crossed the
+network — both arrive from the same bridge address. Since the distinction
+cannot be made, the gate does not pretend to make it: it is either off, with
+the publish address as the boundary, or on for everybody.
+
+`cerefox-local` sets this for you from `CEREFOX_LOCAL_BIND`. To force the gate
+on while still publishing to loopback:
+
+```bash
+echo 'CEREFOX_API_REQUIRE_KEY=1' >> ~/.cerefox/local/.env
+cerefox-local restart
+```
+
+> **v1.12.0 got this wrong** and injected a key into every container without
+> require-mode, so the loopback exemption never matched and every caller — the
+> web UI included — got a `401`. Fixed in **v1.12.1**. If you are on v1.12.0
+> and seeing 401s from a container, upgrade.
+
+### If you run `cerefox web` directly (npm install)
+
+Here the server sees real client addresses, so the loopback rule applies as
+written.
+
 | Your situation | Need a key? |
 |---|---|
 | You use the web UI in your browser | **No** |
-| An agent or script runs on the same machine as Cerefox | **No** |
-| Your harness runs in a container using **host networking** or `host.docker.internal` | **No** — the connection still arrives on the host's loopback |
-| Your harness runs in a container on a **Docker bridge network**, reaching Cerefox as a container | **Yes** |
-| You set `--host 0.0.0.0` or `CEREFOX_LOCAL_BIND=0.0.0.0` to reach Cerefox from another machine | **Yes** |
-| You put a reverse proxy in front of Cerefox on the same machine | **Yes**, plus `CEREFOX_API_REQUIRE_KEY=1` (see below) |
+| An agent or script runs on the same machine | **No** |
+| A container reaches your host server via `host.docker.internal` | **No** — it arrives on the host's loopback |
+| You bind `--host 0.0.0.0` to reach Cerefox from another machine | **Yes** |
+| A reverse proxy sits in front on the same machine | **Yes**, plus `CEREFOX_API_REQUIRE_KEY=1` (see below) |
 
-If every row that applies to you says No, you are done. Nothing to install,
-nothing to configure, nothing changed in v1.12.0.
+If every row that applies to you says No, you are done.
 
-**Not sure which container case you are in?** Ask for the version endpoint from
-inside the client container. A `200` means you are on the exempt path; a `401`
-means you need a key.
+**Not sure?** Ask for the version endpoint the way your client will. `200`
+means you are on the exempt path; `401` means you need a key.
 
 ```bash
 docker exec <your-client-container> \
@@ -84,9 +116,14 @@ the data volume, so it survives `cerefox-local upgrade`. You never create it;
 you only read it.
 
 ```bash
-cerefox-local api-key            # print it
+cerefox-local api-key            # print it (and say whether it is enforced)
 cerefox-local api-key --rotate   # mint a new one and restart
 ```
+
+The key exists whether or not the gate is on, so turning the gate on later
+never changes the value your clients were given. `cerefox-local api-key` tells
+you which state you are in — printing a key while implying it is being enforced
+when it is not would be worse than printing nothing.
 
 ## Using it
 
@@ -120,10 +157,16 @@ the one it would generate, so this pins it across recreates.
 # 1. Mint once, on the host.
 KEY="cfx_lak_$(openssl rand -base64 32 | tr -d '=+/' | cut -c1-43)"
 
-# 2. Give it to Cerefox Local. It is on the passthrough allowlist, so it
-#    survives `cerefox-local upgrade` and any recreate.
-echo "CEREFOX_API_KEY=$KEY" >> ~/.cerefox/local/.env
+# 2. Give it to Cerefox Local. Both variables are on the passthrough allowlist,
+#    so they survive `cerefox-local upgrade` and any recreate. REQUIRE_KEY is
+#    what turns the gate on: inside a container there is no loopback exemption
+#    to fall back on, so the gate is all-or-nothing.
+{ echo "CEREFOX_API_KEY=$KEY"; echo "CEREFOX_API_REQUIRE_KEY=1"; } >> ~/.cerefox/local/.env
 cerefox-local restart
+
+# Note: with the gate on, YOUR BROWSER needs the key too. If you use the web UI
+# daily, prefer leaving Cerefox published on loopback with the gate off and
+# giving your harness host networking instead.
 
 # 3. Give the same value to your client container, however it takes config.
 docker run -e CEREFOX_API_KEY="$KEY" … your-harness
@@ -181,9 +224,13 @@ authenticates every request against a rotatable token. See
 set, which removes the loopback exemption. Unset it unless you are running a
 reverse proxy.
 
-**My container gets 401 but curl on the host works.** That is the gate behaving
-correctly: your container reaches Cerefox over a Docker network, not loopback.
-Give it the key (see the recipe above).
+**My container gets 401 but curl on the host works.** With `cerefox web` on the
+host, that is the gate behaving correctly: your container reaches Cerefox over
+a Docker network, not loopback. Give it the key (see the recipe above).
+
+**Everything gets 401 from a Cerefox Local container, including the web UI.**
+That is the v1.12.0 bug, not a configuration problem. Run
+`cerefox-local upgrade` to get v1.12.1 or newer.
 
 **`cerefox-local api-key` says no key was found.** The image predates v1.12.0.
 Run `cerefox-local upgrade`.

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -50,7 +50,28 @@ is rare, loud, leaves the previous functions live, and self-heals on retry, so a
 permanent manual-bump burden across 9 files is the worse trade. What it does
 justify is a readable error message (see iteration 41).
 
-**2026-09-02 — Iteration 41 OPEN, target v1.12.0.** Authentication for
+**2026-09-03 — v1.12.0 SHIPPED then IMMEDIATELY HOTFIXED. Iteration 42
+(v1.12.1) fixes a release-day break.** v1.12.0's #229 auth gate made Cerefox
+Local **completely inaccessible** — every request 401, web UI included —
+because Docker's port publishing rewrites the source address, so the loopback
+exemption never matched. Found live on the maintainer's instance by a demo
+agent, not by the suite. Detail:
+[iteration 42](plans/iteration-42-container-loopback.md).
+
+**The design correction, which matters beyond the bug**: inside a
+bridge-networked container the server CANNOT distinguish a host-loopback caller
+from a remote one (Docker NATs both to the same address), so the loopback-exempt
+middle ground is not implementable there. The container gate is now
+all-or-nothing, decided on the HOST from the publish address. Guarded by
+`docker/local/smoke-auth.sh`, which builds the real image and was verified to
+fail on the v1.12.0 behaviour.
+
+**Lesson**: a feature that depends on a property of the transport must be tested
+in every packaging that changes the transport. 17 unit tests, 8 HTTP-boundary
+tests and a real LAN verification all passed — every one of them against
+`cerefox web` running natively.
+
+**2026-09-02 — Iteration 41 CLOSED (v1.12.0).** Authentication for
 `/api/v1` (#229, design-first), the ingest routes' HTTP-status inconsistency
 (#232), live suites skipping in a full `bun test` (#230), and the deploy-error
 message above. Detail: [iteration 41](plans/iteration-41-api-auth.md).

--- a/docs/plans/iteration-42-container-loopback.md
+++ b/docs/plans/iteration-42-container-loopback.md
@@ -1,0 +1,76 @@
+# Iteration 42 — the container loopback bug (v1.12.1)
+
+**Status: FIX COMPLETE** (2026-09-03). Branch:
+`fix/v1.12.1-container-loopback`. Target: **v1.12.1**, a hotfix.
+
+## What broke
+
+v1.12.0 shipped the #229 auth gate. Within an hour of release, Cerefox Local
+was **completely inaccessible**: every request returned `401`, the web UI
+included. Found live, on the maintainer's own instance, by a demo agent whose
+Playwright recording started failing.
+
+**Docker's port publishing rewrites the source address.** A request from the
+host to `127.0.0.1:<port>` reaches the server inside the container appearing to
+come from the bridge gateway, never from `127.0.0.1`. The loopback exemption
+could therefore never match, for any caller.
+
+## Why it is not only a wiring mistake
+
+Inside a bridge-networked container the server **cannot** distinguish a
+host-loopback caller from one that crossed the network: Docker NATs both to the
+same address. The loopback-exempt middle ground is **not implementable there**,
+and v1.12.0 was pretending otherwise.
+
+So the container gate is now all-or-nothing, and *which* is decided on the
+**host**, the only place the publish address is known at `docker run` time:
+
+| Publish address | Gate |
+|---|---|
+| `127.0.0.1` (default) | **Off** — the bind is the boundary, exactly as pre-1.12.0 |
+| Anything wider | **On for every caller**, including the browser |
+
+`cerefox-local` derives this from `CEREFOX_LOCAL_BIND`; an explicit
+`CEREFOX_API_REQUIRE_KEY=1` still forces it on. The key is minted and persisted
+either way, so turning the gate on later never changes the value clients were
+given.
+
+## Why the tests missed it
+
+**The mechanism was right; the packaging was wrong.** 17 unit tests, 8
+HTTP-boundary tests and a real non-loopback verification all passed, because
+they exercised `cerefox web` running **natively on the host**. The auth gate was
+never once run inside a container — the single deployment where the address it
+depends on is rewritten before it arrives.
+
+The throwaway-container work in iteration 40 predates the feature, so there was
+no existing container test to extend, and its absence was not noticed.
+
+## Guards added
+
+- **`docker/local/smoke-auth.sh`** — builds the real image, publishes a real
+  port, makes real requests from the host. Asserts the default publish is
+  ungated (the exact v1.12.0 regression), that require-mode gates everyone,
+  that a wrong key is refused, and that the key survives a container recreate.
+  **Verified to fail on the v1.12.0 behaviour**: the fix was reverted, the image
+  rebuilt, and the test reproduced `host request got 401, expected 200`.
+- **A boot warning** (`containerGateWarning()`): `cerefox web` now says so
+  loudly when a key is configured inside a container without require-mode —
+  precisely the broken configuration — instead of silently 401ing everything.
+
+## Also in this release
+
+Two more live tests given realistic budgets (`pipeline-update`,
+`doctor --json`), same flake class as the `ingest-dir` fix in v1.12.0. The
+systematic problem is [#235](https://github.com/fstamatelopoulos/cerefox/issues/235):
+~130 live tests inherit bun's 5s default while making real network calls.
+`bunfig.toml`'s `[test] timeout` does **not** work on bun 1.3.13 — tested, not
+assumed, and recorded on the issue so nobody re-tries it.
+
+## Lesson
+
+Recorded because it generalises past this bug: **a feature that depends on a
+property of the transport must be tested in every packaging that changes the
+transport.** The gate reads a socket address; Docker rewrites socket addresses;
+nothing tested the gate under Docker. Everything else was rigorous, which is
+what made the gap invisible.

--- a/packages/memory/src/web/auth.ts
+++ b/packages/memory/src/web/auth.ts
@@ -39,6 +39,8 @@
  * so anyone fronting Cerefox that way must set it.
  */
 
+import { existsSync } from "node:fs";
+
 import { getConnInfo } from "@hono/node-server/conninfo";
 import type { Context, MiddlewareHandler } from "hono";
 
@@ -68,6 +70,47 @@ const LOOPBACK_ADDRESSES = new Set([
   "::1",
   "::ffff:127.0.0.1",
 ]);
+
+/**
+ * Are we running inside a container? (`/.dockerenv` is Docker's own marker.)
+ *
+ * This matters because of the v1.12.0 bug: Docker's port publishing NATs the
+ * source address, so a request from the host to a published port arrives here
+ * appearing to come from the bridge gateway rather than 127.0.0.1. The
+ * loopback exemption therefore never matches, and — worse — a bridge-networked
+ * container CANNOT distinguish a host-loopback caller from a LAN one, because
+ * both are NAT'd to the same address. The exemption is not implementable here,
+ * so a key without require-mode is a misconfiguration rather than a
+ * preference. `warnIfLoopbackExemptionIsUseless()` says so at boot.
+ */
+export function isContainerised(): boolean {
+  try {
+    return existsSync("/.dockerenv");
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Boot-time check for the one configuration that cannot work.
+ *
+ * Returns the warning text, or null when the configuration is sound — a string
+ * rather than a `console.warn` so it can be asserted in a test. The v1.12.0
+ * incident is the reason this is a function with a test and not a comment.
+ */
+export function containerGateWarning(env: NodeJS.ProcessEnv = process.env): string | null {
+  const hasKey = (env.CEREFOX_API_KEY ?? "").trim() !== "";
+  const requireAll = (env.CEREFOX_API_REQUIRE_KEY ?? "") === "1";
+  if (!hasKey || requireAll || !isContainerised()) return null;
+  return (
+    "\n⚠  CEREFOX_API_KEY is set inside a container without CEREFOX_API_REQUIRE_KEY=1.\n" +
+    "   Docker rewrites the source address of every published-port request, so the\n" +
+    "   loopback exemption cannot match and EVERY caller will get a 401 — including\n" +
+    "   the web UI. In a container the gate must be all-or-nothing:\n" +
+    "     • publishing on 127.0.0.1 → leave CEREFOX_API_KEY unset (the bind is the boundary)\n" +
+    "     • publishing wider        → also set CEREFOX_API_REQUIRE_KEY=1\n"
+  );
+}
 
 /** Is this the address of a connection that originated on this machine? */
 export function isLoopbackAddress(address: string | undefined): boolean {

--- a/packages/memory/src/web/server.ts
+++ b/packages/memory/src/web/server.ts
@@ -27,7 +27,7 @@
 import { serve } from "@hono/node-server";
 import { serveStatic } from "@hono/node-server/serve-static";
 
-import { apiAuth, isLoopbackAddress } from "./auth.ts";
+import { apiAuth, containerGateWarning, isLoopbackAddress } from "./auth.ts";
 import { existsSync } from "node:fs";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -241,6 +241,12 @@ export async function buildWebServer(
   // The gate allows an unconfigured server through (so upgrades never break a
   // working install), which makes silence here the dangerous default — say it
   // out loud at the moment the decision is made.
+  // The container misconfiguration that shipped in v1.12.0 and broke every
+  // Cerefox Local install. Checked before the bind warning because it is the
+  // more specific of the two.
+  const containerWarning = containerGateWarning();
+  if (containerWarning) console.warn(containerWarning);
+
   if (!isLoopbackAddress(host) && !(process.env.CEREFOX_API_KEY ?? "").trim()) {
     console.warn(
       `\n⚠  Binding ${host} with NO API key configured.\n` +

--- a/packages/memory/test/ingestion/pipeline-update.test.ts
+++ b/packages/memory/test/ingestion/pipeline-update.test.ts
@@ -230,7 +230,9 @@ describe("IngestionPipeline.updateDocument (live)", () => {
       .maybeSingle();
     expect(row?.content_hash).toBeTruthy();
     // The v1 hash != v2 hash assertion is implicit (we just snapshotted v1).
-  });
+    // Live: ingest, re-ingest with new content, embed both, snapshot a
+    // version. Several real round trips, well past bun's 5s default.
+  }, 60_000);
 
   test("collision with a different doc → throws ValueError-like", async () => {
     if (!pipeline || !supabase) return;

--- a/packages/memory/test/lifecycle-commands.test.ts
+++ b/packages/memory/test/lifecycle-commands.test.ts
@@ -386,12 +386,16 @@ describe("doctor / status (live)", () => {
     expect(names).toContain("binary");
     expect(names).toContain("supabase");
     expect(names).toContain("schema + RPCs");
-  });
+    // `doctor` runs every check: Supabase, OpenAI, schema RPC, embedder, content
+    // format, metadata health, and the Edge Function version aggregator. Many
+    // real round trips, routinely past bun's 5s default (#235).
+  }, 60_000);
 
   test("status --json returns a 3-element array", () => {
     const { stdout, status } = run(["status", "--json"]);
     expect(status).toBe(0);
     const parsed = JSON.parse(stdout) as unknown[];
     expect(parsed.length).toBe(3);
-  });
+    // Live: shells out to the CLI, which reaches the store (#235).
+  }, 60_000);
 });

--- a/packages/memory/test/web-auth.test.ts
+++ b/packages/memory/test/web-auth.test.ts
@@ -11,7 +11,13 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { decideAuth, isLoopbackAddress, API_KEY_PREFIX } from "../src/web/auth.ts";
+import {
+  API_KEY_PREFIX,
+  containerGateWarning,
+  decideAuth,
+  isContainerised,
+  isLoopbackAddress,
+} from "../src/web/auth.ts";
 
 const KEY = `${API_KEY_PREFIX}testkeytestkeytestkeytestkey`;
 const OTHER = `${API_KEY_PREFIX}differentdifferentdifferent`;
@@ -180,5 +186,46 @@ describe("forwarding headers are never trusted", () => {
     for (const forbidden of ["forwardedFor", "xForwardedFor", "trustProxy", "clientIp"]) {
       expect(accepted).not.toContain(forbidden);
     }
+  });
+});
+
+describe("containerGateWarning — the v1.12.0 container bug", () => {
+  /**
+   * v1.12.0 injected an API key into Cerefox Local unconditionally. Docker's
+   * port publishing NATs the source address, so every request from the host
+   * arrived looking like it came from the bridge gateway, the loopback
+   * exemption never matched, and EVERY caller got a 401 — the web UI included.
+   *
+   * The deeper lesson, and why the fix is "all-or-nothing in a container"
+   * rather than a tweak: inside a bridge-networked container the server cannot
+   * distinguish a host-loopback caller from a LAN one, because Docker NAT's
+   * both to the same address. The exemption is not implementable there.
+   *
+   * These tests pin the boot-time detection of that configuration. They pass
+   * `isContainerised` implicitly through the real filesystem, so the container
+   * branch only asserts the non-container cases here; the real container
+   * behaviour is verified by `docker/local/smoke-auth.sh` against a built
+   * image, which is the check that was missing.
+   */
+  test("says nothing when no key is configured", () => {
+    expect(containerGateWarning({} as NodeJS.ProcessEnv)).toBeNull();
+  });
+
+  test("says nothing when require-mode is on (the sound container config)", () => {
+    expect(
+      containerGateWarning({
+        CEREFOX_API_KEY: KEY,
+        CEREFOX_API_REQUIRE_KEY: "1",
+      } as NodeJS.ProcessEnv),
+    ).toBeNull();
+  });
+
+  test("says nothing outside a container, where the exemption works fine", () => {
+    // A key without require-mode is the NORMAL, correct config for a native
+    // `cerefox web`; warning about it there would be noise.
+    if (isContainerised()) return; // not applicable when the suite runs in one
+    expect(
+      containerGateWarning({ CEREFOX_API_KEY: KEY } as NodeJS.ProcessEnv),
+    ).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

**Hotfix for a release-day break in v1.12.0.** Cerefox Local was **completely inaccessible**: every request returned `401`, the web UI included. Anyone who upgraded to v1.12.0 needs this.

Found live on the maintainer's own instance, by a demo agent whose Playwright recording started failing. Not by the test suite.

## The bug

**Docker's port publishing rewrites the source address.** A request from the host to `127.0.0.1:<port>` reaches the server inside the container appearing to come from the bridge gateway, never from `127.0.0.1`. The v1.12.0 loopback exemption could therefore never match, for any caller.

The three requests that pin it:

| Request | v1.12.0 |
|---|---|
| Host → `127.0.0.1:8010/api/v1/version` | **401** |
| Inside the container → `127.0.0.1:8000/api/v1/version` | 200 |
| `/app/` page load (a static file, not gated) | 200 |

That last row is why it read as mysterious rather than obvious: the page loads, then every call it makes fails.

## Why this is a design correction, not just wiring

Inside a bridge-networked container the server **cannot** distinguish a host-loopback caller from one that crossed the network — Docker NATs both to the same address. **The loopback-exempt middle ground is not implementable there**, and v1.12.0 was pretending otherwise.

So the container gate is now all-or-nothing, and *which* is decided on the **host**, the only place that knows the publish address at `docker run` time:

| Publish address | Gate |
|---|---|
| `127.0.0.1` (the default) | **Off** — the bind is the boundary, exactly as pre-1.12.0 |
| Anything wider | **On for every caller**, browser included |

`cerefox-local` derives this from `CEREFOX_LOCAL_BIND`; an explicit `CEREFOX_API_REQUIRE_KEY=1` still forces it on. The key is minted and persisted either way, so turning the gate on later never changes the value clients were already given.

## Why the tests missed it

**The mechanism was right; the packaging was wrong.** 17 unit tests, 8 HTTP-boundary tests, and a verification against a real non-loopback LAN connection all passed — every one of them against `cerefox web` running **natively on the host**. The auth gate was never once executed inside a container, the single deployment where the address it depends on is rewritten before it arrives.

## Guards, so this cannot recur

- **`docker/local/smoke-auth.sh`** — builds the real image, publishes a real port, makes real requests from the host. There is no other way to test this. It asserts the default publish is ungated (the exact regression), that require-mode gates everyone, that a wrong key is refused, and that the key survives a container recreate.

  **Verified to actually catch the bug**: I reverted the fix in `db-init`, rebuilt the image, and the test reproduced `SMOKE-AUTH FAIL: host request got 401, expected 200`.

- **A boot warning.** `cerefox web` now says so loudly when a key is configured inside a container without require-mode — precisely the broken configuration — instead of silently 401ing everything.

## Also here

Two more live tests given realistic budgets (`pipeline-update`, `doctor --json`), same flake class as the `ingest-dir` fix in v1.12.0: real network round trips inheriting bun's 5-second default. The systematic version is filed as **#235** (~130 live tests across 16 files). Recorded there and worth knowing: **`bunfig.toml`'s `[test] timeout` is not honored by bun 1.3.13** — I tried it, watched a test still time out at exactly 5000ms, and removed the file rather than leave one that looks like it works.

## Docs

`securing-local-access.md` was **wrong** as shipped — it described the loopback rule as applying inside containers. It now splits by how Cerefox itself runs, explains why the container case has no middle setting, and carries a note pointing v1.12.0 users at the upgrade. The container recipe now sets `CEREFOX_API_REQUIRE_KEY=1`, without which the injected key does nothing but break things.

## Test plan

- [x] **`docker/local/smoke-auth.sh` against a freshly built image: PASS** (both cases, 7 assertions)
- [x] **Same script against a deliberately reverted fix: FAILS with the v1.12.0 symptom** — the test earns its place
- [x] `_shared`: 594 pass, 0 fail
- [x] `packages/memory` against **staging**: 297 pass, 2 skip, 0 fail
- [x] `bun run typecheck` (all three projects)
- [x] The maintainer's live instance restored and confirmed working (version, search, dashboard, app page all 200)
- [x] No schema change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013PcVjtEzsfTtAxeayzga5u
