### PR TITLE
Trash page states the exact total; Empty trash says the real number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,17 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
-Open roadmap.
+### Fixed
+
+- **The Trash page now says how many documents are in the trash** (#249).
+  With 569 trashed documents it showed 50 (its selector's default) and
+  nothing said more existed, so Empty trash's "500 or more" read as a bug.
+  `GET /api/v1/documents/trash` now returns the exact total in an
+  `X-Total-Count` header; the page drops the 50/100/200/500 selector, always
+  lists the 500 most recently deleted, and says "Showing the 500 most
+  recently deleted of 569" when capped; the Empty-trash confirmation states
+  the exact number and its progress total starts there instead of growing
+  pass by pass. No schema change.
 
 ---
 

--- a/docs/e2e-use-cases.md
+++ b/docs/e2e-use-cases.md
@@ -126,7 +126,7 @@ frontend built (`cd frontend && bun run build`). Tests target the React SPA at
 | `Dashboard recent docs` | `project selector scopes the tile and refetches` | Recent-docs tile scoped by project via server refetch (`/dashboard/recent-docs?project_id=`), "All projects" default | Done — verified on staging (v1.7.1, 2026-08-14) |
 | `Dashboard recent docs` | `the misleading View all link is gone` | "View all" (which just opened search) removed from the recent-docs tile | Done — verified on staging (v1.7.1, 2026-08-14) |
 | `TestAuditLog` | `test_audit_log_page_loads` | Audit log page renders with heading | Done |
-| `Trash` | `Empty trash asks first, purges one by one, and leaves the trash empty` | Three API-trashed docs; button → confirmation (count) → done summary; trash empty, each doc 404 (#247, v1.14.0). Empties the whole staging trash, so it is opt-in (`CEREFOX_E2E_EMPTY_TRASH=1`) and skips if the trash holds anything not `[E2E`-prefixed; fixtures purged in `finally` | Done (opt-in) |
+| `Trash` | `Empty trash asks first, purges one by one, and leaves the trash empty` | Three API-trashed docs; button → confirmation (exact count, #249) → done summary; trash empty, each doc 404 (#247, v1.14.0). Empties the whole staging trash, so it is opt-in (`CEREFOX_E2E_EMPTY_TRASH=1`) and skips if the trash holds anything not `[E2E`-prefixed; fixtures purged in `finally` | Done (opt-in) |
 | `Trash` | `Cancel in the confirmation purges nothing` | Cancel leaves the trashed doc in place | Done |
 
 The loop behind "Empty trash" (`frontend/src/lib/emptyTrash.ts`: confirmed set with a

--- a/docs/guides/api.md
+++ b/docs/guides/api.md
@@ -171,7 +171,7 @@ default; Cerefox Local picks its own port and `cerefox-local status` prints it).
 | `GET /documents/{id}/chunks` | The document's chunks. |
 | `GET /documents/{id}/versions` | Version history. |
 | `GET /documents/{id}/download` | Raw markdown. |
-| `GET /documents/trash` | Soft-deleted documents. |
+| `GET /documents/trash` | Soft-deleted documents, newest first, `limit` ≤ 500. The exact total is in the `X-Total-Count` response header (v1.14.1). |
 | `POST /documents/metadata-search` | Query by metadata / project / time, no text query. |
 | `GET /metadata-keys` | Metadata keys with counts and example values. |
 | `GET /resolve-link`, `GET /check-filename` | Link and title resolution helpers. |

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -31,9 +31,9 @@
 **2026-09-05 — v1.14.1 IN PROGRESS** (branch `fix/trash-count`, #249): the
 Trash page states the exact total (`X-Total-Count` on the listing), drops the
 row-limit selector, and Empty trash says the real number. Found on Cerefox
-Local right after 1.14.0: 569 in the trash, the page showed 50. Also under
-discussion for 1.14.1: opt-in auto-purge of trash older than N days (design
-options in the iteration doc; not built yet).
+Local right after 1.14.0: 569 in the trash, the page showed 50. Opt-in auto-purge
+of trash older than N days is **backlogged** (#251): trigger on a document
+delete when built; options table in the iteration doc.
 
 **2026-09-05 — v1.14.0 SHIPPED** (PR #248, cut `8e91cc4`; verified on staging
 after the maintainer's deploy: package suite 307/2/0, live EF + remote MCP

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -28,7 +28,17 @@
 ---
 ## Current Focus
 
-**2026-09-05 — v1.14.0 IN PROGRESS** (branch `feat/empty-trash`, #247):
+**2026-09-05 — v1.14.1 IN PROGRESS** (branch `fix/trash-count`, #249): the
+Trash page states the exact total (`X-Total-Count` on the listing), drops the
+row-limit selector, and Empty trash says the real number. Found on Cerefox
+Local right after 1.14.0: 569 in the trash, the page showed 50. Also under
+discussion for 1.14.1: opt-in auto-purge of trash older than N days (design
+options in the iteration doc; not built yet).
+
+**2026-09-05 — v1.14.0 SHIPPED** (PR #248, cut `8e91cc4`; verified on staging
+after the maintainer's deploy: package suite 307/2/0, live EF + remote MCP
+48/0, Playwright 22/22 with the trash test opted in). What it was, as planned
+(#247):
 "Empty trash" in the web UI. Decision (maintainer): **no bulk-purge endpoint**;
 the browser loops over the existing per-document purge, one audited call each,
 behind a confirmation that states the count, with a progress bar and Stop.

--- a/docs/plans/iteration-45-empty-trash.md
+++ b/docs/plans/iteration-45-empty-trash.md
@@ -1,6 +1,18 @@
 # Iteration 45 — Empty trash (v1.14.0)
 
-**Status: IN PROGRESS (2026-09-05, branch `feat/empty-trash`, #247).**
+**Status: v1.14.0 SHIPPED 2026-09-05** (PR #248, cut `8e91cc4`; staging verified
+after the release deploy). **v1.14.1 in progress** (branch `fix/trash-count`, #249).
+
+**v1.14.1 (2026-09-05, #249).** Right after the upgrade the maintainer saw
+"Permanently delete 500 or more documents?" on a Local store they believed
+held 50. It held 569: the Trash page showed 50, its selector's default, and
+said nothing about the rest, so the modal (which could only count the 500
+rows it got) was right and the page was misleading. Fix: the listing returns
+the exact total in `X-Total-Count` (same exact-count query the dashboard
+uses; no schema change); the page drops the 50/100/200/500 selector, always
+shows the 500 most recently deleted and says "Showing the 500 most recently
+deleted of 569" when capped; the modal states the exact number and passes it
+to the loop as `totalHint` so the progress bar starts at the real total.
 
 ## Ask
 
@@ -63,3 +75,40 @@ adding a server endpoint that deletes everything.
   `cerefox server deploy` is not needed for it; `cerefox self-update` (and
   `cerefox-local upgrade`) picks up the new SPA bundle.
 - **#154** (Node baseline / commander 15) moves to the next minor again.
+
+## Under discussion for 1.14.1: auto-purge of trash older than N days
+
+**Ask (maintainer, 2026-09-05).** An opt-in setting, off by default, stored in
+`cerefox_config` and editable in Settings: permanently delete trash older than
+N days (default 30, editable). The difficulty: Cerefox has no scheduled or
+timed process. Version retention is lazy: `cerefox_ingest_document` prunes a
+document's own archived versions when that document is written, and never
+otherwise.
+
+**Constant across every option.** One RPC, `cerefox_purge_expired_trash(p_max)`:
+reads `trash_auto_purge_enabled` and `trash_retention_days` from config,
+purges up to `p_max` rows with `deleted_at < now() - retention` (oldest first),
+one audit entry per document (author `trash-retention`, description carries
+the deleted-at date and the retention in force), returns the ids purged. Not
+exposed on MCP or the Edge Functions (the "no agent path to purge" rule holds;
+the RPC is reachable only with the service key, like every other RPC). Two
+config keys in the catalog + `v_allowed` + seed rows + a migration, so a
+schema bump (0.17.0). The Settings confirmation for enabling it is the
+human-in-the-loop step, and it should say what happens next: "at the next
+sweep, every document trashed more than N days ago is purged."
+
+| Option | Who calls the RPC | For | Against |
+|---|---|---|---|
+| A. Sweep on view | The web server, before answering `GET /documents/trash` (and the dashboard), at most once per few minutes | No new process; runs exactly when someone is about to look at the trash | A GET that destroys data; only sweeps when someone looks, so a store nobody opens never sweeps |
+| B. Sweep on write | `cerefox_ingest_document`, like version pruning | Same shape as the existing lazy cleanup | Every agent write pays for it; an agent's write becomes the trigger for permanent deletion, which is the thing the access model keeps agents away from |
+| C. `pg_cron` | The database itself, hourly | A real schedule, independent of any client | Supabase has it (needs enabling per project); Cerefox Local would need the extension in the image and `shared_preload_libraries`; two environments to configure and document, and a third for anyone on plain Postgres |
+| D. Web-daemon timer | `cerefox web` (which Cerefox Local always runs): a sweep at startup and then hourly | Uses the one long-running process Cerefox already has; no extension; purge stays "executed by the web tier" | A Supabase-only user who never runs `cerefox web` never sweeps, and must be told so |
+| E. D + A | The daemon timer, plus a rate-limited sweep when the trash is listed | Covers both the always-on daemon and the occasional web visit; the listing sweep is a no-op when the timer keeps up | Two triggers to document; still nothing for a store with no daemon and no visits (acceptable: nothing to see, nothing at risk) |
+
+**Recommendation: E**, with `doctor` printing one line (`trash auto-purge: off`
+/ `on, 30 days, last sweep <time>`), the last-sweep time kept in
+`cerefox_config` by the RPC, and a `cerefox server sweep-trash` CLI verb for
+the Supabase-only case and for scripts. Batches of 100 per call so a first
+sweep over a large backlog cannot hold a request. The sweep-on-list trigger
+answers the listing AFTER the sweep, so the page never shows a row that is
+about to vanish. Not built; awaiting the maintainer's pick.

--- a/docs/plans/iteration-45-empty-trash.md
+++ b/docs/plans/iteration-45-empty-trash.md
@@ -111,4 +111,10 @@ sweep, every document trashed more than N days ago is purged."
 the Supabase-only case and for scripts. Batches of 100 per call so a first
 sweep over a large backlog cannot hold a request. The sweep-on-list trigger
 answers the listing AFTER the sweep, so the page never shows a row that is
-about to vanish. Not built; awaiting the maintainer's pick.
+about to vanish.
+
+**Decision (maintainer, 2026-09-05): backlog, and when built, trigger on a
+document delete** (#251). "The write that adds to the trash also sweeps it":
+not elegant, but predictable, simple to build and to document, and the same
+shape as version retention. Not scheduled; the use case is harnesses with
+several roles writing and deleting frequently.

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -86,6 +86,15 @@ export async function apiFetch<T>(
   path: string,
   options?: RequestInit,
 ): Promise<T> {
+  const response = await apiFetchResponse(path, options);
+  return response.json() as Promise<T>;
+}
+
+/** `apiFetch` without the JSON step, for callers that also need a header. */
+export async function apiFetchResponse(
+  path: string,
+  options?: RequestInit,
+): Promise<Response> {
   const url = `${BASE_URL}${path}`;
   const response = await fetch(url, {
     ...options,
@@ -104,7 +113,7 @@ export async function apiFetch<T>(
     throw new ApiError(response.status, response.statusText, body);
   }
 
-  return response.json() as Promise<T>;
+  return response;
 }
 
 /**

--- a/frontend/src/api/trash.ts
+++ b/frontend/src/api/trash.ts
@@ -1,4 +1,4 @@
-import { apiFetch } from "./client";
+import { apiFetch, apiFetchResponse } from "./client";
 
 export interface DeletedDocument {
   id: string;
@@ -14,8 +14,22 @@ export interface DeletedDocument {
   project_ids: string[];
 }
 
-export async function fetchTrash(limit = 50): Promise<DeletedDocument[]> {
-  return apiFetch<DeletedDocument[]>(`/documents/trash?limit=${limit}`);
+/** The server caps a trash listing at this many rows; `total` is exact regardless. */
+export const TRASH_LIST_CAP = 500;
+
+export interface TrashPage {
+  /** The `limit` most recently deleted documents. */
+  rows: DeletedDocument[];
+  /** How many documents are in the trash in total (`X-Total-Count`). */
+  total: number;
+}
+
+export async function fetchTrash(limit = TRASH_LIST_CAP): Promise<TrashPage> {
+  const resp = await apiFetchResponse(`/documents/trash?limit=${limit}`);
+  const rows = (await resp.json()) as DeletedDocument[];
+  const header = Number(resp.headers.get("X-Total-Count"));
+  // A server older than v1.14.1 sends no header: the page is all we know.
+  return { rows, total: Number.isFinite(header) && header >= rows.length ? header : rows.length };
 }
 
 export async function restoreDocument(documentId: string): Promise<void> {

--- a/frontend/src/components/EmptyTrashModal.tsx
+++ b/frontend/src/components/EmptyTrashModal.tsx
@@ -4,11 +4,8 @@ import { useQuery } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
 
 import { ApiError } from "../api/client";
-import { fetchTrash, purgeDocument } from "../api/trash";
+import { fetchTrash, purgeDocument, TRASH_LIST_CAP } from "../api/trash";
 import { emptyTrash, type EmptyTrashProgress, type EmptyTrashResult } from "../lib/emptyTrash";
-
-/** The server caps the trash listing at this many rows. */
-const LIST_CAP = 500;
 
 /**
  * One run per tab. The loop outlives a component that unmounts mid-run (it
@@ -48,19 +45,20 @@ export function EmptyTrashModal({ onClose, onFinished }: Props) {
   const [stopping, setStopping] = useState(false);
   const [refused, setRefused] = useState(false);
 
-  // What the user is confirming: the rows actually in the trash right now (the
-  // page may be showing a slice). These rows ARE the run's set; a document
-  // trashed after this listing is never touched.
+  // What the user is confirming: the trash as it is right now, exact total
+  // from the server and the (up to 500) most recently deleted rows. Those rows
+  // ARE the run's set; a document trashed after this listing is never touched,
+  // and anything beyond the 500 is reached by re-listing under their cutoff.
   const listing = useQuery({
     queryKey: ["trash", "count"],
-    queryFn: () => fetchTrash(LIST_CAP),
+    queryFn: () => fetchTrash(TRASH_LIST_CAP),
     enabled: phase.kind === "confirm",
     staleTime: 0,
     gcTime: 0,
     refetchOnWindowFocus: false,
   });
-  const rows = listing.data;
-  const count = rows?.length;
+  const rows = listing.data?.rows;
+  const count = listing.data?.total;
 
   const running = phase.kind === "running";
 
@@ -89,11 +87,12 @@ export function EmptyTrashModal({ onClose, onFinished }: Props) {
     try {
       const result = await emptyTrash({
         confirmed: rows,
-        listTrash: () => fetchTrash(LIST_CAP),
+        listTrash: async () => (await fetchTrash(TRASH_LIST_CAP)).rows,
         purge: purgeDocument,
         onProgress: (progress) => setPhase({ kind: "running", progress }),
         shouldStop: () => stopRef.current,
         isFatal,
+        totalHint: count,
       });
       setPhase({ kind: "done", result });
       onFinished(result);
@@ -101,8 +100,6 @@ export function EmptyTrashModal({ onClose, onFinished }: Props) {
       runInFlight = false;
     }
   };
-
-  const countLabel = (n: number) => (n >= LIST_CAP ? `${LIST_CAP} or more` : String(n));
 
   return (
     <Modal
@@ -132,7 +129,7 @@ export function EmptyTrashModal({ onClose, onFinished }: Props) {
             <>
               <Alert icon={<IconAlertTriangle size={16} />} color="red">
                 <Text size="sm">
-                  Permanently delete <strong>{countLabel(count)}</strong>{" "}
+                  Permanently delete <strong>{count}</strong>{" "}
                   {count === 1 ? "document" : "documents"}? This cannot be undone: their
                   content, chunks and version history are removed. Restore anything you still
                   want first.
@@ -155,7 +152,7 @@ export function EmptyTrashModal({ onClose, onFinished }: Props) {
             </Button>
             {count !== undefined && count > 0 && (
               <Button color="red" data-testid="empty-trash-start" onClick={() => void start()}>
-                Purge {countLabel(count)} {count === 1 ? "document" : "documents"}
+                Purge {plural(count, "document")}
               </Button>
             )}
           </Group>

--- a/frontend/src/lib/emptyTrash.test.ts
+++ b/frontend/src/lib/emptyTrash.test.ts
@@ -182,6 +182,16 @@ describe("emptyTrash", () => {
     expect(seen[0]!.failures).toEqual([]);
   });
 
+  test("totalHint makes progress report the full size from the first purge", async () => {
+    const ids = Array.from({ length: 5 }, (_, i) => `d${i}`);
+    const t = fakeTrash(ids, { cap: 2 });
+    const confirmed = await t.listTrash();
+    const totals: number[] = [];
+    await emptyTrash({ ...t.deps, confirmed, totalHint: 5, onProgress: (p) => totals.push(p.total) });
+    expect(totals[0]).toBe(5);
+    expect(new Set(totals)).toEqual(new Set([5]));
+  });
+
   test("an empty confirmed set is a no-op with no listing at all", async () => {
     const t = fakeTrash([]);
     expect(await emptyTrash({ ...t.deps, confirmed: [] })).toEqual({ purged: 0, ...NONE });

--- a/frontend/src/lib/emptyTrash.ts
+++ b/frontend/src/lib/emptyTrash.ts
@@ -74,6 +74,8 @@ export interface EmptyTrashDeps {
   shouldStop?: () => boolean;
   /** A purge error that means every further call would fail too (auth, outage). Aborts the run. */
   isFatal?: (err: unknown) => boolean;
+  /** The trash's exact size at confirmation, so progress reports it from the first purge. */
+  totalHint?: number;
 }
 
 const stamp = (d: TrashEntry) => Date.parse(d.deleted_at ?? "") || 0;
@@ -92,7 +94,7 @@ export async function emptyTrash(deps: EmptyTrashDeps): Promise<EmptyTrashResult
   const report = (current: string | null, remaining: number) =>
     deps.onProgress?.({
       done: attempted.size,
-      total: attempted.size + remaining,
+      total: Math.max(attempted.size + remaining, deps.totalHint ?? 0),
       current,
       purged,
       failures: [...failures],

--- a/frontend/src/pages/TrashPage.tsx
+++ b/frontend/src/pages/TrashPage.tsx
@@ -1,10 +1,9 @@
-import { Select } from "@mantine/core";
 import { IconArrowBackUp, IconTrash, IconTrashX } from "@tabler/icons-react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
-import { fetchTrash, purgeDocument, restoreDocument, type DeletedDocument } from "../api/trash";
+import { fetchTrash, purgeDocument, restoreDocument, TRASH_LIST_CAP, type DeletedDocument } from "../api/trash";
 import { CliCard } from "../components/CliCard";
 import { EmptyTrashModal } from "../components/EmptyTrashModal";
 import { ListPage, type ListColumn } from "../components/ListPage";
@@ -26,16 +25,20 @@ export function TrashPage() {
   const { data: projects } = useProjects();
   const projectMap = new Map(projects?.map((p) => [p.id, p.name]) ?? []);
 
-  const [limit, setLimit] = useState("50");
   const [query, setQuery] = useState("");
   const [confirmId, setConfirmId] = useState<string | null>(null);
   const [emptyOpen, setEmptyOpen] = useState(false);
 
-  const { data: docs, isLoading } = useQuery({
-    queryKey: ["trash", limit],
-    queryFn: () => fetchTrash(Number(limit)),
+  // Always the 500 most recently deleted (the server's cap) plus the exact
+  // total, so the page can say when there is more than it shows (#249). The
+  // 50/100/200/500 selector that used to sit here made 569 look like 50.
+  const { data: page, isLoading } = useQuery({
+    queryKey: ["trash", "page"],
+    queryFn: () => fetchTrash(TRASH_LIST_CAP),
     staleTime: 10_000,
   });
+  const docs = page?.rows;
+  const total = page?.total ?? 0;
 
   const invalidate = () => invalidateDocumentViews(queryClient);
   const restoreMut = useMutation({
@@ -147,14 +150,11 @@ export function TrashPage() {
       searchText={(d) => d.title}
       toolbarExtra={
         <>
-          <Select
-            data={["50", "100", "200", "500"]}
-            value={limit}
-            onChange={(v) => setLimit(v || "50")}
-            size="sm"
-            w={110}
-            aria-label="Max rows"
-          />
+          {docs && total > docs.length && (
+            <span className={ui.faint} style={{ fontSize: 12 }} data-testid="trash-count">
+              Showing the {docs.length} most recently deleted of {total}
+            </span>
+          )}
           <button
             type="button"
             className={`${ui.btn} ${ui.btnGhost} ${ui.btnDanger}`}

--- a/frontend/tests/e2e/ui.spec.ts
+++ b/frontend/tests/e2e/ui.spec.ts
@@ -429,7 +429,8 @@ test.describe("Trash", () => {
     // Confirmation first: nothing is purged until the red button is clicked.
     const start = page.getByTestId("empty-trash-start");
     await expect(start).toBeVisible();
-    await expect(page.getByTestId("empty-trash-confirm")).toContainText(/Permanently delete/);
+    // The exact number (#249): the non-fixture guard above means exactly ours.
+    await expect(page.getByTestId("empty-trash-confirm")).toContainText("Permanently delete 3 documents");
     expect(((await (await request.get("/api/v1/documents/trash")).json()) as unknown[]).length).toBeGreaterThanOrEqual(3);
 
     await start.click();

--- a/packages/memory/src/web/routes/discovery.ts
+++ b/packages/memory/src/web/routes/discovery.ts
@@ -736,16 +736,27 @@ export function registerDiscoveryRoutes(app: Hono, ctx: WebContext): void {
       Math.max(Number.parseInt(c.req.query("limit") ?? "50", 10) || 50, 1),
       500,
     );
-    const { data, error } = await ctx.supabase
-      .from("cerefox_documents")
-      .select(
-        "id, title, source, chunk_count, total_chars, review_status, deleted_at, updated_at",
-      )
-      .not("deleted_at", "is", null)
-      .order("deleted_at", { ascending: false })
-      .limit(limit);
+    // The listing is capped at 500 rows; the exact total travels in a header
+    // so the Trash page can say "showing 500 of 569" and Empty trash can
+    // state the real number (#249). Same exact-count query the dashboard uses.
+    const [listed, counted] = await Promise.all([
+      ctx.supabase
+        .from("cerefox_documents")
+        .select(
+          "id, title, source, chunk_count, total_chars, review_status, deleted_at, updated_at",
+        )
+        .not("deleted_at", "is", null)
+        .order("deleted_at", { ascending: false })
+        .limit(limit),
+      ctx.supabase
+        .from("cerefox_documents")
+        .select("id", { count: "exact", head: true })
+        .not("deleted_at", "is", null),
+    ]);
+    const { data, error } = listed;
     if (error) return c.json({ detail: error.message }, 500);
     const docs = (data ?? []) as Array<Record<string, unknown>>;
+    c.header("X-Total-Count", String(counted.count ?? docs.length));
     if (docs.length === 0) return c.json([]);
     const [projects, showReview] = await Promise.all([
       listAllProjects(ctx),

--- a/packages/memory/test/web-integration/destructive.test.ts
+++ b/packages/memory/test/web-integration/destructive.test.ts
@@ -216,11 +216,14 @@ describe("destructive web endpoints (HTTP boundary)", () => {
     const getResp = await fetch(`${server.base}/api/v1/documents/${docId}`);
     expect(getResp.status).toBe(404);
 
-    // Trash should not include it.
-    const trashed = (await (
-      await fetch(`${server.base}/api/v1/documents/trash?limit=20`)
-    ).json()) as Array<{ id: string }>;
+    // Trash should not include it, and the listing carries the exact total
+    // (#249): a number, never below the rows returned.
+    const trashResp = await fetch(`${server.base}/api/v1/documents/trash?limit=20`);
+    const trashed = (await trashResp.json()) as Array<{ id: string }>;
     expect(trashed.some((d) => d.id === docId)).toBe(false);
+    const totalHeader = Number(trashResp.headers.get("x-total-count"));
+    expect(Number.isInteger(totalHeader)).toBe(true);
+    expect(totalHeader).toBeGreaterThanOrEqual(trashed.length);
 
     // Clear the cleanup target so afterAll doesn't double-purge.
     docId = null;


### PR DESCRIPTION
Closes #249. Target: v1.14.1.

## Summary

- `GET /api/v1/documents/trash` returns the exact total in an `X-Total-Count` header, from the same exact-count query the dashboard uses. No new endpoint, no schema change.
- The Trash page drops the 50/100/200/500 selector (it made 569 look like 50), always lists the 500 most recently deleted, and says "Showing the 500 most recently deleted of N" when capped.
- The Empty-trash confirmation states the exact number ("Permanently delete 569 documents?"), and the progress total starts there instead of growing pass by pass (`totalHint` on the loop).
- `apiFetchResponse` added to the API client for callers that need a header; `apiFetch` now wraps it.
- Docs: `api.md`, CHANGELOG `[Unreleased]`, plan, iteration 45 (which also records the design options for the trash auto-purge under discussion, not built).

## Test plan

- [x] `bun run typecheck`; frontend lint clean; frontend unit 20/20 (new: `totalHint`)
- [x] Against staging: `destructive` + `review-workflow` web suites 8/8 (the destructive one asserts the header); Playwright 22/22 with the trash test opted in (it now asserts "Permanently delete 3 documents")

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013PcVjtEzsfTtAxeayzga5u