### PR TITLE
Name the section a chunk result came from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
   the basis of content the caller never received. Present since the handlers
   moved into `_shared/mcp-tools/`; it survived because `docs` is the default
   mode and the CLI and web UI each render chunks correctly on their own.
+- **A chunk-mode result now names its section** (#261). `hybrid` and `fts`
+  return several chunks of the same document, which arrived as identical
+  headings with different bodies once the bodies started printing; the heading
+  now carries the section path and the chunk index, as the CLI and web UI
+  already did. Also from that review: the metadata-search usage row survives a
+  failing fallback probe, the search Edge Function's docblock and the OpenAPI
+  request-side text match the one-header fallback, and a unit test that claimed
+  to cover `docs` mode (it could not: the shared helper pins `fts`) now asserts
+  the column resolver directly.
 - **A capped degraded reply can no longer come back empty** (#259): at least
   one header always survives, since an empty `results` is the "nothing was
   found" shape #254 exists to prevent. `response_bytes` now measures what is
@@ -27,8 +36,6 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
   not contain, `cerefox_metadata_search` writes one usage-log row carrying the
   matched count instead of two, and the GPT Actions OpenAPI block (**4.2.0**)
   says to read `matched`, not `results.length`.
-
-### Fixed
 
 - **The degraded search response no longer leaks content or overruns the
   budget** (#257, a regression in v1.14.2). v1.14.2 made a byte-budget miss

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,14 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
   return several chunks of the same document, which arrived as identical
   headings with different bodies once the bodies started printing; the heading
   now carries the section path and the chunk index, as the CLI and web UI
-  already did. Also from that review: the metadata-search usage row survives a
-  failing fallback probe, the search Edge Function's docblock and the OpenAPI
-  request-side text match the one-header fallback, and a unit test that claimed
-  to cover `docs` mode (it could not: the shared helper pins `fts`) now asserts
-  the column resolver directly.
+  already did, in the rendered path, the degraded one and the truncation
+  footer alike. Also from those reviews: a failed metadata-search fallback
+  probe no longer answers "no documents match" — supabase-js returns errors in
+  the result rather than throwing, so the probe's failure was being read as an
+  empty store; the search Edge Function's docblock and the OpenAPI
+  request-side text match the one-header fallback; and a unit test that
+  claimed to cover `docs` mode (it could not: the shared helper pins `fts`)
+  asserts the column resolver directly.
 - **A capped degraded reply can no longer come back empty** (#259): at least
   one header always survives, since an empty `results` is the "nothing was
   found" shape #254 exists to prevent. `response_bytes` now measures what is

--- a/_shared/__tests__/search-byte-budget.test.ts
+++ b/_shared/__tests__/search-byte-budget.test.ts
@@ -125,6 +125,38 @@ describe("every search mode renders its own content column (#259)", () => {
     expect(rowContent({})).toBe("");
   });
 
+  test("only the LEADING path element is dropped when it repeats the title", async () => {
+    // A section legitimately named after its document must still appear:
+    // dropping every matching element produced a breadcrumb that did not
+    // match the document's structure (#261).
+    const out = await search.handler(
+      supabase([
+        {
+          ...chunkRow("Release Process", "BODY", 0.9),
+          heading_path: ["Release Process", "Release Process", "Steps"],
+          chunk_index: 2,
+        },
+      ]),
+      args({ mode: "fts" }),
+      ctx,
+    );
+    expect(out).toContain("## Release Process › Release Process › Steps");
+  });
+
+  test("the degraded path names sections too, since it is the whole answer", async () => {
+    // Five chunks of one document, none fitting: without the section each
+    // header line would be the same string (#261).
+    const chunks = [0, 1, 2].map((i) => ({
+      ...chunkRow("Doc", "z".repeat(20_000), 0.9 - i / 10),
+      heading_path: ["Doc", `Section ${i}`],
+      chunk_index: i,
+    }));
+    const out = await search.handler(supabase(chunks), args({ mode: "fts", max_bytes: 2_000 }), ctx);
+    expect(out).toContain("Doc › Section 0");
+    expect(out).toContain("Doc › Section 1");
+    expect(out).toContain("Doc › Section 2");
+  });
+
   test("a chunk result names its section, not just the document", async () => {
     // Chunk RPCs return several chunks OF THE SAME document, so identical
     // headings would leave an agent unable to tell them apart (#261).

--- a/_shared/__tests__/search-byte-budget.test.ts
+++ b/_shared/__tests__/search-byte-budget.test.ts
@@ -19,6 +19,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { applyByteBudget } from "../mcp-tools/_utils.ts";
+import { rowContent } from "../mcp-tools/search.ts";
 import { TOOLS_BY_NAME } from "../mcp-tools/index.ts";
 import type { MCPSupabaseClient, ToolContext } from "../mcp-tools/types.ts";
 
@@ -113,9 +114,40 @@ describe("every search mode renders its own content column (#259)", () => {
     expect(out).toContain("CHUNK BODY TEXT");
   });
 
-  test("docs mode is unchanged", async () => {
-    const out = await search.handler(supabase([row("Doc", 40, 1)]), args(), ctx);
-    expect(out).toContain("x".repeat(40));
+  test("the resolver reads either column, and prefers the document one", () => {
+    // `args()` pins mode "fts" (every other mode needs an embedder), so the
+    // docs-mode branch cannot be exercised through the handler here. Assert
+    // the resolver itself rather than a test that only looks like it covers
+    // both shapes (#261).
+    expect(rowContent({ full_content: "DOC BODY" })).toBe("DOC BODY");
+    expect(rowContent({ content: "CHUNK BODY" })).toBe("CHUNK BODY");
+    expect(rowContent({ full_content: "DOC", content: "CHUNK" })).toBe("DOC");
+    expect(rowContent({})).toBe("");
+  });
+
+  test("a chunk result names its section, not just the document", async () => {
+    // Chunk RPCs return several chunks OF THE SAME document, so identical
+    // headings would leave an agent unable to tell them apart (#261).
+    const out = await search.handler(
+      supabase([
+        // heading_path as the RPC returns it: document title first.
+        { ...chunkRow("Doc", "FIRST", 0.9), heading_path: ["Doc", "Intro"], chunk_index: 0 },
+        { ...chunkRow("Doc", "SECOND", 0.8), heading_path: ["Doc", "Details"], chunk_index: 4 },
+        // No heading at all: the index is what tells the two apart.
+        { ...chunkRow("Doc", "THIRD", 0.7), heading_path: [], title: "", chunk_index: 9 },
+      ]),
+      args({ mode: "fts" }),
+      ctx,
+    );
+    // The document title is not repeated, and each block names its section.
+    expect(out).toContain("## Doc › Intro");
+    expect(out).toContain("## Doc › Details");
+    expect(out).not.toContain("Doc › Doc");
+    expect(out).toContain("(chunk 0)");
+    expect(out).toContain("(chunk 9)");
+    expect(out).toContain("FIRST");
+    expect(out).toContain("SECOND");
+    expect(out).toContain("THIRD");
   });
 
   test("a chunk row too large for the budget degrades instead of vanishing", async () => {

--- a/_shared/mcp-tools/metadata-search.ts
+++ b/_shared/mcp-tools/metadata-search.ts
@@ -106,11 +106,21 @@ async function handler(
     // without content before reporting nothing: an agent that is told "no
     // documents" stops looking, and here that would be false.
     if (include_content && max_bytes !== null) {
-      const { data: headers } = await supabase.rpc("cerefox_metadata_search", {
-        ...params,
-        p_include_content: false,
-        p_max_bytes: null,
-      });
+      // A failure here must not swallow the usage row: deferring the log so
+      // it can carry the real count meant a rejected fallback left no trace of
+      // the call at all, and that is the hardest failure to diagnose later
+      // (#261).
+      let headers: unknown;
+      try {
+        ({ data: headers } = await supabase.rpc("cerefox_metadata_search", {
+          ...params,
+          p_include_content: false,
+          p_max_bytes: null,
+        }));
+      } catch (err) {
+        log(0, { degraded_probe_failed: true });
+        throw err;
+      }
       const headerRows = (headers ?? []) as Array<{ document_id: string; title: string }>;
       if (headerRows.length > 0) {
         // The caller asked for a budget; honour it in the answer that explains

--- a/_shared/mcp-tools/metadata-search.ts
+++ b/_shared/mcp-tools/metadata-search.ts
@@ -106,20 +106,24 @@ async function handler(
     // without content before reporting nothing: an agent that is told "no
     // documents" stops looking, and here that would be false.
     if (include_content && max_bytes !== null) {
-      // A failure here must not swallow the usage row: deferring the log so
-      // it can carry the real count meant a rejected fallback left no trace of
-      // the call at all, and that is the hardest failure to diagnose later
-      // (#261).
-      let headers: unknown;
-      try {
-        ({ data: headers } = await supabase.rpc("cerefox_metadata_search", {
-          ...params,
-          p_include_content: false,
-          p_max_bytes: null,
-        }));
-      } catch (err) {
+      // supabase-js RESOLVES with `{ data: null, error }` for PostgREST
+      // failures and for network errors; it does not throw. A try/catch here
+      // was dead code, and worse: `headers` came back null, the branch below
+      // was skipped, and the handler answered "No documents match the given
+      // criteria" — the exact false-empty this branch exists to prevent
+      // (#261). Read the error, and say what is actually known.
+      const { data: headers, error: probeError } = await supabase.rpc(
+        "cerefox_metadata_search",
+        { ...params, p_include_content: false, p_max_bytes: null },
+      );
+      if (probeError) {
         log(0, { degraded_probe_failed: true });
-        throw err;
+        return (
+          `⚠ Nothing fit max_bytes=${max_bytes} with include_content, and the ` +
+          `follow-up query that lists what matched failed: ${probeError.message}. ` +
+          `This is NOT a confirmed empty result — retry with a larger max_bytes, ` +
+          `or with include_content: false.`
+        );
       }
       const headerRows = (headers ?? []) as Array<{ document_id: string; title: string }>;
       if (headerRows.length > 0) {

--- a/_shared/mcp-tools/search.ts
+++ b/_shared/mcp-tools/search.ts
@@ -31,6 +31,12 @@ interface SearchRow {
   full_content?: string;
   /** …while `hybrid` and `fts` return the chunk text under this name. */
   content?: string;
+  /** Chunk-mode identity: the RPCs return several chunks OF THE SAME document. */
+  chunk_id?: string;
+  chunk_index?: number;
+  /** The chunk's own heading, and its full path from the document root. */
+  title?: string;
+  heading_path?: string[];
   best_score?: number;
   score?: number;
   is_partial?: boolean;
@@ -245,8 +251,21 @@ async function handler(
   const belowConfidence = rows.length > 0 && rows.every((r) => r.below_confidence === true);
 
   const parts: string[] = rows.map((row) => {
-    const title = row.doc_title ?? "Untitled";
+    // Name the section for a chunk result. The chunk RPCs do NOT dedupe by
+    // document, so several chunks of one document would otherwise arrive as
+    // identical headings with different bodies, and an agent could not tell
+    // which section it got, or that they were one document (#261). Both other
+    // renderers already carry this; the MCP one was the exception.
+    //
+    // `heading_path` starts WITH the document title, so it is dropped here
+    // rather than printed twice. The chunk index disambiguates the case that
+    // is left: several untitled chunks of one document.
+    const doc = row.doc_title ?? "Untitled";
+    const path = (row.heading_path ?? []).filter((h) => h && h !== doc);
+    const section = path.length ? path.join(" › ") : row.title && row.title !== doc ? row.title : "";
+    const title = `${doc}${section ? ` › ${section}` : ""}`;
     const docId = row.document_id ? ` [id: ${row.document_id}]` : "";
+    const chunk = row.chunk_index != null ? ` (chunk ${row.chunk_index})` : "";
     const rawScore = row.best_score ?? row.score;
     const score = rawScore != null ? ` (score: ${rawScore.toFixed(3)})` : "";
     const partial = row.is_partial
@@ -258,7 +277,7 @@ async function handler(
     // `full_content`; `cerefox_hybrid_search` and `cerefox_fts_search` give
     // `content`, and reading only the first rendered every hybrid/fts result
     // as a title with an empty body.
-    return `## ${title}${docId}${score}${partial}${hash}\n\n${rowContent(row)}`;
+    return `## ${title}${docId}${chunk}${score}${partial}${hash}\n\n${rowContent(row)}`;
   });
 
   let output = parts.join("\n\n---\n\n");

--- a/_shared/mcp-tools/search.ts
+++ b/_shared/mcp-tools/search.ts
@@ -51,15 +51,39 @@ export function rowContent(row: SearchRow): string {
   return row.full_content ?? row.content ?? "";
 }
 
+/**
+ * `Document Title › Section` for a chunk row, `Document Title` for a document
+ * row, plus the ids that identify it.
+ *
+ * The chunk RPCs return several chunks OF THE SAME document, so without the
+ * section and the index those results are indistinguishable (#261). Shared by
+ * the rendered path and the degraded one, where identical headings would be
+ * the entire answer.
+ */
+function rowHeading(row: SearchRow): string {
+  const doc = row.doc_title ?? "Untitled";
+  // `heading_path` normally opens with the document's own H1, so the FIRST
+  // element is dropped when it repeats the title. Only the first: a section
+  // legitimately named after the document must still appear (#261).
+  const path = [...(row.heading_path ?? [])];
+  if (path.length > 0 && path[0] === doc) path.shift();
+  const section = path.length
+    ? path.filter(Boolean).join(" › ")
+    : row.title && row.title !== doc
+      ? row.title
+      : "";
+  const docId = row.document_id ? ` [id: ${row.document_id}]` : "";
+  const chunk = row.chunk_index != null ? ` (chunk ${row.chunk_index})` : "";
+  return `${doc}${section ? ` › ${section}` : ""}${docId}${chunk}`;
+}
+
 /** `## Title [id: …] (score: …) -- 20,297 chars` — everything but the content. */
 function headerLine(row: SearchRow): string {
-  const title = row.doc_title ?? "Untitled";
-  const docId = row.document_id ? ` [id: ${row.document_id}]` : "";
   const raw = row.best_score ?? row.score;
   const score = raw != null ? ` (score: ${raw.toFixed(3)})` : "";
   const size = row.total_chars != null ? ` -- ${row.total_chars.toLocaleString()} chars` : "";
   const hash = row.content_hash ? `\nhash: ${row.content_hash}` : "";
-  return `## ${title}${docId}${score}${size}${hash}`;
+  return `## ${rowHeading(row)}${score}${size}${hash}`;
 }
 
 /**
@@ -251,21 +275,7 @@ async function handler(
   const belowConfidence = rows.length > 0 && rows.every((r) => r.below_confidence === true);
 
   const parts: string[] = rows.map((row) => {
-    // Name the section for a chunk result. The chunk RPCs do NOT dedupe by
-    // document, so several chunks of one document would otherwise arrive as
-    // identical headings with different bodies, and an agent could not tell
-    // which section it got, or that they were one document (#261). Both other
-    // renderers already carry this; the MCP one was the exception.
-    //
-    // `heading_path` starts WITH the document title, so it is dropped here
-    // rather than printed twice. The chunk index disambiguates the case that
-    // is left: several untitled chunks of one document.
-    const doc = row.doc_title ?? "Untitled";
-    const path = (row.heading_path ?? []).filter((h) => h && h !== doc);
-    const section = path.length ? path.join(" › ") : row.title && row.title !== doc ? row.title : "";
-    const title = `${doc}${section ? ` › ${section}` : ""}`;
-    const docId = row.document_id ? ` [id: ${row.document_id}]` : "";
-    const chunk = row.chunk_index != null ? ` (chunk ${row.chunk_index})` : "";
+    const heading = rowHeading(row);
     const rawScore = row.best_score ?? row.score;
     const score = rawScore != null ? ` (score: ${rawScore.toFixed(3)})` : "";
     const partial = row.is_partial
@@ -277,7 +287,7 @@ async function handler(
     // `full_content`; `cerefox_hybrid_search` and `cerefox_fts_search` give
     // `content`, and reading only the first rendered every hybrid/fts result
     // as a title with an empty body.
-    return `## ${title}${docId}${chunk}${score}${partial}${hash}\n\n${rowContent(row)}`;
+    return `## ${heading}${score}${partial}${hash}\n\n${rowContent(row)}`;
   });
 
   let output = parts.join("\n\n---\n\n");
@@ -292,7 +302,9 @@ async function handler(
     // made the footer grow with match_count and overrun the very budget it
     // was reporting on (#257).
     const NAMED = 5;
-    const titles = dropped.slice(0, NAMED).map((r) => (r as SearchRow).doc_title ?? "Untitled");
+    // The section too, for the same reason: five lines of the same document
+    // title tell the caller nothing about what was held back (#261).
+    const titles = dropped.slice(0, NAMED).map((r) => rowHeading(r as SearchRow));
     const rest = dropped.length - titles.length;
     output +=
       `\n\n[${accepted.length} of ${matched.length} result(s) shown; truncated at ` +

--- a/docs/guides/connect-agents.md
+++ b/docs/guides/connect-agents.md
@@ -697,7 +697,10 @@ paths:
                     Response size budget in bytes (server hard ceiling 200000).
                     Whole results are dropped (never truncated mid-document) until
                     the budget is met; the response sets `truncated: true` when this
-                    happens. Advanced; leave unset for the default.
+                    happens. One exception: when nothing fits at all, a single
+                    content-free header is returned even if it exceeds the budget,
+                    because an empty results array would read as "nothing was found"
+                    (see degraded). Advanced; leave unset for the default.
                 author:
                   type: string
                   description: >
@@ -1132,7 +1135,7 @@ If the same content was already ingested (SHA-256 hash match), returns `"skipped
 | `mode` | string | `"docs"` | `"docs"` = full document results (recommended) |
 | `alpha` | number | 0.7 | Semantic weight (0 = FTS only, 1 = semantic only) |
 | `min_score` | number | 0.5 | Minimum cosine similarity threshold |
-| `max_bytes` | number | 200000 | Response size budget in bytes. Results are dropped whole (never truncated mid-document) once the budget is reached. The response includes `truncated: true` and `response_bytes` when the limit was hit. See "Response size limit" below. |
+| `max_bytes` | number | 200000 | Response size budget in bytes. Results are dropped whole (never truncated mid-document) once the budget is reached. The response includes `truncated: true` and `response_bytes` when the limit was hit. When nothing fits, `degraded: true` and a content-free header list come back instead of an empty `results` — always at least one item, even if it exceeds the budget. See "Response size limit" below. |
 
 **Response envelope fields:**
 

--- a/packages/memory/test/edge-functions/edge-functions.test.ts
+++ b/packages/memory/test/edge-functions/edge-functions.test.ts
@@ -397,14 +397,18 @@ describe("Edge Functions (live HTTP)", () => {
       // alone: hybrid and fts return a `content` column, so the degraded
       // response shipped tens of KB of chunk text while claiming content was
       // omitted, against a budget of a few KB.
-      const title = uniqueTitle("Degraded Modes");
-      const r = await invokeOk("cerefox-ingest", {
-        title,
-        content: `# Degraded\n\n${"lorem ipsum dolor sit amet ".repeat(400)}`,
-        author: "e2e-ef-test",
-        author_type: "agent",
-      });
-      track(r.document_id);
+      // TWO oversized fixtures, so `matched >= 2` and the budget assertion
+      // below actually runs: with a single match the list can only ever be
+      // the one-row fallback, which is exempt (#261).
+      for (const n of [1, 2]) {
+        const r = await invokeOk("cerefox-ingest", {
+          title: uniqueTitle(`Degraded Modes ${n}`),
+          content: `# Degraded ${n}\n\n${"lorem ipsum dolor sit amet ".repeat(400)}`,
+          author: "e2e-ef-test",
+          author_type: "agent",
+        });
+        track(r.document_id);
+      }
 
       for (const mode of ["docs", "hybrid", "fts"]) {
         const body = (await invokeOk("cerefox-search", {
@@ -427,10 +431,12 @@ describe("Edge Functions (live HTTP)", () => {
         // exception: a single header is returned even when it does not fit,
         // because an empty `results` is the "nothing was found" shape (#261).
         const listed = body.results ?? [];
+        // Never empty: that is the "nothing was found" shape (#254). Within
+        // budget whenever more than the exempt single fallback row came back.
+        expect(listed.length).toBeGreaterThan(0);
         if (listed.length > 1) {
           expect(JSON.stringify(listed).length).toBeLessThanOrEqual(3000);
         }
-        expect(listed.length).toBeGreaterThan(0);
       }
     });
   });

--- a/packages/memory/test/edge-functions/edge-functions.test.ts
+++ b/packages/memory/test/edge-functions/edge-functions.test.ts
@@ -423,8 +423,14 @@ describe("Edge Functions (live HTTP)", () => {
           expect(row.full_content).toBeUndefined();
           expect(row.content).toBeUndefined();
         }
-        // The answer that explains the budget must itself respect it.
-        expect(JSON.stringify(body.results ?? []).length).toBeLessThanOrEqual(3000);
+        // The answer that explains the budget respects it, with one deliberate
+        // exception: a single header is returned even when it does not fit,
+        // because an empty `results` is the "nothing was found" shape (#261).
+        const listed = body.results ?? [];
+        if (listed.length > 1) {
+          expect(JSON.stringify(listed).length).toBeLessThanOrEqual(3000);
+        }
+        expect(listed.length).toBeGreaterThan(0);
       }
     });
   });

--- a/supabase/functions/cerefox-search/index.ts
+++ b/supabase/functions/cerefox-search/index.ts
@@ -42,8 +42,10 @@ import { applyByteBudget } from "../../../_shared/mcp-tools/_utils.ts";
  * `matched` is how many results the query found, before the byte budget.
  * `degraded` is true when everything that matched was larger than max_bytes:
  * the items then carry NO content, they name what exists so the caller can
- * re-ask with a larger budget. An empty `results` with `degraded: true` is
- * never "nothing was found" — that is `matched: 0` (#254, #257).
+ * re-ask with a larger budget. That header list is capped to max_bytes and so
+ * may be a SUBSET of `matched`, except that one item is always returned even
+ * if it exceeds the budget — an empty `results` would read as "nothing was
+ * found", which is `matched: 0` and nothing else (#254, #257, #261).
  *
  * Example agent prompt:
  *   "Invoke the cerefox-search edge function with query='knowledge management'


### PR DESCRIPTION
Closes #261. The follow-ups from the review of #260. Target: v1.14.3 (hold the cut for this).

## The one that matters

`cerefox_hybrid_search` and `cerefox_fts_search` do not dedupe by document, so several chunks of one document come back as separate results. They rendered as **identical headings with different bodies**, which nobody could see until #259 made the bodies print at all. An agent could not tell which section it received, or that three blocks were one document.

The heading now carries the section path and the chunk index:

```
## Cerefox Implementation Plan › Iteration 23: v0.5.0 … › 23D: Server + ops commands [id: af…] (chunk 7) (score: 3.203)
```

`heading_path` starts **with** the document title, so it is stripped rather than printed twice; an untitled chunk falls back to its index, which is what distinguishes several untitled chunks of one document. The CLI and the web UI already carried this context; the MCP renderer was the only surface dropping it.

## The other four

- **The metadata-search usage row survives a failing fallback probe.** Deferring the log so it could carry the real count meant a rejected probe wrote no usage row at all, making the hardest failure to diagnose the one that leaves no trace.
- **The one-header fallback is documented where it is requested.** It can exceed `max_bytes` on purpose, because an empty `results` reads as "nothing found"; the OpenAPI request-side description and the Edge Function's docblock said otherwise, and the live assertion now allows exactly that one row.
- **A test named "docs mode is unchanged" never ran docs mode**: the shared `args()` helper pins `mode: "fts"` and every other mode needs an embedder, so it re-proved the `fts` branch under a docs-mode name. It asserts the column resolver directly now, both shapes and the precedence between them.
- **`[Unreleased]` has one `### Fixed` heading again.** `cut_release.ts` copies that block verbatim into the annotated tag and the GitHub release, so two headings would have shipped in the release notes.

## Test plan

- [x] `bun run typecheck`; `_shared` **624 pass** (new: a chunk result names its section, the document title is not repeated, an untitled chunk is identified by index, the resolver's precedence)
- [x] Package suite against staging: **313 pass / 2 skip / 0 fail**
- [x] Live EF suite against staging: **23 pass / 0 fail**
- [x] Probed against staging: all three modes render content, and a multi-chunk hit shows distinct section paths

## Release impact

Unchanged: `cerefox self-update` plus `cerefox server deploy --functions-only`. No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013PcVjtEzsfTtAxeayzga5u