### PR TITLE
Stop warning that a correctly configured container is dangerous (#237)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
+### Fixed
+
+- **Cerefox Local no longer warns, on every boot, that it is dangerously
+  configured when it is not (#237).** The "Binding 0.0.0.0 with NO API key
+  configured" warning was written for `cerefox web` on a host, where that is
+  genuinely an open API on the network. A container **must** bind `0.0.0.0`
+  internally — its own loopback is not the host's, so a narrower bind would
+  make the published port unreachable — and the boundary that matters is the
+  *publish* address, which the process inside cannot see. So it fired on every
+  normal boot, described a correct setup in alarming terms, and recommended a
+  command that does not apply there. Suppressed inside containers, for the same
+  reason the loopback exemption is: in there, the server is not in a position
+  to judge. A false alarm on every boot trains people to ignore real ones.
+  `containerGateWarning()` still covers the container configuration that IS
+  broken.
+- **`cerefox-local api-key` says what is actually protecting the port.** The
+  previous wording ("The gate is OFF — … the bind is the boundary") was read by
+  a maintainer as "we still block non-local callers, just without requiring a
+  key", which is the opposite of the truth: with the gate off Cerefox checks
+  nothing, and the protection is that Docker publishes the port on `127.0.0.1`
+  only, so a remote caller cannot open a connection at all. Now spelled out
+  rather than compressed, in both the command and
+  `docs/guides/securing-local-access.md`.
+
 Open roadmap.
 
 ---

--- a/docker/local/cerefox-local
+++ b/docker/local/cerefox-local
@@ -350,12 +350,25 @@ case "$cmd" in
         # Print the key, but never let someone believe it is being enforced
         # when it is not. On a loopback publish the gate is OFF by design (the
         # bind is the boundary) and this key is simply not in play.
+        # Say plainly which of the two states this is, and what is protecting
+        # the port in each. The v1.12.1 wording ("the gate is OFF … the bind is
+        # the boundary") was read as "we still block non-local callers, just
+        # without a key", which is the opposite of the truth — so it is spelled
+        # out here rather than compressed.
+        _bind="$(. "$ENV_FILE" 2>/dev/null; echo "${CEREFOX_LOCAL_BIND:-127.0.0.1}")"
         if docker exec "$CONTAINER" grep -q '^CEREFOX_API_KEY=' /run/cerefox-runtime.env 2>/dev/null; then
-          echo "ℹ The gate is ON: every caller must send this key." >&2
+          echo "ℹ REQUIRED. Every caller must send this key, including your browser." >&2
+          echo "  Authorization: Bearer <key>" >&2
         else
-          echo "ℹ The gate is OFF — this container publishes on loopback, so the bind is" >&2
-          echo "  the boundary and this key is not currently required by anything." >&2
-          echo "  It turns on automatically if you widen CEREFOX_LOCAL_BIND, or now with:" >&2
+          echo "ℹ NOT REQUIRED — Cerefox is not checking credentials at all." >&2
+          echo "  Any caller that can reach the port is served, key or no key." >&2
+          echo "  What protects it is the publish address: Docker binds this container" >&2
+          echo "  to $_bind:$(host_port) only, so nothing outside this machine can open a" >&2
+          echo "  connection in the first place." >&2
+          echo "  Set CEREFOX_LOCAL_BIND wider and the key becomes required for EVERY" >&2
+          echo "  caller — inside a container Cerefox cannot tell local callers from" >&2
+          echo "  remote ones (Docker rewrites the source address), so it is all or" >&2
+          echo "  nothing. To require it now, without widening the bind:" >&2
           echo "    echo CEREFOX_API_REQUIRE_KEY=1 >> $ENV_FILE && cerefox-local restart" >&2
         fi
         ;;

--- a/docs/guides/securing-local-access.md
+++ b/docs/guides/securing-local-access.md
@@ -26,10 +26,17 @@ Introduced in **v1.12.0** ([#229](https://github.com/fstamatelopoulos/cerefox/is
 
 ### If you run Cerefox Local (Docker)
 
-| Your publish address | Gate | You do |
-|---|---|---|
-| `127.0.0.1` (the default) | **Off** | Nothing. Every caller that can reach the published port is allowed, and the port is only reachable from this machine. |
-| Anything wider (`CEREFOX_LOCAL_BIND=0.0.0.0`) | **On, for everyone** | Give the key to every client, including your own browser. |
+| Your publish address | Cerefox checks credentials? | What protects the port | You do |
+|---|---|---|---|
+| `127.0.0.1` (the default) | **No** | **Docker.** The port is bound to this machine's loopback only, so nothing outside it can open a connection at all. | Nothing |
+| Anything wider (`CEREFOX_LOCAL_BIND=0.0.0.0`) | **Yes, for every caller** | The key | Give the key to every client, including your own browser |
+
+**Read the middle column carefully.** On a default install Cerefox is *not*
+refusing remote callers — it never sees them. Docker declines the connection at
+the socket, before Cerefox is involved. "No key required" and "protected" are
+both true at the same time, for different reasons, and it is worth knowing
+which is doing the work: widen the publish address and the first protection
+disappears instantly, which is why the key turns on in the same move.
 
 There is no middle setting here, and that is deliberate rather than a
 limitation we forgot to lift. **Docker rewrites the source address of every

--- a/docs/plans/iteration-43-warning-clarity.md
+++ b/docs/plans/iteration-43-warning-clarity.md
@@ -1,0 +1,88 @@
+# Iteration 43 — say the true thing (v1.12.2)
+
+**Status: COMPLETE** (2026-09-03). Branch: `fix/v1.12.2-container-warnings`.
+Target: **v1.12.2**. Docker image only — no npm publish needed (see below).
+
+Closes [#237](https://github.com/fstamatelopoulos/cerefox/issues/237).
+
+Two messages introduced by v1.12.0/v1.12.1 that were **false or misread**. No
+behaviour changes; both releases behave correctly. What was wrong is what
+Cerefox *said* about itself.
+
+## 1. A false alarm on every boot (#237)
+
+Every Cerefox Local boot printed:
+
+```
+⚠  Binding 0.0.0.0 with NO API key configured.
+   Every read, write, delete and purge on this server is reachable by
+   anything that can connect to port 8000, with no credential.
+```
+
+Written for `cerefox web` on a host, where binding `0.0.0.0` really does expose
+an unauthenticated API. A container is different in exactly the way v1.12.1
+already established: it **must** bind `0.0.0.0` internally (its own loopback is
+not the host's, so a narrower bind makes the published port unreachable), and
+the boundary that matters is the **publish** address, which the process inside
+cannot see.
+
+So it described a correct, safe configuration in alarming terms, on every
+single boot, and recommended `cerefox api-key generate` — the wrong command for
+a container, and one that without `CEREFOX_API_REQUIRE_KEY=1` reproduces the
+v1.12.0 outage.
+
+Suppressed inside containers, for the same reason the loopback exemption is:
+**in there the server is not in a position to judge.** `containerGateWarning()`
+still fires on the container configuration that IS broken.
+
+The cost of leaving it was not the noise. It was that a false alarm on every
+boot teaches people to ignore Cerefox warnings, and there is a real one two
+lines away.
+
+## 2. A message that said the opposite of what it meant
+
+`cerefox-local api-key` printed:
+
+> The gate is OFF — this container publishes on loopback, so the bind is the
+> boundary and this key is not currently required by anything.
+
+The maintainer read that as *"we still block non-local callers, we just don't
+require a key from them"*. That is the **opposite** of the truth: with the gate
+off Cerefox checks nothing at all, and every caller that reaches the port is
+served. The protection is that Docker publishes on `127.0.0.1` only, so a
+remote caller cannot open a connection in the first place — it fails at TCP,
+before Cerefox is involved.
+
+Both facts are true simultaneously ("no key required" and "protected"), for
+different reasons, and compressing them into one clause lost the reason. The
+message now states plainly that Cerefox is not checking credentials, what *is*
+protecting the port, and that widening the bind removes that protection — which
+is why the key turns on in the same move.
+
+`docs/guides/securing-local-access.md` gained a "what protects the port" column
+and a paragraph on the same point.
+
+**Recorded because the lesson generalises**: the maintainer is the person most
+familiar with this system, and the wording still misled him. A security message
+that is technically accurate but reads as its own opposite is a bug, and the
+misreading is the evidence.
+
+## Why the Docker image only
+
+The code change is in `packages/memory/src/web/server.ts`, which ships in both
+artifacts — but the only people it affects are those running `cerefox web`
+**inside a container**, who get it via the image. A native npm install is
+unaffected either way: for them the warning is correct and still fires.
+
+Consequence to be aware of: `cerefox --version` (npm) reports 1.12.1 while
+`cerefox-local` reports 1.12.2. Acceptable for a message-only fix; if the skew
+is ever unwelcome, publishing npm too is harmless.
+
+## Verification
+
+- `docker/local/smoke-auth.sh` against a freshly built image: **PASS** (both
+  cases, 7 assertions).
+- A real container booted from that image: the false warning is **absent** from
+  the logs, and the legitimate `[db-init] API key gate off …` line is still
+  present. Checked in the logs of a running container rather than reasoned
+  about — the v1.12.1 lesson.

--- a/packages/memory/src/web/server.ts
+++ b/packages/memory/src/web/server.ts
@@ -27,7 +27,12 @@
 import { serve } from "@hono/node-server";
 import { serveStatic } from "@hono/node-server/serve-static";
 
-import { apiAuth, containerGateWarning, isLoopbackAddress } from "./auth.ts";
+import {
+  apiAuth,
+  containerGateWarning,
+  isContainerised,
+  isLoopbackAddress,
+} from "./auth.ts";
 import { existsSync } from "node:fs";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -247,7 +252,20 @@ export async function buildWebServer(
   const containerWarning = containerGateWarning();
   if (containerWarning) console.warn(containerWarning);
 
-  if (!isLoopbackAddress(host) && !(process.env.CEREFOX_API_KEY ?? "").trim()) {
+  // Deliberately NOT warned inside a container (#237). A container must bind
+  // 0.0.0.0 internally — its own loopback is not the host's, so a narrower
+  // bind would make the published port unreachable. The boundary that actually
+  // matters is the PUBLISH address (`-p 127.0.0.1:8010:8000`), which this
+  // process cannot see. Warning here fired on every normal Cerefox Local boot,
+  // describing a correct and safe setup in alarming terms and recommending a
+  // command that does not apply there. A false alarm on every boot trains
+  // people to ignore real ones. `containerGateWarning()` above still covers
+  // the container configuration that IS broken.
+  if (
+    !isContainerised() &&
+    !isLoopbackAddress(host) &&
+    !(process.env.CEREFOX_API_KEY ?? "").trim()
+  ) {
     console.warn(
       `\n⚠  Binding ${host} with NO API key configured.\n` +
         `   Every read, write, delete and purge on this server is reachable by\n` +


### PR DESCRIPTION
## Summary

Two messages introduced by v1.12.0/v1.12.1 that were **false or misread**. **No behaviour changes** — both releases gate correctly. What was wrong is what Cerefox *said* about itself.

Closes #237

## 1. A false alarm on every boot

Every Cerefox Local boot printed:

```
⚠  Binding 0.0.0.0 with NO API key configured.
   Every read, write, delete and purge on this server is reachable by
   anything that can connect to port 8000, with no credential.
```

That warning was written for `cerefox web` on a host, where binding `0.0.0.0` really does expose an unauthenticated API to the network. A container is different in exactly the way v1.12.1 already established: it **must** bind `0.0.0.0` internally, because its own loopback is not the host's and a narrower bind would make the published port unreachable. The boundary that matters is the **publish** address, which the process inside cannot see.

So it described a correct, safe configuration in alarming terms, on every single boot, and recommended `cerefox api-key generate` — the wrong command for a container, and one that without `CEREFOX_API_REQUIRE_KEY=1` reproduces the v1.12.0 outage.

Now suppressed inside containers, for the same reason the loopback exemption is: in there, the server is not in a position to judge. `containerGateWarning()` still fires on the container configuration that genuinely IS broken.

The cost of leaving it was not the noise. A false alarm on every boot teaches people to ignore Cerefox warnings, and there is a real one two lines away.

## 2. A message that read as its own opposite

`cerefox-local api-key` printed:

> The gate is OFF — this container publishes on loopback, so the bind is the boundary and this key is not currently required by anything.

The maintainer read this as *"we still block non-local callers, we just don't require a key from them"*. That is the **opposite** of the truth: with the gate off Cerefox checks nothing at all, and any caller reaching the port is served. The protection is that Docker publishes on `127.0.0.1` only, so a remote caller cannot open a connection in the first place — it fails at TCP, before Cerefox is involved.

Both things are true at once ("no key required" and "protected"), for different reasons, and compressing them into one clause lost the reason. It now says plainly that Cerefox is not checking credentials, what *is* protecting the port, and that widening the bind removes that protection — which is why the key turns on in the same move.

`docs/guides/securing-local-access.md` gained a "what protects the port" column and a paragraph on the same distinction.

**Worth recording**: the person who misread it is the one most familiar with this system. A security message that is technically accurate but reads as its own opposite is a bug, and the misreading is the evidence.

## Docker image only

The code change is in `packages/memory/src/web/server.ts`, which ships in both artifacts, but the only people affected are those running `cerefox web` **inside a container** — who get it via the image. A native npm install is unaffected: for them the warning is correct and still fires.

Consequence to be aware of: `cerefox --version` will report 1.12.1 while `cerefox-local` reports 1.12.2. Acceptable for a message-only fix; publishing npm too is harmless if the skew is unwelcome.

## Test plan

- [x] `docker/local/smoke-auth.sh` against a freshly built image: **PASS** (both cases, 7 assertions)
- [x] **A real container booted from that image**: the false warning is **absent** from the logs, and the legitimate `[db-init] API key gate off …` line is still present. Checked in a running container's logs rather than reasoned about — the v1.12.1 lesson
- [x] `bun run typecheck` (all three projects)
- [x] `web-auth` unit tests: 20 pass
- [x] No behaviour change, no schema change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013PcVjtEzsfTtAxeayzga5u