### PR TITLE
Strip both content columns and hold the degraded reply to its budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
+### Fixed
+
+- **The degraded search response no longer leaks content or overruns the
+  budget** (#257, a regression in v1.14.2). v1.14.2 made a byte-budget miss
+  return what matched *without* content instead of reporting "no results", but
+  the `cerefox-search` Edge Function stripped only `full_content` — the column
+  `cerefox_search_docs` returns. `cerefox_hybrid_search` and the FTS path
+  return `content`, so in those modes every matched chunk came back with its
+  full text while the response claimed the content had been omitted: 83 KB
+  answered a 3 KB budget. Both columns are stripped now, and the degraded list
+  is held to `max_bytes` on every surface. Also fixed: the below-confidence
+  warning survives into the degraded path, so weak candidates are never
+  presented as confident matches; the truncation footer names at most five
+  held-back documents plus a count instead of all of them; the
+  `cerefox_metadata_search` fallback list is capped the same way and records
+  how many documents matched rather than zero.
 Open roadmap.
 
 ---

--- a/_shared/__tests__/search-byte-budget.test.ts
+++ b/_shared/__tests__/search-byte-budget.test.ts
@@ -122,6 +122,31 @@ describe("cerefox_search never reports an empty store for a budget miss", () => 
     expect(out).toContain("Huge");
   });
 
+  test("a degraded response keeps the below-confidence warning (#257)", async () => {
+    // 28I exists so weak candidates are not read as real matches. Losing that
+    // flag in the degraded path would tell an agent "3 results matched" about
+    // rows that cleared no threshold.
+    const weak = [row("Maybe Related", 30_000, 0.2)].map((r) => ({
+      ...r,
+      below_confidence: true,
+    }));
+    const out = await search.handler(supabase(weak), args({ max_bytes: 1_200 }), ctx);
+    expect(out).toContain("confidence threshold");
+    expect(out).toContain("Maybe Related");
+    expect(out).not.toContain("No results found");
+  });
+
+  test("the truncation footer names a bounded number of dropped documents (#257)", async () => {
+    // Listing every dropped title made the footer grow with match_count and
+    // overrun the budget it was reporting on.
+    const rows = [row("Fits", 50, 9), ...Array.from({ length: 40 }, (_, i) => row(`Dropped ${i}`, 9_000, 1))];
+    const out = await search.handler(supabase(rows), args({ max_bytes: 3_000 }), ctx);
+    expect(out).toContain("1 of 41 result(s) shown");
+    expect(out).toContain("and 35 more");
+    // Bounded: the footer must not carry all forty titles.
+    expect(out).not.toContain("Dropped 39");
+  });
+
   test("everything fitting is unchanged: full content, no notice", async () => {
     const out = await search.handler(supabase([row("Small", 50, 1)]), args(), ctx);
     expect(out).toContain("## Small");

--- a/_shared/mcp-tools/metadata-search.ts
+++ b/_shared/mcp-tools/metadata-search.ts
@@ -107,13 +107,34 @@ async function handler(
       });
       const headerRows = (headers ?? []) as Array<{ document_id: string; title: string }>;
       if (headerRows.length > 0) {
-        return (
+        // The caller asked for a budget; honour it in the answer that explains
+        // the budget. `limit` is caller-supplied, so an uncapped list could be
+        // tens of KB in reply to a 2 KB request (#257).
+        const lead =
           `⚠ ${headerRows.length} document(s) match, but none fit max_bytes=${max_bytes} ` +
           `with include_content. This is NOT an empty result. Listing them without ` +
           `content — raise max_bytes, or read one with cerefox_get_document ` +
-          `(outline: true for structure).\n\n` +
-          headerRows.map((r) => `## ${r.title} [id: ${r.document_id}]`).join("\n")
-        );
+          `(outline: true for structure).`;
+        const lines: string[] = [];
+        let used = new TextEncoder().encode(lead).length;
+        for (const r of headerRows) {
+          const line = `## ${r.title} [id: ${r.document_id}]`;
+          const size = new TextEncoder().encode(line).length + 1;
+          if (used + size > max_bytes) break;
+          lines.push(line);
+          used += size;
+        }
+        logUsage(supabase, {
+          operation: "metadata_search",
+          accessPath: ctx.accessPath,
+          requestor: callerIdentity(args),
+          query_text: JSON.stringify(metadata_filter ?? {}),
+          project_id: projectId,
+          // What matched, not what the budget allowed through (#257).
+          result_count: headerRows.length,
+          extra: { returned: lines.length, degraded: true },
+        });
+        return lines.length > 0 ? `${lead}\n${lines.join("\n")}` : lead;
       }
     }
     return "No documents match the given criteria.";

--- a/_shared/mcp-tools/search.ts
+++ b/_shared/mcp-tools/search.ts
@@ -56,15 +56,26 @@ function headerLine(row: SearchRow): string {
  * still honours the limit the caller asked for; if even one header does not
  * fit, the count and the remedy alone still beat silence.
  */
-function degradedToHeaders(matched: SearchRow[], maxBytes: number): string {
+function degradedToHeaders(
+  matched: SearchRow[],
+  maxBytes: number,
+  belowConfidence: boolean,
+): string {
   const biggest = Math.max(
     ...matched.map((r) => new TextEncoder().encode(JSON.stringify(r)).length),
   );
+  // A degraded response must not silently promote 28I's weak-signal
+  // candidates into real matches: an agent told "N result(s) matched" about
+  // rows that cleared no threshold would trust them.
+  const confidence = belowConfidence
+    ? "None of these cleared the confidence threshold — they are the closest " +
+      "candidates, so judge relevance from the scores. "
+    : "";
   const lead =
     `⚠ ${matched.length} result(s) matched, but none fit max_bytes=${maxBytes} ` +
-    `(the largest is ${biggest.toLocaleString()} bytes). This is NOT an empty ` +
-    `knowledge base. Listing what matched, without content — raise max_bytes to ` +
-    `read it, or read one document with cerefox_get_document (outline: true for ` +
+    `(the largest is ${biggest.toLocaleString()} bytes). ${confidence}This is NOT an ` +
+    `empty knowledge base. Listing what matched, without content — raise max_bytes ` +
+    `to read it, or read one document with cerefox_get_document (outline: true for ` +
     `structure, or section: "## Heading" for one part).`;
 
   const lines: string[] = [];
@@ -211,7 +222,11 @@ async function handler(
   // the headers instead — a few hundred bytes that name what exists and how
   // to read it.
   if (accepted.length === 0) {
-    return degradedToHeaders(matched, max_bytes);
+    return degradedToHeaders(
+      matched,
+      max_bytes,
+      matched.every((r) => r.below_confidence === true),
+    );
   }
 
   const rows = accepted as SearchRow[];
@@ -242,10 +257,16 @@ async function handler(
       `not necessarily absent knowledge.\n\n` + output;
   }
   if (truncated) {
+    // Name what was held back, but boundedly: listing every dropped title
+    // made the footer grow with match_count and overrun the very budget it
+    // was reporting on (#257).
+    const NAMED = 5;
+    const titles = dropped.slice(0, NAMED).map((r) => (r as SearchRow).doc_title ?? "Untitled");
+    const rest = dropped.length - titles.length;
     output +=
       `\n\n[${accepted.length} of ${matched.length} result(s) shown; truncated at ` +
-      `${usedBytes} bytes. ${dropped.length} did not fit: ` +
-      `${dropped.map((r) => (r as SearchRow).doc_title ?? "Untitled").join(", ")}. ` +
+      `${usedBytes} bytes. ${dropped.length} did not fit: ${titles.join(", ")}` +
+      `${rest > 0 ? ` and ${rest} more` : ""}. ` +
       `Raise max_bytes, narrow the query, or lower match_count.]`;
   }
   return output;

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -28,7 +28,18 @@
 ---
 ## Current Focus
 
-**2026-09-08 — v1.14.2 IN PROGRESS** (#252 + #253 merged as PR #255; #254 on
+**2026-09-08 — v1.14.3 IN PROGRESS** (branch `fix/degraded-response-budget`,
+#257): the v1.14.2 degraded-response regression, found by review after the cut.
+The search EF stripped only `full_content`, so hybrid and fts returned full
+chunk text (83 KB against a 3 KB budget) while claiming content was omitted;
+the degraded list was never capped either. Both content columns stripped, the
+list held to the budget everywhere, below-confidence carried into the degraded
+lead, the truncation footer bounded, the metadata fallback capped and logged.
+Staging runs the fixed function; **1.14.3 needs `cerefox server deploy
+--functions-only`** like 1.14.2.
+
+**2026-09-08 — v1.14.2 SHIPPED** (cut `f18ccb0`; npm 1.14.2, ~8 min of CDN lag
+on the tarball after a successful publish). (#252 + #253 merged as PR #255; #254 on
 `fix/search-budget-false-negative`). Three items. (a) The
 stale-SPA bug found on production after `self-update`: `index.html` is now read
 per request (mtime-cached), a missing `/app/assets/*` is a 404 instead of the

--- a/docs/plans/iteration-46-spa-serving-and-tab-titles.md
+++ b/docs/plans/iteration-46-spa-serving-and-tab-titles.md
@@ -152,3 +152,29 @@ longer reads as an empty store in analytics either.
 **Consequence for the release.** 1.14.2 now includes an Edge Function change,
 so the upgrade is `cerefox self-update` **plus** `cerefox server deploy
 --functions-only`, not the client-only story it was before.
+
+## #257 — the degraded response, reviewed after the cut (v1.14.3)
+
+The review of the #254 fix landed after 1.14.2 was already tagged, and it found
+a regression the fix had introduced. The Edge Function's degraded projection
+stripped `full_content`, which is a column of `cerefox_search_docs` (mode
+`docs`) only: `cerefox_hybrid_search` and the FTS path return `content`, so in
+those modes the rest-spread copied every matched chunk **with its text** while
+the response reported `degraded: true` and a note saying content was omitted.
+Measured on staging with `match_count: 20` and `max_bytes: 3000`: docs 14.7 KB,
+hybrid 69 KB, fts 83 KB — the last two carrying full content.
+
+The header list was never capped either, on any surface, so even the correct
+`docs` mode answered a 3 KB budget with 14.7 KB.
+
+Fixed: both content columns stripped, the degraded list held to `max_bytes`
+(Edge Function, `cerefox_search`, and the `cerefox_metadata_search` fallback),
+the 28I below-confidence flag carried into the degraded lead so weak candidates
+are never presented as confident matches, the truncation footer capped at five
+named documents plus a count, the metadata path logging what matched, and the
+Edge Function's orphaned JSDoc and stale response contract corrected.
+
+**Lesson.** The fix for a "reports nothing" bug is a new response shape, and a
+new response shape has to be checked in every mode the tool offers. The
+original change was verified in `docs` mode alone, which is the one mode where
+the column name made it correct.

--- a/packages/memory/test/edge-functions/edge-functions.test.ts
+++ b/packages/memory/test/edge-functions/edge-functions.test.ts
@@ -390,6 +390,45 @@ describe("Edge Functions (live HTTP)", () => {
     });
   });
 
+  // ── cerefox-search: the degraded response (#254, #257) ─────────────────────
+  describe("cerefox-search degraded response", () => {
+    liveTest("a budget miss omits content in EVERY mode and honours the budget (#257)", async () => {
+      // v1.14.2 stripped only `full_content`, which exists in "docs" mode
+      // alone: hybrid and fts return a `content` column, so the degraded
+      // response shipped tens of KB of chunk text while claiming content was
+      // omitted, against a budget of a few KB.
+      const title = uniqueTitle("Degraded Modes");
+      const r = await invokeOk("cerefox-ingest", {
+        title,
+        content: `# Degraded\n\n${"lorem ipsum dolor sit amet ".repeat(400)}`,
+        author: "e2e-ef-test",
+        author_type: "agent",
+      });
+      track(r.document_id);
+
+      for (const mode of ["docs", "hybrid", "fts"]) {
+        const body = (await invokeOk("cerefox-search", {
+          query: "lorem ipsum dolor",
+          mode,
+          match_count: 20,
+          max_bytes: 3000,
+        })) as {
+          degraded?: boolean;
+          matched?: number;
+          results?: Array<Record<string, unknown>>;
+        };
+        if (!body.degraded) continue; // nothing oversized in this store: nothing to assert
+        expect(body.matched ?? 0).toBeGreaterThan(0);
+        for (const row of body.results ?? []) {
+          expect(row.full_content).toBeUndefined();
+          expect(row.content).toBeUndefined();
+        }
+        // The answer that explains the budget must itself respect it.
+        expect(JSON.stringify(body.results ?? []).length).toBeLessThanOrEqual(3000);
+      }
+    });
+  });
+
   // ── cerefox-metadata-search ────────────────────────────────────────────────
   describe("cerefox-metadata-search", () => {
     liveTest("returns matches for a metadata filter", async () => {

--- a/supabase/functions/cerefox-search/index.ts
+++ b/supabase/functions/cerefox-search/index.ts
@@ -36,7 +36,14 @@ import { applyByteBudget } from "../../../_shared/mcp-tools/_utils.ts";
  *                                      `truncated` flag when results were dropped.
  *
  * Response: { results: [...], query, mode, match_count, project_name?,
- *             truncated: boolean, response_bytes: number }
+ *             truncated: boolean, response_bytes: number,
+ *             matched: number, degraded: boolean, note?: string }
+ *
+ * `matched` is how many results the query found, before the byte budget.
+ * `degraded` is true when everything that matched was larger than max_bytes:
+ * the items then carry NO content, they name what exists so the caller can
+ * re-ask with a larger budget. An empty `results` with `degraded: true` is
+ * never "nothing was found" — that is `matched: 0` (#254, #257).
  *
  * Example agent prompt:
  *   "Invoke the cerefox-search edge function with query='knowledge management'
@@ -150,14 +157,6 @@ async function lookupProjectId(
   return data[0].id;
 }
 
-/**
- * Apply a byte budget to an array of result rows.
- *
- * Each row is serialised to JSON to measure its size. Rows are included in
- * order until the next row would push the running total over `maxBytes`.
- * Rows are always kept or dropped whole — content is never truncated
- * mid-document. Returns the accepted rows and a `truncated` flag.
- */
 const headers = {
   "Content-Type": "application/json",
   "Access-Control-Allow-Origin": "*",
@@ -362,10 +361,20 @@ Deno.serve(async (req: Request) => {
   // knowledge does not exist" to whatever is on the other end, so send the
   // rows WITHOUT their content instead: the caller learns what matched, how
   // big it is, and can re-ask with a larger budget or fetch one document.
+  //
+  // Both content columns have to go: `cerefox_search_docs` (mode "docs")
+  // returns `full_content`, while `cerefox_hybrid_search` and the FTS RPC
+  // return `content`. Stripping one of them shipped in v1.14.2 and returned
+  // 83 KB of chunk text against a 3 KB budget while the response claimed the
+  // content had been omitted (#257).
   const degraded = accepted.length === 0 && matched.length > 0;
-  const results = degraded
-    ? matched.map(({ full_content: _omitted, ...header }) => header)
-    : accepted;
+  const headerRows = matched.map(
+    ({ full_content: _full, content: _chunk, ...header }) => header,
+  );
+  // And the headers themselves are held to the budget the caller asked for:
+  // a `match_count` of 200 makes even a content-free list large.
+  const listed = degraded ? applyByteBudget(headerRows, max_bytes).accepted : [];
+  const results = degraded ? listed : accepted;
 
   // Fire-and-forget usage logging (never blocks the response)
   Promise.resolve(supabase.rpc("cerefox_log_usage", {
@@ -395,7 +404,13 @@ Deno.serve(async (req: Request) => {
         ? {
             note:
               `${matched.length} result(s) matched but none fit max_bytes=${max_bytes}; ` +
-              `content omitted. Raise max_bytes, or fetch one document with cerefox-get-document.`,
+              `content omitted${
+                listed.length < matched.length
+                  ? `, and only ${listed.length} of them are listed here` +
+                    " (the rest did not fit either)"
+                  : ""
+              }. This is NOT an empty result. Raise max_bytes, or fetch one ` +
+              `document with cerefox-get-document.`,
           }
         : {}),
     }),


### PR DESCRIPTION
Closes #257. Target: v1.14.3. **A regression in v1.14.2**, found by the review of #256 after that release was cut.

## What went wrong

v1.14.2 made a byte-budget miss return what matched *without* content instead of reporting "no results". The Edge Function stripped only `full_content`, which is a column of `cerefox_search_docs` (mode `docs`). `cerefox_hybrid_search` and the FTS path return `content`, so in those modes the rest-spread copied every matched chunk **with its full text** while the response reported `degraded: true` and a note saying content had been omitted.

Measured against staging (`match_count: 20`, `max_bytes: 3000`), before:

| mode | rows with content | response |
|---|---|---|
| docs | 0 | 14,712 bytes |
| hybrid | 20 | 68,963 bytes |
| fts | 20 | 83,255 bytes |

The header list was never capped either, which is why even the correct `docs` mode answered a 3 KB budget with 14.7 KB.

After, on the same store: 0 rows with content in every mode, and `results` inside the budget (3,375 / 3,260 / 3,033 bytes total including the response envelope).

## Also fixed, from the same review

- **The below-confidence signal survives the degraded path.** When every matched row is a 28I weak-signal fallback and none fit the budget, the lead now says so instead of announcing "N result(s) matched" about rows that cleared no threshold.
- **The truncation footer is bounded**: five named documents plus "and N more", rather than every dropped title, which made the footer grow with `match_count` and overrun the budget it was reporting on.
- **The `cerefox_metadata_search` fallback list is capped** to `max_bytes` and now logs how many documents matched rather than zero.
- The Edge Function's orphaned JSDoc block and its stale response contract (`matched` / `degraded` / `note`) are corrected.

## Test plan

- [x] `bun run typecheck`; `_shared` **620 pass** (2 new: the below-confidence warning survives a degraded reply; the footer names a bounded set)
- [x] Package suite against staging: **313 pass / 2 skip / 0 fail**
- [x] Fixed function deployed to staging; live EF suite **23 pass / 0 fail**, including a new case that runs all three modes and asserts no `content`, no `full_content`, and `results` within the budget
- [x] Direct probe against staging, before and after, table above

## Release impact

Same as 1.14.2: `cerefox self-update` **plus** `cerefox server deploy --functions-only`. No schema change. Staging currently runs this branch's function, so it is ahead of `main` until the cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013PcVjtEzsfTtAxeayzga5u