### PR TITLE
Render the content column each search mode actually returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ### Fixed
 
+- **Search modes `hybrid` and `fts` returned titles with empty bodies over
+  MCP** (#259). `cerefox_search_docs` returns `full_content`; the two chunk
+  RPCs return `content`, and the shared renderer read only the first, so every
+  chunk-mode result arrived as a heading with nothing under it (218 bytes
+  against 22,689 for the same query in `docs` mode). The byte budget measured
+  the text it then declined to print, so oversized chunk rows were dropped on
+  the basis of content the caller never received. Present since the handlers
+  moved into `_shared/mcp-tools/`; it survived because `docs` is the default
+  mode and the CLI and web UI each render chunks correctly on their own.
+- **A capped degraded reply can no longer come back empty** (#259): at least
+  one header always survives, since an empty `results` is the "nothing was
+  found" shape #254 exists to prevent. `response_bytes` now measures what is
+  actually returned rather than the content-bearing set a degraded reply does
+  not contain, `cerefox_metadata_search` writes one usage-log row carrying the
+  matched count instead of two, and the GPT Actions OpenAPI block (**4.2.0**)
+  says to read `matched`, not `results.length`.
+
+### Fixed
+
 - **The degraded search response no longer leaks content or overruns the
   budget** (#257, a regression in v1.14.2). v1.14.2 made a byte-budget miss
   return what matched *without* content instead of reporting "no results", but
@@ -25,6 +44,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
   held-back documents plus a count instead of all of them; the
   `cerefox_metadata_search` fallback list is capped the same way and records
   how many documents matched rather than zero.
+
 Open roadmap.
 
 ---

--- a/_shared/__tests__/search-byte-budget.test.ts
+++ b/_shared/__tests__/search-byte-budget.test.ts
@@ -82,6 +82,55 @@ describe("applyByteBudget", () => {
   });
 });
 
+/** A chunk row, as `cerefox_hybrid_search` and `cerefox_fts_search` return one. */
+function chunkRow(title: string, text: string, score: number) {
+  return {
+    document_id: `id-${title}`,
+    chunk_id: `chunk-${title}`,
+    doc_title: title,
+    content: text, // NOT full_content: that column belongs to the docs-mode RPC
+    heading_path: [title, "Section"],
+    score,
+  };
+}
+
+describe("every search mode renders its own content column (#259)", () => {
+  test("a chunk row is not rendered as an empty body", async () => {
+    // The docs-mode RPC returns `full_content`; hybrid and fts return
+    // `content`. Reading only the first rendered every chunk result as a
+    // title with nothing under it, over both MCP transports, for as long as
+    // the shared handlers have existed.
+    //
+    // Only `fts` is exercised here: `hybrid` embeds the query first and would
+    // need a live embedder, but it renders through the same code path, and
+    // the live Edge Function suite covers all three modes.
+    const out = await search.handler(
+      supabase([chunkRow("Contact", "CHUNK BODY TEXT", 0.9)]),
+      args({ mode: "fts" }),
+      ctx,
+    );
+    expect(out).toContain("## Contact");
+    expect(out).toContain("CHUNK BODY TEXT");
+  });
+
+  test("docs mode is unchanged", async () => {
+    const out = await search.handler(supabase([row("Doc", 40, 1)]), args(), ctx);
+    expect(out).toContain("x".repeat(40));
+  });
+
+  test("a chunk row too large for the budget degrades instead of vanishing", async () => {
+    // The budget always measured `content`; only the renderer ignored it, so
+    // a big chunk could empty the result set AND print nothing.
+    const out = await search.handler(
+      supabase([chunkRow("Big", "y".repeat(30_000), 0.9)]),
+      args({ mode: "fts", max_bytes: 2_000 }),
+      ctx,
+    );
+    expect(out).not.toContain("No results found");
+    expect(out).toContain("Big");
+  });
+});
+
 describe("cerefox_search never reports an empty store for a budget miss", () => {
   test("matched but nothing fits: headers, not \"No results found.\"", async () => {
     const supabase = clientReturning([row("Contact - Josh Cohen", 20_000, 2.9)]);

--- a/_shared/mcp-tools/metadata-search.ts
+++ b/_shared/mcp-tools/metadata-search.ts
@@ -84,14 +84,20 @@ async function handler(
     content: string | null;
   }>;
 
-  logUsage(supabase, {
-    operation: "metadata_search",
-    accessPath: ctx.accessPath,
-    requestor: callerIdentity(args),
-    query_text: JSON.stringify(metadata_filter ?? {}),
-    project_id: projectId,
-    result_count: rows.length,
-  });
+  // Logged once, AFTER the degraded branch below may have found the real
+  // count: firing here unconditionally wrote a `result_count: 0` row for
+  // every budget-wiped search, and adding a second row in the branch made
+  // analytics double-count them (#259).
+  const log = (result_count: number, extra?: Record<string, unknown>) =>
+    logUsage(supabase, {
+      operation: "metadata_search",
+      accessPath: ctx.accessPath,
+      requestor: callerIdentity(args),
+      query_text: JSON.stringify(metadata_filter ?? {}),
+      project_id: projectId,
+      result_count,
+      ...(extra ? { extra } : {}),
+    });
 
   if (rows.length === 0) {
     // The RPC applies the byte budget server-side by stopping at the first row
@@ -124,21 +130,15 @@ async function handler(
           lines.push(line);
           used += size;
         }
-        logUsage(supabase, {
-          operation: "metadata_search",
-          accessPath: ctx.accessPath,
-          requestor: callerIdentity(args),
-          query_text: JSON.stringify(metadata_filter ?? {}),
-          project_id: projectId,
-          // What matched, not what the budget allowed through (#257).
-          result_count: headerRows.length,
-          extra: { returned: lines.length, degraded: true },
-        });
+        // What matched, not what the budget allowed through (#257).
+        log(headerRows.length, { returned: lines.length, degraded: true });
         return lines.length > 0 ? `${lead}\n${lines.join("\n")}` : lead;
       }
     }
+    log(0);
     return "No documents match the given criteria.";
   }
+  log(rows.length);
 
   // The review status is a column of a feature that may be off (#241); when
   // it is, an agent should not see "approved" and wonder what it means.

--- a/_shared/mcp-tools/search.ts
+++ b/_shared/mcp-tools/search.ts
@@ -27,7 +27,10 @@ import { AUTHOR_PARAM_READ, callerIdentity } from "./identity.ts";
 interface SearchRow {
   document_id?: string;
   doc_title?: string;
+  /** Document-level modes (`docs`) return this… */
   full_content?: string;
+  /** …while `hybrid` and `fts` return the chunk text under this name. */
+  content?: string;
   best_score?: number;
   score?: number;
   is_partial?: boolean;
@@ -35,6 +38,11 @@ interface SearchRow {
   total_chars?: number;
   content_hash?: string;
   below_confidence?: boolean;
+}
+
+/** The row's text, under whichever column name this search mode returns. */
+export function rowContent(row: SearchRow): string {
+  return row.full_content ?? row.content ?? "";
 }
 
 /** `## Title [id: …] (score: …) -- 20,297 chars` — everything but the content. */
@@ -246,7 +254,11 @@ async function handler(
       : "";
     // content_hash = the concurrency token for cerefox_ingest updates (iter-32).
     const hash = row.content_hash ? `\nhash: ${row.content_hash}` : "";
-    return `## ${title}${docId}${score}${partial}${hash}\n\n${row.full_content ?? ""}`;
+    // Whichever column this mode returns (#259). `cerefox_search_docs` gives
+    // `full_content`; `cerefox_hybrid_search` and `cerefox_fts_search` give
+    // `content`, and reading only the first rendered every hybrid/fts result
+    // as a title with an empty body.
+    return `## ${title}${docId}${score}${partial}${hash}\n\n${rowContent(row)}`;
   });
 
   let output = parts.join("\n\n---\n\n");

--- a/docs/guides/connect-agents.md
+++ b/docs/guides/connect-agents.md
@@ -638,7 +638,7 @@ In the action editor, paste this schema (replace `<your-project-ref>`):
 openapi: 3.1.0
 info:
   title: Cerefox Knowledge Base
-  version: 4.1.0
+  version: 4.2.0
 servers:
   - url: https://<your-project-ref>.supabase.co/functions/v1
 paths:
@@ -713,9 +713,11 @@ paths:
             chunk_count, total_chars, best_score, is_partial.
             matched is how many results the query found, before the byte budget.
             When degraded is true, everything that matched was larger than max_bytes, so the
-            items carry NO full_content — they name what exists so you can re-ask with a
-            larger max_bytes or fetch one document. An empty results array with degraded
-            true is never "nothing was found"; results is empty only when matched is 0.
+            items carry NO content of any kind — they name what exists so you can re-ask with
+            a larger max_bytes or fetch one document. That header list is itself capped to
+            max_bytes, so it may be a SUBSET of matched (at least one item is always
+            returned). Read matched, never results.length, to know how much the query found:
+            "nothing was found" is matched == 0.
             is_partial is true when the document exceeded the small-to-big threshold — in that
             case full_content contains matched chunks plus their neighbours rather than the
             complete document, and total_chars still reflects the full document size.

--- a/supabase/functions/cerefox-search/index.ts
+++ b/supabase/functions/cerefox-search/index.ts
@@ -368,13 +368,26 @@ Deno.serve(async (req: Request) => {
   // 83 KB of chunk text against a 3 KB budget while the response claimed the
   // content had been omitted (#257).
   const degraded = accepted.length === 0 && matched.length > 0;
-  const headerRows = matched.map(
-    ({ full_content: _full, content: _chunk, ...header }) => header,
-  );
   // And the headers themselves are held to the budget the caller asked for:
-  // a `match_count` of 200 makes even a content-free list large.
-  const listed = degraded ? applyByteBudget(headerRows, max_bytes).accepted : [];
+  // a `match_count` of 200 makes even a content-free list large. At least one
+  // survives regardless: an empty `results` is the "nothing was found" shape
+  // #254 exists to prevent, and a header row can exceed a very small budget
+  // on its own (#259).
+  const listed = degraded
+    ? (() => {
+        const headerRows = matched.map(
+          ({ full_content: _full, content: _chunk, ...header }) => header,
+        );
+        const fitted = applyByteBudget(headerRows, max_bytes).accepted;
+        return fitted.length > 0 ? fitted : headerRows.slice(0, 1);
+      })()
+    : [];
   const results = degraded ? listed : accepted;
+  // What is actually being returned, which on a degraded response is the
+  // header list rather than the (empty) content-bearing set.
+  const responseBytes = degraded
+    ? new TextEncoder().encode(JSON.stringify(results)).length
+    : usedBytes;
 
   // Fire-and-forget usage logging (never blocks the response)
   Promise.resolve(supabase.rpc("cerefox_log_usage", {
@@ -397,7 +410,7 @@ Deno.serve(async (req: Request) => {
       project_name: project_name ?? null,
       metadata_filter: metadata_filter ?? null,
       truncated,
-      response_bytes: usedBytes,
+      response_bytes: responseBytes,
       matched: matched.length,
       degraded,
       ...(degraded


### PR DESCRIPTION
Closes #259 and the remaining findings from the review of #258. Target: v1.14.3 (hold the cut for this).

## The headline bug, and it predates this release

Over both MCP transports, `cerefox_search` with `mode: "hybrid"` or `"fts"` returned every result's header with **an empty body**. Measured on staging, same query and `match_count`:

| mode | before | after |
|---|---|---|
| docs | 22,689 bytes | 22,689 bytes |
| hybrid | 218 bytes, 0 body chars | 6,127 bytes |
| fts | 218 bytes, 0 body chars | 6,127 bytes |

`cerefox_search_docs` returns `full_content`; `cerefox_hybrid_search` and `cerefox_fts_search` return `content`. The shared renderer emitted `${row.full_content ?? ""}`. The byte budget measured the row's true size, including the `content` it then declined to print, so oversized chunk rows were also dropped on the basis of text nobody received. Present since the handlers moved into `_shared/mcp-tools/` (iter-22).

**Why nobody saw it**: `docs` is the default mode and is what every guide, agent instruction and test uses; the CLI (`doc.full_content` vs `chunk.content`) and the web UI (`isDocResult()` with separate types) each render chunks correctly on their own, so checking a chunk mode in a terminal or a browser looks right; and the tests that pass `--mode fts` run through the CLI's renderer, so nothing ever compared a chunk mode's MCP output against its input.

## The rest of the review of #258

- **A capped degraded reply could come back empty** (`results: []` with `matched > 0`), which is exactly the "nothing was found" shape #254 exists to prevent, since `max_bytes` has no floor and a header row can be 500-1500 bytes. At least one header now always survives. Verified: `max_bytes: 200` returns 1 header rather than 0.
- **`response_bytes` was 0 on every degraded reply**, because it measured the content-bearing set that a degraded reply by definition does not contain, while the guide documents it as the bytes in `results`. It now measures what is returned (verified: reported equals actual, in every mode).
- **`cerefox_metadata_search` wrote two usage-log rows** on the degraded path and a `result_count: 0` row on the very path #254 was fixing. One row now, carrying the matched count.
- **The GPT Actions block contradicted the function**: it said `results` is empty only when `matched` is 0, which capping made untrue. It now says the list is capped, may be a subset, always has at least one item, and that `matched` is the field to read. Bumped to **4.2.0**.
- `headerRows` is built only on the degraded path, and the CHANGELOG paragraph break is fixed.

## Test plan

- [x] `bun run typecheck`; `_shared` **623 pass** (3 new: a chunk row renders its body, docs mode unchanged, an oversized chunk row degrades rather than vanishing)
- [x] Package suite against staging: **313 pass / 2 skip / 0 fail**
- [x] Function deployed to staging; live EF + remote MCP: **49 pass / 0 fail**
- [x] Probes against staging, tables above: all three MCP modes render content; the degraded reply keeps at least one header at `max_bytes: 200`; `response_bytes` matches the real payload in every mode

## Release impact

Unchanged from 1.14.3's existing scope: `cerefox self-update` plus `cerefox server deploy --functions-only`. No schema change. Staging runs this branch's function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013PcVjtEzsfTtAxeayzga5u