### PR TITLE
Serve the SPA fresh after an upgrade, and name the browser tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,9 +31,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
   the tab, a search shows its query, the edit page marks unsaved changes with
   a leading dot, and every other page carries its own name. The app name is
   not repeated in front, because tabs truncate from the right and a shared
-  prefix makes every tab look alike. When the server reports an environment
-  label the tab is prefixed with it, so a staging tab is distinguishable from
-  production at a glance.
+  prefix makes every tab look alike.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,31 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
-Open roadmap.
+### Fixed
+
+- **A running web server no longer serves a stale app after an in-place
+  upgrade** (#252). `cerefox self-update` replaces the package while the
+  daemon keeps running, and the daemon had read `index.html` once at startup
+  for client-side routes while serving the root from disk. After an upgrade it
+  therefore handed the browser the new shell at `/app/` and the pre-upgrade
+  shell on every deep route, pointing it at a hashed bundle the upgrade had
+  deleted. That bundle then fell through to the SPA catch-all and came back as
+  `200 text/html`, so the browser received HTML where it asked for a script and
+  rendered a blank page, with a 200 in the access log. Now: `index.html` is
+  read per request (cached on mtime), a missing `/app/assets/*` is a real
+  `404`, `self-update` says when a daemon is still running the previous build
+  and prints the restart command, and both `cerefox web status` and `doctor`
+  compare the running server's version with the client's.
+
+### Added
+
+- **The browser tab says what you are looking at** (#253). A document names
+  the tab, a search shows its query, the edit page marks unsaved changes with
+  a leading dot, and every other page carries its own name. The app name is
+  not repeated in front, because tabs truncate from the right and a shared
+  prefix makes every tab look alike. When the server reports an environment
+  label the tab is prefixed with it, so a staging tab is distinguishable from
+  production at a glance.
 
 ---
 

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -34,8 +34,7 @@ stale-SPA bug found on production after `self-update`: `index.html` is now read
 per request (mtime-cached), a missing `/app/assets/*` is a 404 instead of the
 shell with a `200 text/html`, `self-update` warns when a daemon is still on the
 previous build, and `web status` + `doctor` compare the running server's
-version with the client's. (b) Per-page browser tab titles, environment label
-prefixed when the server reports one. Frontend + web server only: no schema, no
+version with the client's. (b) Per-page browser tab titles. Frontend + web server only: no schema, no
 Edge Function, no `minSchema` change. Also filed while investigating: **#254**,
 `cerefox_search` reports "No results found." when the top hit exceeds
 `max_bytes` — a false negative agents act on, not in this branch.

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -28,6 +28,18 @@
 ---
 ## Current Focus
 
+**2026-09-08 — v1.14.2 IN PROGRESS** (branch
+`fix/spa-stale-index-and-tab-titles`, #252 + #253). Two web-app items. (a) The
+stale-SPA bug found on production after `self-update`: `index.html` is now read
+per request (mtime-cached), a missing `/app/assets/*` is a 404 instead of the
+shell with a `200 text/html`, `self-update` warns when a daemon is still on the
+previous build, and `web status` + `doctor` compare the running server's
+version with the client's. (b) Per-page browser tab titles, environment label
+prefixed when the server reports one. Frontend + web server only: no schema, no
+Edge Function, no `minSchema` change. Also filed while investigating: **#254**,
+`cerefox_search` reports "No results found." when the top hit exceeds
+`max_bytes` — a false negative agents act on, not in this branch.
+
 **2026-09-05 — v1.14.1 SHIPPED** (PR #250, cut `6c879fe`; staging verified
 after the maintainer's deploy: `_shared` 610, package suite 307/2/0, live EF +
 remote MCP 48/0, Playwright 22/22 with the trash test opted in; Local

--- a/docs/plans/iteration-46-spa-serving-and-tab-titles.md
+++ b/docs/plans/iteration-46-spa-serving-and-tab-titles.md
@@ -1,0 +1,88 @@
+# Iteration 46 — the SPA after an upgrade, and what the tab says (v1.14.2)
+
+**Status: IN PROGRESS (2026-09-08, branch `fix/spa-stale-index-and-tab-titles`).**
+Closes [#252](https://github.com/fstamatelopoulos/cerefox/issues/252) and
+[#253](https://github.com/fstamatelopoulos/cerefox/issues/253).
+
+## #252 — a blank page after `self-update`
+
+**What happened.** The maintainer's production client was upgraded to 1.14.1
+while their `cerefox web` daemon (1.13.1, started hours earlier) kept running.
+Refreshing a deep route showed a blank page; the root loaded fine.
+
+**Why, exactly.** Two independent defects, both invisible in the access log:
+
+1. `server.ts` read `index.html` **once at startup** for the SPA catch-all,
+   while `/app/` itself was answered by `serveStatic` from disk. An in-place
+   upgrade therefore split the two: the root served the new shell, every deep
+   route the pre-upgrade one, which referenced a hashed bundle the upgrade had
+   deleted.
+2. A missing `/app/assets/*` fell through to that catch-all and was answered
+   `200 text/html`. A script tag that receives HTML executes nothing.
+
+**Confirmed from the maintainer's own `web.log`**: at 18:11 and 18:13 a deep
+route (`/app/projects/<uuid>/documents`) requested `index-InRztcXr.js` → `200`
+(the deleted bundle, answered with HTML); at 18:15 `/app/` requested
+`index-BC_iqEHZ.js` → `200` (the real one) and worked; at 18:16 `/app/trash`
+went back to the stale bundle. A restart at 19:03 fixed it.
+
+**Fix.** `index.html` read per request, cached on mtime, so an upgrade is
+picked up without a restart and the root and deep routes can never disagree.
+`/app/assets/*` misses return `404 text/plain`. `self-update` reads the pidfile
+and prints the restart command when a daemon is running. `statusDaemon()` now
+reports the running server's version, which `cerefox web status` and a new
+`doctor` row ("web server") compare against `PKG_VERSION`.
+
+## #253 — browser tab titles
+
+The tab said `Cerefox` on every page. Now each page sets its own, through
+`usePageTitle()` (one call per page) over a pure `pageTitle()`.
+
+| Route | Title |
+|---|---|
+| Dashboard | `Cerefox` |
+| Document | the document's title |
+| Edit | `Editing: <title>`, with a leading `•` while unsaved |
+| Search | `Search: <query>` |
+| Project documents | the project's name |
+| Help | `Help: <doc title>` |
+| the rest | the page's own name |
+
+**Decisions.** The app name is *not* prefixed: tabs truncate from the right, so
+`Cerefox: <x>` would make every tab look alike, and the favicon already
+identifies the app. The one thing allowed to push the title right is the
+**environment label** (`[staging] Trash`), because someone with production,
+staging and a local container open needs to see which tab they are about to act
+in; production and Cerefox Local report no label and stay clean. Titles are
+truncated at 60 characters.
+
+## Tests
+
+- `packages/memory/test/web-integration/spa-serving.test.ts` (new, 5 cases):
+  root and deep route serve the same shell; a rewritten `index.html` is picked
+  up with no restart; a missing asset is a 404 and not HTML; a real asset still
+  has a JavaScript content type; a client-side route still gets the shell.
+- `cli-web-daemon.test.ts`: `web status` flags a daemon reporting a different
+  version, driven by a stub server. **It must spawn the child asynchronously**:
+  `spawnSync` blocks bun's event loop, so an in-process stub cannot answer the
+  probe and the daemon reads as "alive but not responding".
+- `frontend/src/lib/pageTitle.test.ts` (7 cases) via `bun test src/`.
+- Playwright: static page titles, the dashboard, a search query, a document's
+  own title, and the environment prefix.
+
+## Verification (staging, 2026-09-08)
+
+- `bun run typecheck` clean; frontend lint clean; `_shared` 610 pass.
+- Package suite against staging: **313 pass / 2 skip / 0 fail**.
+- Playwright: tab-title specs pass; full run below.
+- `doctor` shows the new row: `✓ web server  v1.14.1 on :8030 (pid …)`.
+
+## Release notes for the cut
+
+- Frontend + web server only. No schema, no Edge Function, no `minSchema`
+  change: `cerefox self-update` (and `cerefox-local upgrade`) is the whole
+  upgrade, and **the daemon must be restarted**, which this release is the
+  first to say out loud.
+- **#154** (Node baseline) moves again, same reasoning as the last four times.
+- Filed but not fixed here: **#254** (`cerefox_search` reports "No results
+  found." when the top hit exceeds `max_bytes`).

--- a/docs/plans/iteration-46-spa-serving-and-tab-titles.md
+++ b/docs/plans/iteration-46-spa-serving-and-tab-titles.md
@@ -70,6 +70,30 @@ truncated at 60 characters.
 - Playwright: static page titles, the dashboard, a search query, a document's
   own title, and the environment prefix.
 
+## Review follow-ups (all applied)
+
+- **The restart remedy carried no host or port.** `cerefox web start` defaults
+  to 127.0.0.1:8000, so the printed command would have MOVED any daemon bound
+  elsewhere — the maintainer's staging daemon listens on :8030, and following
+  the advice would have replaced a blank page with a connection refused. One
+  `restartCommand(host, port)` in `daemon.ts` now serves all three call sites.
+- **An unreadable `index.html` answered `200` with an empty body**, which is
+  the same lie as the wrong-typed 200 this iteration exists to remove. It is a
+  503 with a sentence.
+- **The mtime-only cache key** could miss a same-mtime replacement (npm and tar
+  preserve tarball mtimes; some filesystems store whole seconds), resurrecting
+  the bug. Keyed on mtime AND size.
+- **`doctor` printed the client's version when the server reported none**, i.e.
+  the check invented the very number it exists to compare. Now a warning.
+- **A stale pidfile was a warning**, so a leftover file from a reboot failed
+  `doctor --strict` during release verification. Now `skipped`.
+- **`self-update` warned even when the daemon was already current.** Gated on
+  the version actually differing.
+- **The SPA test wrote into the shipped build artifact** with only `afterAll`
+  to restore it. Restored in a `finally` plus signal handlers.
+- **`dirty` on the edit page ignored metadata and project membership**, so the
+  tab's one unsaved-work signal said "saved" during a metadata-only edit.
+
 ## Verification (staging, 2026-09-08)
 
 - `bun run typecheck` clean; frontend lint clean; `_shared` 610 pass.

--- a/docs/plans/iteration-46-spa-serving-and-tab-titles.md
+++ b/docs/plans/iteration-46-spa-serving-and-tab-titles.md
@@ -50,11 +50,11 @@ The tab said `Cerefox` on every page. Now each page sets its own, through
 
 **Decisions.** The app name is *not* prefixed: tabs truncate from the right, so
 `Cerefox: <x>` would make every tab look alike, and the favicon already
-identifies the app. The one thing allowed to push the title right is the
-**environment label** (`[staging] Trash`), because someone with production,
-staging and a local container open needs to see which tab they are about to act
-in; production and Cerefox Local report no label and stay clean. Titles are
-truncated at 60 characters.
+identifies the app. Titles are truncated at 60 characters. An environment-label
+prefix (`[staging] Trash`) was built and then **removed on the maintainer's
+call**: running several instances side by side is their own setup rather than a
+general one, and the environment banner already names it on every page. Nothing
+in the title depends on the server now, so the hook makes no request.
 
 ## Tests
 

--- a/frontend/src/hooks/usePageTitle.ts
+++ b/frontend/src/hooks/usePageTitle.ts
@@ -1,0 +1,32 @@
+import { useQuery } from "@tanstack/react-query";
+import { useEffect } from "react";
+
+import { fetchVersion } from "../api/version";
+import { pageTitle } from "../lib/pageTitle";
+
+/**
+ * Sets the browser tab title for the page that calls it (#253).
+ *
+ * Every page calls this once. Pages whose title depends on loaded data pass
+ * `null` (or nothing) while it loads, which shows the app name rather than a
+ * flash of "undefined". The environment label is read from the same
+ * `["version"]` query the environment banner uses, so it costs no extra
+ * request.
+ *
+ * There is no cleanup on unmount: the next page sets its own title, and
+ * restoring a previous one in between would only make the tab flicker.
+ */
+export function usePageTitle(page?: string | null, opts: { dirty?: boolean } = {}): void {
+  const { data } = useQuery({
+    queryKey: ["version"],
+    queryFn: fetchVersion,
+    staleTime: Infinity,
+    retry: false,
+  });
+  const envLabel = data?.env_label ?? null;
+  const dirty = opts.dirty ?? false;
+
+  useEffect(() => {
+    document.title = pageTitle({ page, envLabel, dirty });
+  }, [page, envLabel, dirty]);
+}

--- a/frontend/src/hooks/usePageTitle.ts
+++ b/frontend/src/hooks/usePageTitle.ts
@@ -1,7 +1,5 @@
-import { useQuery } from "@tanstack/react-query";
 import { useEffect } from "react";
 
-import { fetchVersion } from "../api/version";
 import { pageTitle } from "../lib/pageTitle";
 
 /**
@@ -9,24 +7,15 @@ import { pageTitle } from "../lib/pageTitle";
  *
  * Every page calls this once. Pages whose title depends on loaded data pass
  * `null` (or nothing) while it loads, which shows the app name rather than a
- * flash of "undefined". The environment label is read from the same
- * `["version"]` query the environment banner uses, so it costs no extra
- * request.
+ * flash of "undefined".
  *
  * There is no cleanup on unmount: the next page sets its own title, and
  * restoring a previous one in between would only make the tab flicker.
  */
 export function usePageTitle(page?: string | null, opts: { dirty?: boolean } = {}): void {
-  const { data } = useQuery({
-    queryKey: ["version"],
-    queryFn: fetchVersion,
-    staleTime: Infinity,
-    retry: false,
-  });
-  const envLabel = data?.env_label ?? null;
   const dirty = opts.dirty ?? false;
 
   useEffect(() => {
-    document.title = pageTitle({ page, envLabel, dirty });
-  }, [page, envLabel, dirty]);
+    document.title = pageTitle({ page, dirty });
+  }, [page, dirty]);
 }

--- a/frontend/src/lib/pageTitle.test.ts
+++ b/frontend/src/lib/pageTitle.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Browser tab titles (#253), tested without a browser.
+ *
+ * The rule the tests encode: the distinguishing text comes first, the app
+ * name is dropped, and the environment label is the only thing allowed to
+ * push it right.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { pageTitle, truncateTitle, TITLE_MAX } from "./pageTitle";
+
+describe("pageTitle", () => {
+  test("a page's own name is the whole title; the app name is not repeated", () => {
+    // Tabs truncate from the right, so "Cerefox: X" would make every tab look
+    // identical. The favicon identifies the app.
+    expect(pageTitle({ page: "Trash" })).toBe("Trash");
+    expect(pageTitle({ page: "Contact - Josh Cohen" })).toBe("Contact - Josh Cohen");
+  });
+
+  test("no page (the dashboard, or data still loading) falls back to the app name", () => {
+    expect(pageTitle({})).toBe("Cerefox");
+    expect(pageTitle({ page: null })).toBe("Cerefox");
+    expect(pageTitle({ page: "   " })).toBe("Cerefox");
+  });
+
+  test("an environment label is prefixed, because picking the wrong tab is the costly mistake", () => {
+    expect(pageTitle({ page: "Trash", envLabel: "staging" })).toBe("[staging] Trash");
+    // Production and Cerefox Local report no label and stay clean.
+    expect(pageTitle({ page: "Trash", envLabel: null })).toBe("Trash");
+    expect(pageTitle({ page: "Trash", envLabel: "  " })).toBe("Trash");
+  });
+
+  test("unsaved changes show a leading dot, outside the label", () => {
+    expect(pageTitle({ page: "Editing: Notes", dirty: true })).toBe("• Editing: Notes");
+    expect(pageTitle({ page: "Editing: Notes", dirty: true, envLabel: "staging" })).toBe(
+      "• [staging] Editing: Notes",
+    );
+  });
+
+  test("long titles are truncated, so the tab never carries a whole heading", () => {
+    const long = "A".repeat(TITLE_MAX + 40);
+    const out = pageTitle({ page: long });
+    expect(out.length).toBe(TITLE_MAX);
+    expect(out.endsWith("…")).toBe(true);
+  });
+
+  test("truncation collapses whitespace and does not leave a dangling space", () => {
+    expect(truncateTitle("  spaced   out  ")).toBe("spaced out");
+    expect(truncateTitle("word ".repeat(30)).endsWith(" …")).toBe(false);
+  });
+
+  test("a title exactly at the limit is left alone", () => {
+    const exact = "B".repeat(TITLE_MAX);
+    expect(truncateTitle(exact)).toBe(exact);
+  });
+});

--- a/frontend/src/lib/pageTitle.test.ts
+++ b/frontend/src/lib/pageTitle.test.ts
@@ -1,9 +1,8 @@
 /**
  * Browser tab titles (#253), tested without a browser.
  *
- * The rule the tests encode: the distinguishing text comes first, the app
- * name is dropped, and the environment label is the only thing allowed to
- * push it right.
+ * The rule the tests encode: the page's own name IS the title, and the app
+ * name is not repeated in front of it.
  */
 import { describe, expect, test } from "bun:test";
 
@@ -23,18 +22,9 @@ describe("pageTitle", () => {
     expect(pageTitle({ page: "   " })).toBe("Cerefox");
   });
 
-  test("an environment label is prefixed, because picking the wrong tab is the costly mistake", () => {
-    expect(pageTitle({ page: "Trash", envLabel: "staging" })).toBe("[staging] Trash");
-    // Production and Cerefox Local report no label and stay clean.
-    expect(pageTitle({ page: "Trash", envLabel: null })).toBe("Trash");
-    expect(pageTitle({ page: "Trash", envLabel: "  " })).toBe("Trash");
-  });
-
-  test("unsaved changes show a leading dot, outside the label", () => {
+  test("unsaved changes show a leading dot", () => {
     expect(pageTitle({ page: "Editing: Notes", dirty: true })).toBe("• Editing: Notes");
-    expect(pageTitle({ page: "Editing: Notes", dirty: true, envLabel: "staging" })).toBe(
-      "• [staging] Editing: Notes",
-    );
+    expect(pageTitle({ page: "Editing: Notes" })).toBe("Editing: Notes");
   });
 
   test("long titles are truncated, so the tab never carries a whole heading", () => {

--- a/frontend/src/lib/pageTitle.ts
+++ b/frontend/src/lib/pageTitle.ts
@@ -1,0 +1,38 @@
+/**
+ * What the browser tab says (#253).
+ *
+ * The distinguishing part comes FIRST and the app name is dropped: tabs
+ * truncate from the right, so "Cerefox: My Document" collapses to
+ * "Cerefox: My Do…" and every tab looks the same. The favicon already says
+ * which app this is.
+ *
+ * The environment label, when the server reports one, is the exception that
+ * earns a prefix: someone with production, staging and a local container open
+ * side by side needs to see which tab they are about to act in, and that
+ * matters more than the first few characters of the title. Production and
+ * Cerefox Local report no label, so their tabs stay clean.
+ */
+
+/** Long document titles get cut here; a tab shows far less than this anyway. */
+export const TITLE_MAX = 60;
+
+export function truncateTitle(text: string, max = TITLE_MAX): string {
+  const clean = text.replace(/\s+/g, " ").trim();
+  return clean.length <= max ? clean : `${clean.slice(0, max - 1).trimEnd()}…`;
+}
+
+export interface PageTitleParts {
+  /** The page-specific part. Empty or absent means the app name alone. */
+  page?: string | null;
+  /** `env_label` from /api/v1/version, when the server reports one. */
+  envLabel?: string | null;
+  /** Unsaved changes: shown the way editors do, with a leading dot. */
+  dirty?: boolean;
+}
+
+/** The full `document.title` string for a page. */
+export function pageTitle({ page, envLabel, dirty }: PageTitleParts): string {
+  const base = page?.trim() ? truncateTitle(page) : "Cerefox";
+  const env = envLabel?.trim() ? `[${envLabel.trim()}] ` : "";
+  return `${dirty ? "• " : ""}${env}${base}`;
+}

--- a/frontend/src/lib/pageTitle.ts
+++ b/frontend/src/lib/pageTitle.ts
@@ -1,16 +1,10 @@
 /**
  * What the browser tab says (#253).
  *
- * The distinguishing part comes FIRST and the app name is dropped: tabs
- * truncate from the right, so "Cerefox: My Document" collapses to
+ * The distinguishing part is the whole title and the app name is dropped:
+ * tabs truncate from the right, so "Cerefox: My Document" collapses to
  * "Cerefox: My Do…" and every tab looks the same. The favicon already says
  * which app this is.
- *
- * The environment label, when the server reports one, is the exception that
- * earns a prefix: someone with production, staging and a local container open
- * side by side needs to see which tab they are about to act in, and that
- * matters more than the first few characters of the title. Production and
- * Cerefox Local report no label, so their tabs stay clean.
  */
 
 /** Long document titles get cut here; a tab shows far less than this anyway. */
@@ -24,15 +18,12 @@ export function truncateTitle(text: string, max = TITLE_MAX): string {
 export interface PageTitleParts {
   /** The page-specific part. Empty or absent means the app name alone. */
   page?: string | null;
-  /** `env_label` from /api/v1/version, when the server reports one. */
-  envLabel?: string | null;
   /** Unsaved changes: shown the way editors do, with a leading dot. */
   dirty?: boolean;
 }
 
 /** The full `document.title` string for a page. */
-export function pageTitle({ page, envLabel, dirty }: PageTitleParts): string {
+export function pageTitle({ page, dirty }: PageTitleParts): string {
   const base = page?.trim() ? truncateTitle(page) : "Cerefox";
-  const env = envLabel?.trim() ? `[${envLabel.trim()}] ` : "";
-  return `${dirty ? "• " : ""}${env}${base}`;
+  return `${dirty ? "• " : ""}${base}`;
 }

--- a/frontend/src/pages/AnalyticsPage.tsx
+++ b/frontend/src/pages/AnalyticsPage.tsx
@@ -36,6 +36,7 @@ import ui from "../styles/redesign.module.css";
 import { WordCloudChart } from "../components/WordCloudChart";
 import { HEBChart } from "../components/HEBChart";
 import { HEBOperationChart } from "../components/HEBOperationChart";
+import { usePageTitle } from "../hooks/usePageTitle";
 
 const DATE_PRESETS = [
   { value: "7", label: "Last 7 days" },
@@ -110,6 +111,7 @@ function buildFilters(
 }
 
 export function AnalyticsPage() {
+  usePageTitle("Analytics");
   const queryClient = useQueryClient();
 
   // ── Filter state ─────────────────────────────────────────────────────────

--- a/frontend/src/pages/AuditLogPage.tsx
+++ b/frontend/src/pages/AuditLogPage.tsx
@@ -11,6 +11,7 @@ import { ListPage, type ListColumn } from "../components/ListPage";
 import { formatDateTime } from "../utils/dates";
 import { STORE_LEVEL_AUDIT_OPS } from "@cerefox/audit-ops";
 import ui from "../styles/redesign.module.css";
+import { usePageTitle } from "../hooks/usePageTitle";
 
 // Membership is the SHARED definition (via the @cerefox/audit-ops alias, the
 // @cerefox/schemas pattern): a fifth store-level operation renders "(store)"
@@ -63,6 +64,7 @@ const OP_TONE: Record<string, string> = {
 };
 
 export function AuditLogPage() {
+  usePageTitle("Audit log");
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
 

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -28,6 +28,7 @@ import type { DashboardDoc } from "../api/types";
 import ui from "../styles/redesign.module.css";
 import { formatDateTime } from "../utils/dates";
 import styles from "./DashboardPage.module.css";
+import { usePageTitle } from "../hooks/usePageTitle";
 
 const PROJECT_COLORS = ["--primary", "--violet", "--blue", "--green", "--yellow", "--red"];
 
@@ -67,6 +68,7 @@ function sourceChip(source: string | null): { icon: typeof IconMapPin; label: st
 const SINCE_30D = new Date(Date.now() - 30 * 864e5).toISOString();
 
 export function DashboardPage() {
+  usePageTitle();
   const navigate = useNavigate();
   const [quick, setQuick] = useState("");
   // The aggregate dashboard keeps its plain (shared) cache key — SearchPage

--- a/frontend/src/pages/DocumentEditPage.tsx
+++ b/frontend/src/pages/DocumentEditPage.tsx
@@ -38,6 +38,29 @@ function displayMetaValue(value: unknown): string {
   }
 }
 
+/** Order-insensitive equality: reordering project chips is not a change. */
+function sameStrings(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  const left = [...a].sort();
+  const right = [...b].sort();
+  return left.every((v, i) => v === right[i]);
+}
+
+/**
+ * The edited metadata rows against what was loaded, compared the way the form
+ * displays them (`displayMetaValue`), so an untouched document is never dirty.
+ */
+function sameMetaPairs(
+  pairs: { key: string; value: string }[],
+  loaded: Record<string, unknown>,
+): boolean {
+  const entries = Object.entries(loaded);
+  const filled = pairs.filter((p) => p.key.trim() !== "");
+  if (filled.length !== entries.length) return false;
+  const asMap = new Map(filled.map((p) => [p.key, p.value]));
+  return entries.every(([k, v]) => asMap.has(k) && asMap.get(k) === displayMetaValue(v));
+}
+
 export function DocumentEditPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
@@ -60,9 +83,16 @@ export function DocumentEditPage() {
   );
   const [initialized, setInitialized] = useState(false);
   // Editing is a mode, so the tab says so; the leading dot marks unsaved work
-  // the way an editor does.
+  // the way an editor does. Every editable field counts: a metadata-only or
+  // membership-only change is still unsaved work, and the dot is the page's
+  // one signal that it exists.
   const dirty =
-    initialized && doc != null && (title !== (doc.doc_title ?? "") || content !== (doc.full_content ?? ""));
+    initialized &&
+    doc != null &&
+    (title !== (doc.doc_title ?? "") ||
+      content !== (doc.full_content ?? "") ||
+      !sameStrings(projectIds, doc.project_ids ?? []) ||
+      !sameMetaPairs(metaPairs, doc.doc_metadata ?? {}));
   usePageTitle(doc?.doc_title ? `Editing: ${doc.doc_title}` : "Editing", { dirty });
 
   const [contentView, setContentView] = useState<string>("edit");

--- a/frontend/src/pages/DocumentEditPage.tsx
+++ b/frontend/src/pages/DocumentEditPage.tsx
@@ -23,6 +23,7 @@ import { MarkdownViewer } from "../components/MarkdownViewer";
 import { invalidateDocumentViews } from "../lib/invalidate";
 import { useMetadataKeys, useProjects } from "../hooks/useProjects";
 import { showSuccess, showError, showV07DeferredToast } from "../utils/notifications";
+import { usePageTitle } from "../hooks/usePageTitle";
 
 /** Inverse of the parse-on-save: strings that JSON.parse would reinterpret
  * (numbers, booleans, quoted strings, JSON structures) render JSON-encoded
@@ -58,6 +59,11 @@ export function DocumentEditPage() {
     [],
   );
   const [initialized, setInitialized] = useState(false);
+  // Editing is a mode, so the tab says so; the leading dot marks unsaved work
+  // the way an editor does.
+  const dirty =
+    initialized && doc != null && (title !== (doc.doc_title ?? "") || content !== (doc.full_content ?? ""));
+  usePageTitle(doc?.doc_title ? `Editing: ${doc.doc_title}` : "Editing", { dirty });
 
   const [contentView, setContentView] = useState<string>("edit");
 

--- a/frontend/src/pages/DocumentPage.tsx
+++ b/frontend/src/pages/DocumentPage.tsx
@@ -41,6 +41,7 @@ import { showError, showSuccess } from "../utils/notifications";
 import md from "../components/MarkdownViewer.module.css";
 import ui from "../styles/redesign.module.css";
 import styles from "./DocumentPage.module.css";
+import { usePageTitle } from "../hooks/usePageTitle";
 
 type View = "rendered" | "source" | "chunks";
 
@@ -125,6 +126,8 @@ export function DocumentPage() {
     queryFn: () => fetchDocument(id!, versionParam ?? undefined),
     enabled: !!id,
   });
+  // The document's own title names the tab; "Document" only while it loads.
+  usePageTitle(doc?.doc_title ?? null);
   const { data: chunks, isLoading: chunksLoading } = useQuery({
     queryKey: ["document-chunks", id],
     queryFn: () => fetchChunks(id!),

--- a/frontend/src/pages/HelpPage.tsx
+++ b/frontend/src/pages/HelpPage.tsx
@@ -20,6 +20,7 @@ import { fetchDocContent, fetchDocsIndex, type DocEntry } from "../api/docs";
 import { CliHint } from "../components/CliHint";
 import { MarkdownViewer } from "../components/MarkdownViewer";
 import ui from "../styles/redesign.module.css";
+import { usePageTitle } from "../hooks/usePageTitle";
 
 const CATEGORY_LABELS: Record<string, string> = {
   readme: "Project overview",
@@ -57,6 +58,8 @@ export function HelpPage() {
 
   // Default to README on first visit
   const selectedPath = docPath && docPath.length > 0 ? docPath : docs[0]?.path;
+  const selectedTitle = docs.find((d) => d.path === selectedPath)?.title;
+  usePageTitle(selectedTitle ? `Help: ${selectedTitle}` : "Help");
 
   const contentQuery = useQuery({
     queryKey: ["docs", "content", selectedPath],

--- a/frontend/src/pages/IngestPage.tsx
+++ b/frontend/src/pages/IngestPage.tsx
@@ -14,12 +14,14 @@ import { useMetadataKeys, useProjects } from "../hooks/useProjects";
 import { showError, showV07DeferredToast } from "../utils/notifications";
 import ui from "../styles/redesign.module.css";
 import styles from "./IngestPage.module.css";
+import { usePageTitle } from "../hooks/usePageTitle";
 
 const PROJECT_COLORS = ["--primary", "--violet", "--blue", "--green", "--yellow", "--red"];
 
 type Tab = "paste" | "file";
 
 export function IngestPage() {
+  usePageTitle("Ingest");
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { data: projects } = useProjects();

--- a/frontend/src/pages/MetadataSearchPage.tsx
+++ b/frontend/src/pages/MetadataSearchPage.tsx
@@ -20,8 +20,10 @@ import type { MetadataSearchResult } from "../api/types";
 import { CliHint } from "../components/CliHint";
 import ui from "../styles/redesign.module.css";
 import lp from "../components/ListPage.module.css";
+import { usePageTitle } from "../hooks/usePageTitle";
 
 export function MetadataSearchPage() {
+  usePageTitle("Metadata search");
   const navigate = useNavigate();
   const [filters, setFilters] = useState<Array<{ key: string; value: string }>>([{ key: "", value: "" }]);
   const [projectId, setProjectId] = useState<string>("");

--- a/frontend/src/pages/ProjectDocumentsPage.tsx
+++ b/frontend/src/pages/ProjectDocumentsPage.tsx
@@ -13,6 +13,7 @@ import { useRowsPerPage } from "../hooks/useRowsPerPage";
 import { formatDate } from "../utils/dates";
 import ui from "../styles/redesign.module.css";
 import lp from "../components/ListPage.module.css";
+import { usePageTitle } from "../hooks/usePageTitle";
 
 export function ProjectDocumentsPage() {
   const { id } = useParams<{ id: string }>();
@@ -20,6 +21,7 @@ export function ProjectDocumentsPage() {
   const { data: projects } = useProjects();
 
   const project = projects?.find((p) => p.id === id);
+  usePageTitle(project?.name ?? null);
   const projectMap = new Map(projects?.map((p) => [p.id, p.name]) ?? []);
 
   const [page, setPage] = useState(1);

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -13,10 +13,12 @@ import { useProjects } from "../hooks/useProjects";
 import { showError, showSuccess } from "../utils/notifications";
 import { ApiError } from "../api/client";
 import ui from "../styles/redesign.module.css";
+import { usePageTitle } from "../hooks/usePageTitle";
 
 const PROJECT_COLORS = ["--primary", "--violet", "--blue", "--green", "--yellow", "--red"];
 
 export function ProjectsPage() {
+  usePageTitle("Projects");
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { data: projects, isLoading } = useProjects();

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -10,11 +10,13 @@ import { SearchResults } from "../components/SearchResults";
 import { serializeMfParam, useSearchQuery, useSearchState } from "../hooks/useSearch";
 import ui from "../styles/redesign.module.css";
 import styles from "./SearchPage.module.css";
+import { usePageTitle } from "../hooks/usePageTitle";
 
 export function SearchPage() {
   const [, setSearchParams] = useSearchParams();
   const state = useSearchState();
   const { data, isLoading, error } = useSearchQuery(state);
+  usePageTitle(state.q ? `Search: ${state.q}` : "Search");
   const { data: dash } = useQuery({ queryKey: ["dashboard"], queryFn: () => fetchDashboard() });
 
   const handleSearch = useCallback(

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -20,6 +20,7 @@ import { useState } from "react";
 import { fetchConfig, setConfigValue, type ConfigEntry } from "../api/config";
 import { CliCard } from "../components/CliCard";
 import { showError, showSuccess } from "../utils/notifications";
+import { usePageTitle } from "../hooks/usePageTitle";
 
 /**
  * Runtime settings — the web face of `cerefox config get/set`.
@@ -47,6 +48,7 @@ const GROUP_BLURB: Record<string, string> = {
 };
 
 export function SettingsPage() {
+  usePageTitle("Settings");
   const queryClient = useQueryClient();
   const { data, isLoading } = useQuery({ queryKey: ["config"], queryFn: fetchConfig });
 

--- a/frontend/src/pages/TrashPage.tsx
+++ b/frontend/src/pages/TrashPage.tsx
@@ -11,6 +11,7 @@ import { useProjects } from "../hooks/useProjects";
 import { invalidateDocumentViews } from "../lib/invalidate";
 import { showError, showInfo, showSuccess } from "../utils/notifications";
 import ui from "../styles/redesign.module.css";
+import { usePageTitle } from "../hooks/usePageTitle";
 
 const PROJECT_COLORS = ["--primary", "--violet", "--blue", "--green", "--yellow", "--red"];
 function colorFor(name: string): string {
@@ -20,6 +21,7 @@ function colorFor(name: string): string {
 }
 
 export function TrashPage() {
+  usePageTitle("Trash");
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { data: projects } = useProjects();

--- a/frontend/tests/e2e/ui.spec.ts
+++ b/frontend/tests/e2e/ui.spec.ts
@@ -485,16 +485,16 @@ test.describe("Tab titles", () => {
       ["/audit-log", "Audit log"],
     ] as const) {
       await page.goto(`${APP}${path}`);
-      await expect(page).toHaveTitle(new RegExp(`(^|\\] )${expected}$`));
+      await expect(page).toHaveTitle(expected);
     }
 
     // The dashboard is the app name alone.
     await page.goto(APP);
-    await expect(page).toHaveTitle(/(^|\] )Cerefox$/);
+    await expect(page).toHaveTitle("Cerefox");
 
     // A search names the query.
     await page.goto(`${APP}/search?q=oauth+design`);
-    await expect(page).toHaveTitle(/Search: oauth design$/);
+    await expect(page).toHaveTitle("Search: oauth design");
 
     // A document names the document, once loaded.
     const title = uniqueTitle("Tab Title");
@@ -512,12 +512,4 @@ test.describe("Tab titles", () => {
     }
   });
 
-  test("a labelled environment is named in the tab, ahead of the page", async ({ page, request }) => {
-    // Production and Cerefox Local report no label and stay clean; a staging
-    // tab says so, because picking the wrong tab is the costly mistake.
-    const info = (await (await request.get("/api/v1/version")).json()) as { env_label?: string | null };
-    const label = (info.env_label ?? "").trim();
-    await page.goto(`${APP}/trash`);
-    await expect(page).toHaveTitle(label ? `[${label}] Trash` : "Trash");
-  });
 });

--- a/frontend/tests/e2e/ui.spec.ts
+++ b/frontend/tests/e2e/ui.spec.ts
@@ -472,3 +472,52 @@ test.describe("Trash", () => {
     expect((await request.delete(`/api/v1/documents/${document_id}/purge`)).ok()).toBeTruthy();
   });
 });
+
+// ── Browser tab titles (v1.14.2, #253) ─────────────────────────────────────
+test.describe("Tab titles", () => {
+  test("each page names itself in the tab, and a document names the document", async ({ page, request }) => {
+    // Static pages: the page's own name, no "Cerefox:" prefix (tabs truncate
+    // from the right, so a shared prefix would make every tab look alike).
+    for (const [path, expected] of [
+      ["/trash", "Trash"],
+      ["/projects", "Projects"],
+      ["/settings", "Settings"],
+      ["/audit-log", "Audit log"],
+    ] as const) {
+      await page.goto(`${APP}${path}`);
+      await expect(page).toHaveTitle(new RegExp(`(^|\\] )${expected}$`));
+    }
+
+    // The dashboard is the app name alone.
+    await page.goto(APP);
+    await expect(page).toHaveTitle(/(^|\] )Cerefox$/);
+
+    // A search names the query.
+    await page.goto(`${APP}/search?q=oauth+design`);
+    await expect(page).toHaveTitle(/Search: oauth design$/);
+
+    // A document names the document, once loaded.
+    const title = uniqueTitle("Tab Title");
+    const r = await request.post("/api/v1/ingest", {
+      data: { title, content: "# Tab title\n\nNames the browser tab.", author: "e2e-ui", author_type: "user" },
+    });
+    expect(r.ok()).toBeTruthy();
+    const { document_id } = (await r.json()) as { document_id: string };
+    try {
+      await page.goto(`${APP}/document/${document_id}`);
+      await expect(page).toHaveTitle(new RegExp(`${title.replace(/[[\]()]/g, "\\$&")}$`));
+    } finally {
+      await request.delete(`/api/v1/documents/${document_id}`);
+      await request.delete(`/api/v1/documents/${document_id}/purge`);
+    }
+  });
+
+  test("a labelled environment is named in the tab, ahead of the page", async ({ page, request }) => {
+    // Production and Cerefox Local report no label and stay clean; a staging
+    // tab says so, because picking the wrong tab is the costly mistake.
+    const info = (await (await request.get("/api/v1/version")).json()) as { env_label?: string | null };
+    const label = (info.env_label ?? "").trim();
+    await page.goto(`${APP}/trash`);
+    await expect(page).toHaveTitle(label ? `[${label}] Trash` : "Trash");
+  });
+});

--- a/packages/memory/src/cli/commands/self-update.ts
+++ b/packages/memory/src/cli/commands/self-update.ts
@@ -27,7 +27,7 @@ import {
   userError,
 } from "../../../../../_shared/cli-core/index.ts";
 import { PKG_VERSION } from "../../meta.ts";
-import { statusDaemon } from "../../web/daemon.ts";
+import { restartCommand, statusDaemon } from "../../web/daemon.ts";
 
 interface SelfUpdateOptions {
   check?: boolean;
@@ -174,7 +174,10 @@ async function action(options: SelfUpdateOptions): Promise<void> {
   // (#252): the upgrade replaced the package under it, so its SPA bundle and
   // its API are the old ones. Say so here, where the user is looking.
   const daemon = await statusDaemon().catch(() => null);
-  if (daemon?.kind === "running") {
+  // Only when it is actually behind: the user may have restarted it in another
+  // terminal between the install and this probe, and telling someone to fix
+  // something that is already correct teaches them to ignore the warning.
+  if (daemon?.kind === "running" && daemon.version !== target) {
     println("");
     println(
       c.yellow(
@@ -183,7 +186,10 @@ async function action(options: SelfUpdateOptions): Promise<void> {
           `${daemon.version ? `, v${daemon.version}` : ""}).`,
       ),
     );
-    println("  Restart it: " + c.bold("cerefox web stop && cerefox web start"));
+    // Carry its host and port: `web start` defaults to 127.0.0.1:8000, so a
+    // bare restart command silently MOVES a daemon that was listening
+    // anywhere else, and the bookmark or reverse proxy in front of it breaks.
+    println("  Restart it: " + c.bold(restartCommand(daemon.info.host, daemon.info.port)));
   }
 
   println("");

--- a/packages/memory/src/cli/commands/self-update.ts
+++ b/packages/memory/src/cli/commands/self-update.ts
@@ -27,6 +27,7 @@ import {
   userError,
 } from "../../../../../_shared/cli-core/index.ts";
 import { PKG_VERSION } from "../../meta.ts";
+import { statusDaemon } from "../../web/daemon.ts";
 
 interface SelfUpdateOptions {
   check?: boolean;
@@ -169,6 +170,22 @@ async function action(options: SelfUpdateOptions): Promise<void> {
   // earlier releases did not hard-require their schema at ingest time.
   // The sync belongs AFTER the server update; `cerefox server deploy` prints
   // the pointer, and `cerefox guides ingest` remains the standalone command.
+  // A running daemon keeps serving the PREVIOUS build until it is restarted
+  // (#252): the upgrade replaced the package under it, so its SPA bundle and
+  // its API are the old ones. Say so here, where the user is looking.
+  const daemon = await statusDaemon().catch(() => null);
+  if (daemon?.kind === "running") {
+    println("");
+    println(
+      c.yellow(
+        `⚠ The web server is still running the previous build ` +
+          `(pid ${daemon.info.pid} on :${daemon.info.port}` +
+          `${daemon.version ? `, v${daemon.version}` : ""}).`,
+      ),
+    );
+    println("  Restart it: " + c.bold("cerefox web stop && cerefox web start"));
+  }
+
   println("");
   println("Next steps:");
   println("  1. " + c.bold("cerefox server deploy") + "   apply this release's schema/RPC/EF updates");

--- a/packages/memory/src/cli/commands/web.ts
+++ b/packages/memory/src/cli/commands/web.ts
@@ -22,6 +22,7 @@ import { buildWebServer, CompatibilityError } from "../../web/server.ts";
 import {
   daemonPaths,
   startDaemon,
+  restartCommand,
   statusDaemon,
   stopDaemon,
 } from "../../web/daemon.ts";
@@ -215,7 +216,10 @@ export function registerWeb(program: Command): void {
                   ),
                 );
                 println(
-                  c.dim("  Restart to pick up the new build: cerefox web stop && cerefox web start"),
+                  c.dim(
+                    "  Restart to pick up the new build: " +
+                      restartCommand(status.info.host, status.info.port),
+                  ),
                 );
               }
             } else {

--- a/packages/memory/src/cli/commands/web.ts
+++ b/packages/memory/src/cli/commands/web.ts
@@ -25,6 +25,7 @@ import {
   statusDaemon,
   stopDaemon,
 } from "../../web/daemon.ts";
+import { PKG_VERSION } from "../../meta.ts";
 
 interface WebOptions {
   host: string;
@@ -206,6 +207,17 @@ export function registerWeb(program: Command): void {
                   `Cerefox web: running on :${status.info.port} (pid ${status.info.pid}, since ${status.info.startedAt}).`,
                 ),
               );
+              // An in-place upgrade leaves the old server running (#252).
+              if (status.version && status.version !== PKG_VERSION) {
+                println(
+                  c.yellow(
+                    `  ⚠ It is serving v${status.version}; this CLI is v${PKG_VERSION}.`,
+                  ),
+                );
+                println(
+                  c.dim("  Restart to pick up the new build: cerefox web stop && cerefox web start"),
+                );
+              }
             } else {
               println(
                 c.yellow(

--- a/packages/memory/src/cli/util/checks.ts
+++ b/packages/memory/src/cli/util/checks.ts
@@ -33,6 +33,7 @@ import {
   compareSemver,
 } from "../../../../../_shared/compatibility/index.ts";
 import { resolveServerAssets } from "../../../../../_shared/server-assets/index.ts";
+import { statusDaemon } from "../../web/daemon.ts";
 
 export type CheckStatus = "ok" | "warn" | "error" | "skipped";
 
@@ -707,6 +708,57 @@ function hasCerefoxInJsonFile(path: string): boolean {
   }
 }
 
+/**
+ * The running web daemon's build, compared with this CLI's (#252).
+ *
+ * `self-update` replaces the package in place; a daemon started before it
+ * keeps serving the old SPA bundle and the old API until it is restarted.
+ * The symptom is a blank page on a deep route after an upgrade, with a 200
+ * in the access log, so it is worth one line here.
+ */
+export async function checkWebDaemon(): Promise<CheckResult> {
+  let status: Awaited<ReturnType<typeof statusDaemon>>;
+  try {
+    status = await statusDaemon();
+  } catch {
+    return { name: "web server", status: "skipped", detail: "could not read the daemon pidfile" };
+  }
+  if (status.kind === "stopped") {
+    return { name: "web server", status: "skipped", detail: "no background daemon running" };
+  }
+  if (status.kind === "stale") {
+    return {
+      name: "web server",
+      status: "warn",
+      detail: `stale pidfile — process ${status.info.pid} is not running.`,
+      hint: `Clean it up: cerefox web stop`,
+    };
+  }
+  if (!status.responding) {
+    return {
+      name: "web server",
+      status: "warn",
+      detail: `process ${status.info.pid} is alive but not answering on :${status.info.port}.`,
+      hint: "Check the log, then: cerefox web stop && cerefox web start",
+    };
+  }
+  if (status.version && status.version !== PKG_VERSION) {
+    return {
+      name: "web server",
+      status: "warn",
+      detail:
+        `running v${status.version} on :${status.info.port}, but this client is v${PKG_VERSION} ` +
+        `— it is still serving the previous build.`,
+      hint: "Restart it: cerefox web stop && cerefox web start",
+    };
+  }
+  return {
+    name: "web server",
+    status: "ok",
+    detail: `v${status.version ?? PKG_VERSION} on :${status.info.port} (pid ${status.info.pid})`,
+  };
+}
+
 export function checkMcpConfigs(): CheckResult {
   // Walk known MCP client config locations and report which ones have
   // a `cerefox` server entry registered.
@@ -1035,6 +1087,7 @@ export async function runAllChecks(opts: RunChecksOptions = {}): Promise<CheckRe
     { name: "metadata health", phase: "Checking metadata well-formedness", run: () => checkMetadataHealth() },
     { name: "edge functions", phase: "Probing Edge Function versions", run: () => checkEdgeFunctionsCompat() },
     { name: "postgres", phase: "Probing Postgres DDL endpoint", run: () => checkPostgres() },
+    { name: "web server", phase: "Probing the web daemon", run: () => checkWebDaemon() },
     { name: "mcp clients", phase: "Scanning MCP client configs", run: () => checkMcpConfigs() },
   ];
   return runSteps(steps, opts);

--- a/packages/memory/src/cli/util/checks.ts
+++ b/packages/memory/src/cli/util/checks.ts
@@ -33,7 +33,7 @@ import {
   compareSemver,
 } from "../../../../../_shared/compatibility/index.ts";
 import { resolveServerAssets } from "../../../../../_shared/server-assets/index.ts";
-import { statusDaemon } from "../../web/daemon.ts";
+import { restartCommand, statusDaemon } from "../../web/daemon.ts";
 
 export type CheckStatus = "ok" | "warn" | "error" | "skipped";
 
@@ -727,11 +727,14 @@ export async function checkWebDaemon(): Promise<CheckResult> {
     return { name: "web server", status: "skipped", detail: "no background daemon running" };
   }
   if (status.kind === "stale") {
+    // Not "warn": a pidfile outlives a reboot or a kill -9 and says nothing
+    // about the health of the install, and `doctor --strict` (used in release
+    // verification) fails on any warning.
     return {
       name: "web server",
-      status: "warn",
-      detail: `stale pidfile — process ${status.info.pid} is not running.`,
-      hint: `Clean it up: cerefox web stop`,
+      status: "skipped",
+      detail: `no daemon running (stale pidfile for process ${status.info.pid}).`,
+      hint: "Clean it up: cerefox web stop",
     };
   }
   if (!status.responding) {
@@ -739,7 +742,7 @@ export async function checkWebDaemon(): Promise<CheckResult> {
       name: "web server",
       status: "warn",
       detail: `process ${status.info.pid} is alive but not answering on :${status.info.port}.`,
-      hint: "Check the log, then: cerefox web stop && cerefox web start",
+      hint: `Check the log, then: ${restartCommand(status.info.host, status.info.port)}`,
     };
   }
   if (status.version && status.version !== PKG_VERSION) {
@@ -749,13 +752,25 @@ export async function checkWebDaemon(): Promise<CheckResult> {
       detail:
         `running v${status.version} on :${status.info.port}, but this client is v${PKG_VERSION} ` +
         `— it is still serving the previous build.`,
-      hint: "Restart it: cerefox web stop && cerefox web start",
+      hint: `Restart it: ${restartCommand(status.info.host, status.info.port)}`,
+    };
+  }
+  if (!status.version) {
+    // A 200 with no parseable version is not proof it is this build: the port
+    // may have been recycled by another service. Never print the client's own
+    // version as if the server had reported it — that is the one number this
+    // check exists to compare.
+    return {
+      name: "web server",
+      status: "warn",
+      detail: `responding on :${status.info.port} (pid ${status.info.pid}) but did not report a version.`,
+      hint: `Confirm it is Cerefox: curl http://${status.info.host}:${status.info.port}/api/v1/version`,
     };
   }
   return {
     name: "web server",
     status: "ok",
-    detail: `v${status.version ?? PKG_VERSION} on :${status.info.port} (pid ${status.info.pid})`,
+    detail: `v${status.version} on :${status.info.port} (pid ${status.info.pid})`,
   };
 }
 

--- a/packages/memory/src/web/daemon.ts
+++ b/packages/memory/src/web/daemon.ts
@@ -101,8 +101,19 @@ export function isProcessAlive(pid: number): boolean {
   }
 }
 
-/** HTTP-probe the server's /version endpoint; true when it answers 200. */
-async function isResponding(host: string, port: number, timeoutMs = 1_500): Promise<boolean> {
+/**
+ * HTTP-probe the server's /version endpoint.
+ *
+ * Returns the version string the RUNNING process reports, which is not
+ * necessarily this binary's: an in-place `self-update` leaves the old server
+ * running until it is restarted (#252), and that mismatch is what callers
+ * want to surface.
+ */
+async function probeVersion(
+  host: string,
+  port: number,
+  timeoutMs = 1_500,
+): Promise<{ responding: boolean; version: string | null }> {
   const probeHost = host === "0.0.0.0" ? "127.0.0.1" : host;
   try {
     const ctrl = new AbortController();
@@ -111,13 +122,22 @@ async function isResponding(host: string, port: number, timeoutMs = 1_500): Prom
       const resp = await fetch(`http://${probeHost}:${port}/api/v1/version`, {
         signal: ctrl.signal,
       });
-      return resp.ok;
+      if (!resp.ok) return { responding: false, version: null };
+      const body = (await resp.json().catch(() => null)) as { version?: unknown } | null;
+      return {
+        responding: true,
+        version: typeof body?.version === "string" ? body.version : null,
+      };
     } finally {
       clearTimeout(timer);
     }
   } catch {
-    return false;
+    return { responding: false, version: null };
   }
+}
+
+async function isResponding(host: string, port: number, timeoutMs = 1_500): Promise<boolean> {
+  return (await probeVersion(host, port, timeoutMs)).responding;
 }
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
@@ -240,13 +260,13 @@ export async function stopDaemon(): Promise<StopOutcome> {
 export type DaemonStatus =
   | { kind: "stopped" }
   | { kind: "stale"; info: PidInfo }
-  | { kind: "running"; info: PidInfo; responding: boolean };
+  | { kind: "running"; info: PidInfo; responding: boolean; version: string | null };
 
 /** Report daemon status: stopped / stale-pidfile / running(+reachable). */
 export async function statusDaemon(): Promise<DaemonStatus> {
   const info = readPidFile();
   if (!info) return { kind: "stopped" };
   if (!isProcessAlive(info.pid)) return { kind: "stale", info };
-  const responding = await isResponding(info.host, info.port);
-  return { kind: "running", info, responding };
+  const { responding, version } = await probeVersion(info.host, info.port);
+  return { kind: "running", info, responding, version };
 }

--- a/packages/memory/src/web/daemon.ts
+++ b/packages/memory/src/web/daemon.ts
@@ -257,6 +257,18 @@ export async function stopDaemon(): Promise<StopOutcome> {
   return { kind: "stopped", pid: info.pid, forced };
 }
 
+/**
+ * The exact command that restarts a daemon **where it is listening** (#252).
+ *
+ * `cerefox web start` defaults to 127.0.0.1:8000, so a bare
+ * "stop && start" moves any daemon bound elsewhere. Everything that prints
+ * this remedy uses this function, so the three call sites cannot drift.
+ */
+export function restartCommand(host: string, port: number): string {
+  const flags = `${host === "127.0.0.1" ? "" : ` --host ${host}`}${port === 8000 ? "" : ` --port ${port}`}`;
+  return `cerefox web stop && cerefox web start${flags}`;
+}
+
 export type DaemonStatus =
   | { kind: "stopped" }
   | { kind: "stale"; info: PidInfo }

--- a/packages/memory/src/web/server.ts
+++ b/packages/memory/src/web/server.ts
@@ -193,20 +193,32 @@ export function buildApp(ctx: WebContext | null = buildWebContext()): Hono {
     // one stat() per request, and an upgrade is picked up without a restart.
     const indexPath = join(spaDist, "index.html");
     if (existsSync(indexPath)) {
-      let cached: { mtimeMs: number; html: string } | null = null;
-      const readIndex = (): string => {
+      // Keyed on mtime AND size: npm and tar preserve tarball mtimes and some
+      // filesystems store whole seconds, so a same-mtime replacement is not
+      // hypothetical — and it would resurrect exactly the bug this fixes.
+      let cached: { mtimeMs: number; size: number; html: string } | null = null;
+      const readIndex = (): string | null => {
         try {
-          const { mtimeMs } = statSync(indexPath);
-          if (!cached || cached.mtimeMs !== mtimeMs) {
-            cached = { mtimeMs, html: readFileSync(indexPath, "utf8") };
+          const { mtimeMs, size } = statSync(indexPath);
+          if (!cached || cached.mtimeMs !== mtimeMs || cached.size !== size) {
+            cached = { mtimeMs, size, html: readFileSync(indexPath, "utf8") };
           }
         } catch {
           // Mid-upgrade the file can briefly vanish; serve the last good copy.
         }
-        return cached?.html ?? "";
+        return cached?.html ?? null;
       };
       readIndex();
-      app.get("/app/*", (c) => c.html(readIndex()));
+      app.get("/app/*", (c) => {
+        const html = readIndex();
+        // An empty 200 is the same class of lie as the wrong-typed 200 above:
+        // the browser renders a blank page and the log says success. If the
+        // shell cannot be read at all, say so with a status that means it.
+        if (html === null) {
+          return c.text("The web UI could not be read from disk. Restart the server.", 503);
+        }
+        return c.html(html);
+      });
     }
   }
 

--- a/packages/memory/src/web/server.ts
+++ b/packages/memory/src/web/server.ts
@@ -34,7 +34,7 @@ import {
   isLoopbackAddress,
 } from "./auth.ts";
 import { existsSync } from "node:fs";
-import { readFileSync } from "node:fs";
+import { readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { Hono } from "hono";
 import { logger } from "hono/logger";
@@ -174,11 +174,39 @@ export function buildApp(ctx: WebContext | null = buildWebContext()): Hono {
       }),
     );
 
+    // (4b) A missing hashed asset is a 404, never the SPA shell (#252).
+    //
+    // serveStatic calls next() on a miss, so without this an absent
+    // /app/assets/<hash>.js fell through to the catch-all below and was
+    // answered `200 text/html`. The browser asked for a script, got HTML,
+    // executed nothing, and rendered a blank page — while the access log
+    // recorded a 200. A wrong-typed 200 is the worst answer for a script tag.
+    app.get("/app/assets/*", (c) => c.text("Not found", 404));
+
     // (5) SPA catch-all for client-side routing.
+    //
+    // Read per request, not once at startup (#252). `cerefox self-update`
+    // replaces the package in place while a daemon keeps running: a cached
+    // copy then served the PRE-upgrade index.html on every deep route (the
+    // root came from serveStatic, i.e. from disk), pointing the browser at a
+    // bundle the upgrade had deleted. Cached on mtime, so the common case is
+    // one stat() per request, and an upgrade is picked up without a restart.
     const indexPath = join(spaDist, "index.html");
     if (existsSync(indexPath)) {
-      const indexHtml = readFileSync(indexPath, "utf8");
-      app.get("/app/*", (c) => c.html(indexHtml));
+      let cached: { mtimeMs: number; html: string } | null = null;
+      const readIndex = (): string => {
+        try {
+          const { mtimeMs } = statSync(indexPath);
+          if (!cached || cached.mtimeMs !== mtimeMs) {
+            cached = { mtimeMs, html: readFileSync(indexPath, "utf8") };
+          }
+        } catch {
+          // Mid-upgrade the file can briefly vanish; serve the last good copy.
+        }
+        return cached?.html ?? "";
+      };
+      readIndex();
+      app.get("/app/*", (c) => c.html(readIndex()));
     }
   }
 

--- a/packages/memory/test/cli-web-daemon.test.ts
+++ b/packages/memory/test/cli-web-daemon.test.ts
@@ -9,20 +9,24 @@
 
 import { describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const PKG_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const BIN = join(PKG_ROOT, "dist", "bin", "cerefox.js");
 
-function run(args: string[]): { stdout: string; stderr: string; status: number } {
+function run(
+  args: string[],
+  extraEnv: Record<string, string> = {},
+): { stdout: string; stderr: string; status: number } {
   if (!existsSync(BIN)) {
     throw new Error(`Built bin not found at ${BIN}. Run \`bun run build\` first.`);
   }
   const result = spawnSync("node", [BIN, ...args], {
     encoding: "utf8",
-    env: { ...process.env },
+    env: { ...process.env, ...extraEnv },
     timeout: 15_000,
   });
   return {
@@ -53,6 +57,52 @@ describe("cerefox web daemon CLI", () => {
     const { status, stderr } = run(["web", "start", "--port", "notaport"]);
     expect(status).toBe(2);
     expect(stderr).toContain("Invalid --port");
+  });
+
+  // v1.14.2 (#252): a daemon left running across an in-place `self-update`
+  // keeps serving the previous build. `web status` and `doctor` must say so;
+  // silence is what turned a stale daemon into a blank page nobody could
+  // explain. Driven through a stub server + a pidfile in an isolated
+  // CEREFOX_CONFIG_DIR, so it touches neither a store nor the real daemon.
+  test("`web status` flags a daemon serving a different version", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "cfx-web-status-"));
+    // Bun.serve, not node:http: a node:http server hosted from the bun test
+    // process was not reachable from the spawned node child, which cost an
+    // hour of chasing a bug that was in the harness.
+    const stub = Bun.serve({
+      port: 0,
+      fetch: () => Response.json({ version: "0.0.1-stale", git_commit_short: null }),
+    });
+    try {
+      writeFileSync(
+        join(dir, "web.pid"),
+        JSON.stringify({
+          // Our own pid: alive, so the status is "running", not "stale".
+          pid: process.pid,
+          port: stub.port,
+          host: "127.0.0.1",
+          startedAt: new Date().toISOString(),
+        }),
+      );
+      // Async spawn, NOT the spawnSync helper: spawnSync blocks bun's event
+      // loop, so the in-process stub cannot answer the child's probe and the
+      // daemon reads as "alive but not responding". That cost an hour; the
+      // comment is cheaper than the second hour.
+      const proc = Bun.spawn(["node", BIN, "web", "status"], {
+        env: { ...process.env, CEREFOX_CONFIG_DIR: dir },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const stdout = await new Response(proc.stdout).text();
+      expect(await proc.exited).toBe(0);
+      expect(stdout).toContain("running");
+      expect(stdout).toContain("0.0.1-stale");
+      // The remediation has to be in the output, not just the diagnosis.
+      expect(stdout).toContain("cerefox web stop && cerefox web start");
+    } finally {
+      await stub.stop(true);
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   test("`web status` reports a state line (stopped/running/stale)", () => {

--- a/packages/memory/test/web-integration/spa-serving.test.ts
+++ b/packages/memory/test/web-integration/spa-serving.test.ts
@@ -43,16 +43,29 @@ describe("SPA serving after an in-place upgrade (#252)", () => {
   const indexPath = resolveIndexHtml();
   let original: string | null = null;
 
+  /** Restore the artifact even if the runner is interrupted mid-test. */
+  const restore = () => {
+    if (indexPath && original !== null) {
+      try {
+        writeFileSync(indexPath, original);
+      } catch {
+        /* best effort */
+      }
+    }
+  };
+
   beforeAll(async () => {
     if (!indexPath) return;
     original = readFileSync(indexPath, "utf8");
+    for (const sig of ["SIGINT", "SIGTERM"] as const) process.once(sig, restore);
+    process.once("exit", restore);
     server = await spawnWebServer();
   }, LIVE_TEST_BUDGET_MS);
 
   afterAll(async () => {
     // Restore the build artifact before anything else, so a failure mid-test
     // cannot leave a marker in a bundle someone later ships.
-    if (indexPath && original !== null) writeFileSync(indexPath, original);
+    restore();
     if (server) await server.stop();
   }, LIVE_TEST_BUDGET_MS);
 
@@ -75,15 +88,22 @@ describe("SPA serving after an in-place upgrade (#252)", () => {
   liveTest("a rewritten index.html is picked up without restarting", async () => {
     if (!server || !indexPath || original === null) return;
     const marker = `<!-- upgraded ${Date.now()} -->`;
-    writeFileSync(indexPath, original.replace("</head>", `${marker}</head>`));
+    // This writes into the SHIPPED build artifact, so it is restored in a
+    // `finally` here (not only in afterAll, which a failed assertion would
+    // reach but a killed runner would not) and by the signal handlers
+    // registered above. A marker left inside dist/frontend/index.html would
+    // otherwise ride along into a published package.
+    try {
+      writeFileSync(indexPath, original.replace("</head>", `${marker}</head>`));
 
-    // This is the upgrade, simulated: the file changed under a running server.
-    const deep = await (await fetch(`${server.base}/app/settings`)).text();
-    expect(deep).toContain(marker);
-    const root = await (await fetch(`${server.base}/app/`)).text();
-    expect(root).toContain(marker);
-
-    writeFileSync(indexPath, original);
+      // This is the upgrade, simulated: the file changed under a running server.
+      const deep = await (await fetch(`${server.base}/app/settings`)).text();
+      expect(deep).toContain(marker);
+      const root = await (await fetch(`${server.base}/app/`)).text();
+      expect(root).toContain(marker);
+    } finally {
+      writeFileSync(indexPath, original);
+    }
     const afterRestore = await (await fetch(`${server.base}/app/settings`)).text();
     expect(afterRestore).not.toContain(marker);
   });

--- a/packages/memory/test/web-integration/spa-serving.test.ts
+++ b/packages/memory/test/web-integration/spa-serving.test.ts
@@ -1,0 +1,120 @@
+/**
+ * How the web server hands the SPA to a browser (#252).
+ *
+ * Both regressions here were found on a live install after an in-place
+ * `cerefox self-update`, and both were invisible in the access log:
+ *
+ *  1. `index.html` was read ONCE at startup for the SPA catch-all, while
+ *     `/app/` itself came from `serveStatic`, i.e. from disk. An upgrade
+ *     under a running daemon therefore served the NEW shell at the root and
+ *     the PRE-upgrade shell on every deep route, pointing the browser at a
+ *     hashed bundle the upgrade had deleted.
+ *  2. A missing `/app/assets/*` fell through to that catch-all and was
+ *     answered `200 text/html`. The browser asked for a script, got HTML,
+ *     ran nothing, and showed a blank page — logged as a 200.
+ *
+ * The suite touches no store: it spawns the server, reads the SPA it is
+ * serving, and rewrites its own build artifact, restoring it afterwards.
+ */
+
+import { afterAll, beforeAll, describe, expect } from "bun:test";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { LIVE_TEST_BUDGET_MS, liveTest } from "../_live-test.ts";
+
+import { spawnWebServer, type SpawnedServer } from "./_helpers.js";
+
+const PKG_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const REPO_ROOT = join(PKG_ROOT, "..", "..");
+
+/** The same candidates, in the same order, as `resolveSpaDist()`. */
+function resolveIndexHtml(): string | null {
+  for (const dir of [join(PKG_ROOT, "dist", "frontend"), join(REPO_ROOT, "frontend", "dist")]) {
+    const candidate = join(dir, "index.html");
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+describe("SPA serving after an in-place upgrade (#252)", () => {
+  let server: SpawnedServer | null = null;
+  const indexPath = resolveIndexHtml();
+  let original: string | null = null;
+
+  beforeAll(async () => {
+    if (!indexPath) return;
+    original = readFileSync(indexPath, "utf8");
+    server = await spawnWebServer();
+  }, LIVE_TEST_BUDGET_MS);
+
+  afterAll(async () => {
+    // Restore the build artifact before anything else, so a failure mid-test
+    // cannot leave a marker in a bundle someone later ships.
+    if (indexPath && original !== null) writeFileSync(indexPath, original);
+    if (server) await server.stop();
+  }, LIVE_TEST_BUDGET_MS);
+
+  liveTest("the root and a deep route serve the SAME shell", async () => {
+    if (!server || !indexPath) return;
+    const bundleOf = async (path: string) => {
+      const resp = await fetch(`${server!.base}${path}`);
+      expect(resp.status).toBe(200);
+      const html = await resp.text();
+      return /assets\/index-[A-Za-z0-9_-]+\.js/.exec(html)?.[0] ?? html.slice(0, 80);
+    };
+    // The failure mode was these two disagreeing: root from disk, deep route
+    // from a copy read at startup.
+    expect(await bundleOf("/app/trash")).toBe(await bundleOf("/app/"));
+    expect(await bundleOf("/app/document/00000000-0000-0000-0000-000000000000")).toBe(
+      await bundleOf("/app/"),
+    );
+  });
+
+  liveTest("a rewritten index.html is picked up without restarting", async () => {
+    if (!server || !indexPath || original === null) return;
+    const marker = `<!-- upgraded ${Date.now()} -->`;
+    writeFileSync(indexPath, original.replace("</head>", `${marker}</head>`));
+
+    // This is the upgrade, simulated: the file changed under a running server.
+    const deep = await (await fetch(`${server.base}/app/settings`)).text();
+    expect(deep).toContain(marker);
+    const root = await (await fetch(`${server.base}/app/`)).text();
+    expect(root).toContain(marker);
+
+    writeFileSync(indexPath, original);
+    const afterRestore = await (await fetch(`${server.base}/app/settings`)).text();
+    expect(afterRestore).not.toContain(marker);
+  });
+
+  liveTest("a missing hashed asset is a 404, not the SPA shell with a 200", async () => {
+    if (!server) return;
+    // The exact shape of the blank page: the browser requests a bundle that no
+    // longer exists and must be told so, not handed HTML.
+    const resp = await fetch(`${server.base}/app/assets/index-DoesNotExist.js`);
+    expect(resp.status).toBe(404);
+    expect(resp.headers.get("content-type") ?? "").not.toContain("text/html");
+    const body = await resp.text();
+    expect(body).not.toContain("<html");
+    expect(body).not.toContain("<div id=\"root\"");
+  });
+
+  liveTest("a real asset is still served, with a JavaScript content type", async () => {
+    if (!server || !indexPath) return;
+    // The 404 above must not have broken the assets route itself.
+    const html = await (await fetch(`${server.base}/app/`)).text();
+    const bundle = /assets\/index-[A-Za-z0-9_-]+\.js/.exec(html)?.[0];
+    if (!bundle) return;
+    const resp = await fetch(`${server.base}/app/${bundle}`);
+    expect(resp.status).toBe(200);
+    expect(resp.headers.get("content-type") ?? "").toContain("javascript");
+  });
+
+  liveTest("a client-side route still gets the shell, so deep links work", async () => {
+    if (!server) return;
+    const resp = await fetch(`${server.base}/app/projects/abc/documents`);
+    expect(resp.status).toBe(200);
+    expect(await resp.text()).toContain('<div id="root">');
+  });
+});


### PR DESCRIPTION
Closes #252 and #253. Target: v1.14.2.

## #252 — the blank page after `self-update`

Two defects, both confirmed against the maintainer's own `web.log` and both invisible in it:

- `index.html` was read **once at startup** for the SPA catch-all while `/app/` was served from disk, so an in-place upgrade split them: the root got the new shell, every deep route the pre-upgrade one, which referenced a hashed bundle the upgrade had deleted.
- A missing `/app/assets/*` fell through to that catch-all and was answered `200 text/html`. A script tag that receives HTML executes nothing, so the page rendered blank while the log recorded a 200.

Fixes: `index.html` read per request (cached on mtime, so an upgrade needs no restart and root and deep routes cannot disagree); `/app/assets/*` misses return `404 text/plain`; `self-update` prints the restart command when a daemon is still running the previous build; `statusDaemon()` reports the running server's version, which `cerefox web status` and a new `doctor` row compare with the client's.

## #253 — browser tab titles

Every page sets its own title through `usePageTitle()` over a pure `pageTitle()`: the document's title on a document, `Search: <query>`, `Editing: <title>` with a leading dot while unsaved, the project's name, the page name elsewhere, `Cerefox` on the dashboard. The app name is **not** prefixed (tabs truncate from the right, and the favicon already identifies the app). Titles truncate at 60 characters. (An environment-label prefix was built and removed on review: the environment banner already names it on every page, so the title carries nothing server-dependent and the hook makes no request.)

Frontend + web server only: no schema, no Edge Function, no `minSchema` change.

## Test plan

- [x] `bun run typecheck` (all three); frontend lint clean
- [x] `_shared` 610 pass; frontend unit 27 pass (7 new for `pageTitle`)
- [x] New `web-integration/spa-serving.test.ts`, 5 cases: root and deep route serve the same shell; a rewritten `index.html` is picked up with no restart; a missing asset is a 404 and not HTML; a real asset keeps its JavaScript content type; a client-side route still gets the shell
- [x] `cli-web-daemon.test.ts`: `web status` flags a daemon reporting a different version (stub server; the child must be spawned **asynchronously**, since `spawnSync` blocks bun's event loop and starves the stub)
- [x] Package suite against staging: **313 pass / 2 skip / 0 fail**
- [x] Playwright against staging: **23 passed**, including the new tab-title specs
- [x] `doctor` against staging shows `✓ web server  v1.14.1 on :8030 (pid …)`

## Note

While investigating I filed **#254**: `cerefox_search` returns "No results found." when the top hit is larger than `max_bytes`, because the byte budget drops the row and the empty-check returns before the truncation notice. Reproduced on staging. Not in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013PcVjtEzsfTtAxeayzga5u
