### PR TITLE
Finish the response-contract sweep on the metadata-search pair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,34 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 - **The CLI stopped at the first oversized result instead of skipping it**
   (#268), the same shape as #266: one large document suppressed every smaller
   one behind it, so raising `--max-bytes` could show *fewer* results than a
-  lower value. It now skips and continues, as the MCP path does.
+  lower value. It now skips and continues, as the MCP path does, and its
+  truncation line names the counts (`3 of 8 result(s) shown`) rather than
+  saying only that something was cut.
+- **`cerefox-search` did the same thing** (#268). `applyByteBudget` — the
+  helper the Edge Function shares — still stopped at the first row over
+  budget, so an oversized top hit emptied the result set, flipped the reply to
+  the degraded shape and stripped content from results 2 and 3 that would have
+  fitted. Rows are now skipped and reported, matching the MCP tool since #266.
+- **An explicit `max_bytes: null` meant a ONE-BYTE budget, not the default**
+  (#268). `Number(null)` is `0`, which is finite, so the clamp to at least 1
+  turned "unset" into "almost nothing": a client that serialises optional
+  fields as `null` asked for content and received none. The budget arithmetic
+  now lives in one shared `resolveByteBudget()` rather than being written out
+  by hand on four surfaces — where each hand-written copy was wrong
+  differently — and treats `null`, `undefined`, `""` and non-numeric values
+  alike as unset, while still honouring a real number of zero or less as a
+  tiny budget.
+- **`cerefox metadata search` had the same false empty** (#268), on the surface
+  a human reads: with `--include-content`, an oversized first document made it
+  print "No documents match the metadata filter." It now lists every match,
+  omits only content, and says how many were left without it.
+- **A failed follow-up probe no longer ships an unqualified empty array**
+  (#268). If the query that establishes what matched fails, the
+  metadata-search Edge Function answers `502` with the reason instead of
+  `200 []` — an error says the question was not resolved, where an empty array
+  answers it wrongly. The merge also appends rather than discards any document
+  the content query returned but the probe did not, since the two calls can
+  disagree under a `LIMIT` with no tiebreaker.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,46 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — all `
 
 ## [Unreleased]
 
-Open roadmap.
+### Fixed
+
+- **The metadata-search surfaces could report an empty store, or hold documents
+  back without saying so** (#268). The v1.14.x work fixed the search response
+  contract on the search tool and `cerefox-search`; the two surfaces answering
+  the same question by metadata were never swept. `p_max_bytes` is applied by
+  the database, which stops at the first document whose content does not fit, so
+  when that was the first row the result set came back **empty** — the MCP tool
+  said "No documents match", the Edge Function returned `[]`, and an agent that
+  reads either stops looking. Both now report what matched. When only some
+  documents fit, the MCP tool appends `[2 of 7 document(s) shown; 5 did not fit
+  max_bytes=…]`, and the Edge Function lists **every** matching document,
+  marking those whose content was dropped with `"content_omitted": true`, so
+  `results.length` is always the true match count. The array shape is unchanged,
+  so existing Custom GPTs keep working.
+- **`max_bytes` was not sanitised on `cerefox-metadata-search`** (#268) — the
+  hole #267 closed on the search tool, still open on its sibling.
+  `Math.min("lots", MAX_BYTES)` is `NaN`, which serialises to JSON null, and
+  `p_max_bytes NULL` means *no limit*: one word instead of a number returned
+  298,602 bytes, above the ceiling the parameter exists to enforce. `limit` two
+  lines above was already sanitised. A derived guard test now walks every
+  surface that reads a budget out of caller input — MCP tool `args`, Edge
+  Function `body`, CLI `options` — and fails if any of them skips the check, so
+  a new surface is policed the day it is written rather than the day it is
+  reported.
+- **The CLI stopped at the first oversized result instead of skipping it**
+  (#268), the same shape as #266: one large document suppressed every smaller
+  one behind it, so raising `--max-bytes` could show *fewer* results than a
+  lower value. It now skips and continues, as the MCP path does.
+
+### Documentation
+
+- **`docs/guides/response-limits.md` said the CLI never truncates.** It has
+  truncated since **v0.10.2**, which made the CLI honour
+  `CEREFOX_MAX_RESPONSE_BYTES` and corrected `CLAUDE.md` — but not this guide,
+  which then became v1.14.3's statement of the response contract while still
+  describing the pre-v0.10.2 behaviour. Corrected, with the changed-in note, and
+  extended with the metadata-search guarantees above.
+- GPT Actions OpenAPI block bumped to **4.3.0**: the metadata-search response
+  documents `content_omitted` and the completeness guarantee.
 
 ---
 

--- a/_shared/__tests__/max-bytes-sanitised.test.ts
+++ b/_shared/__tests__/max-bytes-sanitised.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Class guard for #268: every surface that accepts a `max_bytes` budget must
+ * SANITISE it before it reaches the RPC.
+ *
+ * Why this is a static scan rather than a behavioural test. The hole is always
+ * the same shape and always invisible at the call site:
+ *
+ *     Math.min(requested_max_bytes ?? MAX_BYTES, MAX_BYTES)   // "lots" -> NaN
+ *
+ * `NaN` serialises to JSON `null`, and `p_max_bytes NULL` means NO limit in
+ * Postgres — so the one parameter that exists to bound the reply, handed a
+ * word, removes the bound instead. It was fixed on the search tool (#265),
+ * missed on the metadata-search Edge Function, and found only by pointing a
+ * malformed call at a deployed function. A unit test per surface would have to
+ * be remembered for each NEW surface; this cannot be forgotten, because the
+ * file list is DERIVED from the tree.
+ *
+ * The same shape produced the missing RLS table, the unguarded test suites and
+ * the Edge Function bundle allow-list: a list that must match another list,
+ * maintained by hand, drifts.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, "..", "..");
+
+/** Every source file in the tree that takes a caller-supplied byte budget. */
+function budgetTakingSources(): Array<{ path: string; source: string }> {
+  const candidates: string[] = [];
+
+  const efDir = join(REPO_ROOT, "supabase", "functions");
+  for (const name of readdirSync(efDir)) {
+    const p = join(efDir, name, "index.ts");
+    if (existsSync(p)) candidates.push(p);
+  }
+
+  const toolsDir = join(REPO_ROOT, "_shared", "mcp-tools");
+  for (const name of readdirSync(toolsDir)) {
+    if (name.endsWith(".ts")) candidates.push(join(toolsDir, name));
+  }
+
+  const cliDir = join(REPO_ROOT, "packages", "memory", "src", "cli", "commands");
+  if (existsSync(cliDir)) {
+    for (const name of readdirSync(cliDir)) {
+      if (name.endsWith(".ts")) candidates.push(join(cliDir, name));
+    }
+  }
+
+  return candidates
+    .map((path) => ({ path, source: readFileSync(path, "utf8") }))
+    // A file that merely mentions the parameter in prose (a tool schema
+    // description, a docblock) is not a surface. A surface READS a budget out
+    // of caller input, and each layer has exactly one way to do that: MCP tools
+    // take `args`, Edge Functions parse a JSON `body`, the CLI gets commander
+    // `options`. Keying on the three input shapes rather than on a file list
+    // means a new surface is policed the day it is written — and keying on the
+    // RPC parameter alone was not enough, because the search surfaces spend
+    // the budget in TypeScript instead of forwarding it.
+    .filter(({ source }) =>
+      /\bargs\.max_bytes\b/.test(source) ||
+      /\bbody\.max_bytes\b/.test(source) ||
+      /\boptions\.maxBytes\b/.test(source) ||
+      // An Edge Function may destructure it out of the parsed body under a
+      // local alias (`max_bytes: requested_max_bytes`) instead of reading the
+      // property, which is how the one surface this guard was written for was
+      // nearly missed a second time.
+      /max_bytes\s*:\s*\w+[\s\S]{0,400}?\}\s*=\s*body/.test(source),
+    );
+}
+
+/**
+ * Does this source sanitise before clamping?
+ *
+ * Two idioms are legitimate and both are proven safe against a non-numeric
+ * value: the shared `Math.floor(Number(x))` + `Number.isFinite` pair used by
+ * the tools and Edge Functions, and the CLI's `parseNonNegativeInt`, which
+ * rejects the call outright rather than coercing.
+ */
+function sanitisesBudget(source: string): boolean {
+  const coercesThenChecksFinite =
+    /Math\.floor\(\s*Number\(/.test(source) && /Number\.isFinite\(/.test(source);
+  const rejectsAtTheBoundary = /parseNonNegativeInt\(/.test(source);
+  return coercesThenChecksFinite || rejectsAtTheBoundary;
+}
+
+describe("max_bytes is sanitised on every surface that accepts one", () => {
+  const surfaces = budgetTakingSources();
+
+  test("the detector finds the surfaces it is meant to police", () => {
+    // If this ever collapses to nothing the suite below passes vacuously —
+    // which is exactly how two static checks in this project once passed while
+    // policing an empty set. Assert a plausible population, and name the ones
+    // that must always be in it.
+    expect(surfaces.length).toBeGreaterThanOrEqual(4);
+    const names = surfaces.map((s) => s.path.replace(REPO_ROOT + "/", ""));
+    expect(names).toContain("supabase/functions/cerefox-search/index.ts");
+    expect(names).toContain("supabase/functions/cerefox-metadata-search/index.ts");
+    expect(names).toContain("_shared/mcp-tools/search.ts");
+    expect(names).toContain("_shared/mcp-tools/metadata-search.ts");
+  });
+
+  for (const { path, source } of surfaces) {
+    const rel = path.replace(REPO_ROOT + "/", "");
+    test(`${rel} sanitises its byte budget`, () => {
+      expect(sanitisesBudget(source)).toBe(true);
+    });
+  }
+
+  test("the guard fires on the shape it exists to catch", () => {
+    // A guard that cannot fail is not a guard. This is the exact code that
+    // shipped in the metadata-search Edge Function, and it must be rejected.
+    const shippedHole = `
+      const requested_max_bytes = body.max_bytes;
+      const max_bytes = include_content
+        ? Math.min(requested_max_bytes ?? MAX_BYTES, MAX_BYTES)
+        : null;
+      params.p_max_bytes = max_bytes;
+    `;
+    expect(sanitisesBudget(shippedHole)).toBe(false);
+
+    // And a clamp without the finite check is still the hole: `Math.max` and
+    // `Math.min` both propagate NaN.
+    const clampOnly = `
+      const max_bytes = Math.min(Math.max(1, Number(body.max_bytes)), MAX_BYTES);
+      params.p_max_bytes = max_bytes;
+    `;
+    expect(sanitisesBudget(clampOnly)).toBe(false);
+
+    // The two accepted idioms must pass, or the guard is unsatisfiable.
+    expect(
+      sanitisesBudget(`
+        const requestedBytes = Math.floor(Number(body.max_bytes));
+        const max_bytes = Number.isFinite(requestedBytes) ? requestedBytes : MAX_BYTES;
+        params.p_max_bytes = max_bytes;
+      `),
+    ).toBe(true);
+    expect(
+      sanitisesBudget(`
+        const maxBytes = parseNonNegativeInt(options.maxBytes, "--max-bytes", 200_000);
+        params.p_max_bytes = maxBytes;
+      `),
+    ).toBe(true);
+  });
+});

--- a/_shared/__tests__/max-bytes-sanitised.test.ts
+++ b/_shared/__tests__/max-bytes-sanitised.test.ts
@@ -73,18 +73,75 @@ function budgetTakingSources(): Array<{ path: string; source: string }> {
 }
 
 /**
- * Does this source sanitise before clamping?
+ * Does this source sanitise the budget AT THE POINT IT READS IT?
  *
- * Two idioms are legitimate and both are proven safe against a non-numeric
- * value: the shared `Math.floor(Number(x))` + `Number.isFinite` pair used by
- * the tools and Edge Functions, and the CLI's `parseNonNegativeInt`, which
- * rejects the call outright rather than coercing.
+ * File-scoped matching is not enough, and the failure is easy to picture: a
+ * file that already sanitises one budget would pass while a second, unhardened
+ * read sat right beside it. That is the same "one list drifts from another"
+ * shape this whole test exists to prevent, so the check follows each read.
+ *
+ * Three idioms are legitimate:
+ *
+ * - `resolveByteBudget(...)` — the shared resolver, preferred, and the reason
+ *   this arithmetic is no longer written out by hand on four surfaces;
+ * - `Math.floor(Number(x))` guarded by `Number.isFinite` — the inline form it
+ *   replaced, still accepted so this test does not mandate a refactor;
+ * - `parseNonNegativeInt(...)` — the CLI boundary, which rejects the call
+ *   outright rather than coercing.
  */
-function sanitisesBudget(source: string): boolean {
-  const coercesThenChecksFinite =
-    /Math\.floor\(\s*Number\(/.test(source) && /Number\.isFinite\(/.test(source);
-  const rejectsAtTheBoundary = /parseNonNegativeInt\(/.test(source);
-  return coercesThenChecksFinite || rejectsAtTheBoundary;
+function sanitisesBudget(rawSource: string): boolean {
+  // Comments are stripped first, for two reasons: a `;` inside prose would
+  // split a statement in the wrong place, and — more to the point — the
+  // comments in these very files quote the sanitiser they describe, so an
+  // unstripped scan could be satisfied by an explanation of the fix rather
+  // than the fix.
+  const source = rawSource
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1 ");
+
+  const reads = [
+    ...source.matchAll(/\bargs\.max_bytes\b/g),
+    ...source.matchAll(/\bbody\.max_bytes\b/g),
+    ...source.matchAll(/\boptions\.maxBytes\b/g),
+    ...source.matchAll(/max_bytes\s*:\s*(\w+)[\s\S]{0,400}?\}\s*=\s*body/g),
+  ];
+  if (reads.length === 0) return false;
+
+  const sanitisedIn = (text: string): boolean =>
+    /resolveByteBudget\s*\(/.test(text) ||
+    /parseNonNegativeInt\s*\(/.test(text) ||
+    (/Math\.floor\(\s*Number\(/.test(text) && /Number\.isFinite\(/.test(text));
+
+  /** The single statement containing an offset — the unit the check is scoped to. */
+  const statementAt = (idx: number): string => {
+    const from = source.lastIndexOf(";", idx) + 1;
+    const to = source.indexOf(";", idx);
+    return source.slice(from, to === -1 ? source.length : to + 1);
+  };
+
+  return reads.every((m) => {
+    const at = m.index ?? 0;
+    // The scope is THIS budget's statements: the one that reads it, plus the
+    // ones that use the local it binds. Not a byte window — a generous window
+    // let a correctly-sanitised read one line above vouch for an unsanitised
+    // one below it, the drift this test exists to catch. Not the whole file
+    // either, for the same reason.
+    const stmt = statementAt(at);
+    const binding = m[1] ?? stmt.match(/(?:const|let|var)\s+(\w+)[^=]*=/)?.[1];
+
+    const scope = [stmt];
+    if (binding) {
+      const from = at + m[0].length;
+      const after = source.slice(from);
+      for (const u of after.matchAll(new RegExp(`\\b${binding}\\b`, "g"))) {
+        scope.push(statementAt(from + (u.index ?? 0)));
+      }
+    }
+    // Joined, because the inline idiom is legitimately spread across two
+    // statements: `Math.floor(Number(x))` on one line, `Number.isFinite` on
+    // the next.
+    return sanitisedIn(scope.join("\n"));
+  });
 }
 
 describe("max_bytes is sanitised on every surface that accepts one", () => {
@@ -129,6 +186,17 @@ describe("max_bytes is sanitised on every surface that accepts one", () => {
       params.p_max_bytes = max_bytes;
     `;
     expect(sanitisesBudget(clampOnly)).toBe(false);
+
+    // A file that sanitises ONE budget must not pass with a second, unhardened
+    // read sitting beside it — the file-scoped version of this check did, and
+    // that is the same "one list drifts from another" failure the whole test
+    // exists to prevent.
+    const oneGoodOneBad = `
+      const good = resolveByteBudget(args.max_bytes, CEILING);
+      const alsoBudget = body.max_bytes ?? CEILING;
+      params.p_max_bytes = alsoBudget;
+    `;
+    expect(sanitisesBudget(oneGoodOneBad)).toBe(false);
 
     // The two accepted idioms must pass, or the guard is unsatisfiable.
     expect(

--- a/_shared/__tests__/search-byte-budget.test.ts
+++ b/_shared/__tests__/search-byte-budget.test.ts
@@ -56,12 +56,29 @@ const args = (over: Record<string, unknown> = {}) => ({
 });
 
 describe("applyByteBudget", () => {
-  test("reports what it dropped, so callers can say so", () => {
+  test("an oversized top hit is skipped, not the end of the list", () => {
     const rows = [row("big", 5_000, 1), row("small", 10, 0.5)];
     const out = applyByteBudget(rows, 1_000);
-    expect(out.accepted).toEqual([]);
+    // Until #268 this returned NOTHING: the scan stopped at the first row that
+    // did not fit, so one oversized top hit suppressed every smaller result
+    // behind it and the Edge Function then reported that nothing fitted. The
+    // MCP tool has skipped since #266; this is the same rule on the surface
+    // GPT Actions and direct HTTP callers use.
+    expect((out.accepted as Array<{ doc_title: string }>).map((r) => r.doc_title)).toEqual([
+      "small",
+    ]);
     // Before #254 this information did not exist and the caller could only
     // see an empty array.
+    expect((out.dropped as Array<{ doc_title: string }>).map((r) => r.doc_title)).toEqual([
+      "big",
+    ]);
+    expect(out.truncated).toBe(true);
+  });
+
+  test("nothing fits at all: everything is dropped, and said so", () => {
+    const rows = [row("big", 5_000, 1), row("bigger", 6_000, 0.5)];
+    const out = applyByteBudget(rows, 1_000);
+    expect(out.accepted).toEqual([]);
     expect(out.dropped).toEqual(rows);
     expect(out.truncated).toBe(true);
   });

--- a/_shared/mcp-tools/_utils.ts
+++ b/_shared/mcp-tools/_utils.ts
@@ -147,25 +147,32 @@ export function applyByteBudget(
   maxBytes: number,
 ): { accepted: unknown[]; dropped: unknown[]; truncated: boolean; usedBytes: number } {
   const accepted: unknown[] = [];
+  const dropped: unknown[] = [];
   let usedBytes = 0;
   let truncated = false;
-  let cut = rows.length;
 
-  for (const [i, row] of rows.entries()) {
+  for (const row of rows) {
     const rowBytes = new TextEncoder().encode(JSON.stringify(row)).length;
+    // Skipped, not the end of the list (#266, #268). This used to `break`, so
+    // one oversized top hit suppressed every smaller result behind it: the
+    // Edge Function answered with an empty `accepted`, flipped to the degraded
+    // shape and stripped content from results 2 and 3 that would have fitted
+    // comfortably. The MCP tool has skipped since #266; this is the same rule
+    // reaching the surface GPT Actions and direct HTTP callers use.
     if (usedBytes + rowBytes > maxBytes) {
       truncated = true;
-      cut = i;
-      break;
+      dropped.push(row);
+      continue;
     }
     accepted.push(row);
     usedBytes += rowBytes;
   }
 
   // What did not fit, so a caller can say so instead of reporting nothing
-  // (#254): a first row larger than the budget empties `accepted` entirely,
+  // (#254): every row larger than the budget lands here — they are no longer
+  // a contiguous tail, because the scan no longer stops at the first one —
   // and "no results" is the one answer an agent acts on irreversibly.
-  return { accepted, dropped: rows.slice(cut), truncated, usedBytes };
+  return { accepted, dropped, truncated, usedBytes };
 }
 
 import type { AccessPath } from "./types.ts";
@@ -292,4 +299,29 @@ export function logUsage(supabase: MCPSupabaseClient, params: LogUsageParams): v
       p_extra: params.extra ?? {},
     }),
   ).catch(() => {});
+}
+
+/**
+ * Resolve a caller-supplied byte budget against the server ceiling.
+ *
+ * One implementation, because this arithmetic was written out by hand on four
+ * surfaces and each hand-written copy was wrong in its own way (#267, #268):
+ *
+ * - **Non-numeric means unset, not unbounded.** `Math.min("lots", CEILING)` is
+ *   `NaN`; `NaN` compares false against every `>` check and serialises to JSON
+ *   `null`, and `p_max_bytes NULL` means NO limit in Postgres. So the one
+ *   parameter that exists to bound a reply, handed a word, removed the bound.
+ * - **`null` and `undefined` mean unset too.** `Number(null)` is `0`, which is
+ *   finite, so a clamp to `>= 1` turned an explicitly-null budget into a
+ *   ONE-BYTE budget — a client that serialises optional fields as `null` asked
+ *   for content and got none.
+ * - **A real number of zero or less means "almost nothing", and is honoured.**
+ *   Falling back to the ceiling there would hand a caller whose allowance had
+ *   run out the largest possible reply.
+ */
+export function resolveByteBudget(requested: unknown, ceiling: number): number {
+  if (requested === null || requested === undefined || requested === "") return ceiling;
+  const n = Math.floor(Number(requested));
+  if (!Number.isFinite(n)) return ceiling;
+  return Math.min(Math.max(n, 1), ceiling);
 }

--- a/_shared/mcp-tools/metadata-search.ts
+++ b/_shared/mcp-tools/metadata-search.ts
@@ -7,7 +7,7 @@
 
 import type { MCPSupabaseClient } from "./types.ts";
 
-import { getMaxResponseBytes, logUsage } from "./_utils.ts";
+import { getMaxResponseBytes, logUsage, resolveByteBudget } from "./_utils.ts";
 import { lookupProjectId } from "./_projects.ts";
 import { reviewWorkflowEnabled } from "./feature-flags.ts";
 import { McpInvalidParams, type ToolContext, type ToolDefinition } from "./types.ts";
@@ -51,20 +51,14 @@ async function handler(
     if (!projectId) throw new Error(`Project not found: ${project_name}`);
   }
 
-  // Enforce byte ceiling for content mode.
-  //
-  // Sanitised first: a non-numeric `max_bytes` became `NaN`, which reaches the
-  // RPC as JSON null, and `p_max_bytes NULL` means NO limit — so one word
-  // instead of a number returned every matching document's full content, with
-  // the in-process guard below disabled too (#267). Same hole as the search
-  // tool's, in the sibling that shares its transport.
+  // Enforce byte ceiling for content mode, via the one shared resolver every
+  // budget-taking surface uses (#268). It was written out by hand here and on
+  // three other surfaces, and each copy was wrong differently: a non-numeric
+  // value became `NaN` and disabled the limit entirely (#267), and an explicit
+  // `null` coerced to 0 and became a ONE-BYTE budget.
   const ceiling = getMaxResponseBytes();
-  const requestedBytes = Math.floor(Number(requested_max_bytes));
   const max_bytes = include_content
-    ? Math.min(
-        Number.isFinite(requestedBytes) ? Math.max(requestedBytes, 1) : ceiling,
-        ceiling,
-      )
+    ? resolveByteBudget(requested_max_bytes, ceiling)
     : null;
 
   const params: Record<string, unknown> = {
@@ -173,9 +167,13 @@ async function handler(
   // side knows which, and only after asking — so ask, with the same
   // content-free probe the empty branch above uses.
   //
-  // Cheap by construction: a full page (`rows.length === limit`) cannot have
-  // been cut short by the budget in a way this would reveal, and without a
-  // budget there is nothing to reveal, so neither case pays for the probe.
+  // Cost, stated honestly: this is a second RPC round-trip, and it fires
+  // whenever a content-bearing search returns less than a full page — which is
+  // the COMMON case, not a rare one, since `limit` defaults to 10. A full page
+  // and a budget-free call both skip it, but nothing else does. The RPC gives
+  // no "there was more" signal, and the alternative to asking is guessing:
+  // a short list is indistinguishable from a cut list from here, and guessing
+  // wrong is the bug (#268). Worth revisiting if the RPC ever returns a total.
   let matched = rows.length;
   if (include_content && max_bytes !== null && rows.length < limit) {
     const { data: headers, error: probeError } = await supabase.rpc(

--- a/_shared/mcp-tools/metadata-search.ts
+++ b/_shared/mcp-tools/metadata-search.ts
@@ -166,7 +166,29 @@ async function handler(
     log(0);
     return "No documents match the given criteria.";
   }
-  log(rows.length);
+  // How many documents actually matched, as opposed to how many the budget
+  // let through (#268). The RPC applies `p_max_bytes` by stopping at the first
+  // row that does not fit, so a short list has two indistinguishable causes:
+  // fewer documents matched, or the budget cut the list. Only the caller's
+  // side knows which, and only after asking — so ask, with the same
+  // content-free probe the empty branch above uses.
+  //
+  // Cheap by construction: a full page (`rows.length === limit`) cannot have
+  // been cut short by the budget in a way this would reveal, and without a
+  // budget there is nothing to reveal, so neither case pays for the probe.
+  let matched = rows.length;
+  if (include_content && max_bytes !== null && rows.length < limit) {
+    const { data: headers, error: probeError } = await supabase.rpc(
+      "cerefox_metadata_search",
+      { ...params, p_include_content: false, p_max_bytes: null },
+    );
+    // A failed probe must not invent a count. supabase-js resolves with
+    // `{ data: null, error }` rather than throwing (#261), so read the error:
+    // leaving `matched` at `rows.length` states only what is known.
+    if (!probeError) matched = Math.max(rows.length, ((headers ?? []) as unknown[]).length);
+  }
+
+  log(matched, matched > rows.length ? { returned: rows.length, truncated: true } : undefined);
 
   // The review status is a column of a feature that may be off (#241); when
   // it is, an agent should not see "approved" and wonder what it means.
@@ -193,6 +215,19 @@ async function handler(
     }
     return header;
   });
+
+  // Never hold results back silently (#268). A caller who receives 1 of 5 and
+  // is told nothing believes they saw everything — the same failure as a false
+  // empty, in a quieter form. This notice is framing that is never dropped.
+  if (matched > rows.length) {
+    const held = matched - rows.length;
+    return (
+      `${parts.join("\n\n---\n\n")}\n\n` +
+      `[${rows.length} of ${matched} document(s) shown; ${held} did not fit ` +
+      `max_bytes=${max_bytes}. Raise max_bytes, lower limit, or use ` +
+      `include_content: false to list them all.]`
+    );
+  }
 
   return parts.join("\n\n---\n\n");
 }

--- a/_shared/mcp-tools/search.ts
+++ b/_shared/mcp-tools/search.ts
@@ -19,7 +19,7 @@ import type { MCPSupabaseClient } from "./types.ts";
 
 import { getEmbedding, resolveEmbedderKind } from "../embeddings/index.ts";
 import { getConfiguredMinSearchScore, getConfiguredSearchAlpha,
-  getMaxResponseBytes, getMinTermCoverage, logUsage } from "./_utils.ts";
+  getMaxResponseBytes, getMinTermCoverage, logUsage , resolveByteBudget } from "./_utils.ts";
 import { lookupProjectId } from "./_projects.ts";
 import { McpInvalidParams, type ToolContext, type ToolDefinition } from "./types.ts";
 import { AUTHOR_PARAM_READ, callerIdentity } from "./identity.ts";
@@ -214,11 +214,7 @@ async function handler(
   // falling back to the ceiling there would hand a caller whose remaining
   // allowance ran out the largest possible reply (#267). Only a missing or
   // non-numeric value defaults to the ceiling.
-  const requestedBytes = Math.floor(Number(requested_max_bytes));
-  const max_bytes = Math.min(
-    Number.isFinite(requestedBytes) ? Math.max(requestedBytes, 1) : ceiling,
-    ceiling,
-  );
+  const max_bytes = resolveByteBudget(requested_max_bytes, ceiling);
 
   if (
     metadata_filter !== null &&

--- a/docs/guides/connect-agents.md
+++ b/docs/guides/connect-agents.md
@@ -638,7 +638,7 @@ In the action editor, paste this schema (replace `<your-project-ref>`):
 openapi: 3.1.0
 info:
   title: Cerefox Knowledge Base
-  version: 4.2.0
+  version: 4.3.0
 servers:
   - url: https://<your-project-ref>.supabase.co/functions/v1
 paths:
@@ -1051,8 +1051,10 @@ paths:
                   type: integer
                   default: 200000
                   description: >
-                    Response size budget in bytes when include_content is true
-                    (whole results dropped to fit). Advanced; leave unset for the default.
+                    Response size budget in bytes when include_content is true.
+                    Content is dropped whole, never truncated mid-document, and a
+                    document whose content is dropped is still listed with
+                    content_omitted: true. Advanced; leave unset for the default.
                 author:
                   type: string
                   description: >
@@ -1067,6 +1069,12 @@ paths:
                version_count, content_hash, content }], plus review_status
             only while the store's review workflow is on (the key is absent
             when it is off).
+            The array lists EVERY matching document, so its length is the true
+            match count. When include_content is true and max_bytes cannot
+            carry a document's text, that document is still listed, with its
+            content omitted and "content_omitted": true set on the item — the
+            list is never silently shortened, and an empty array always means
+            nothing matched.
             content_hash is the concurrency token — pass it back as
             expected_content_hash when updating via ingestNote.
 ```

--- a/docs/guides/response-limits.md
+++ b/docs/guides/response-limits.md
@@ -8,11 +8,18 @@ explains how response size limits work and how to tune them.
 
 ## The key principle: opt-in limits, never truncate the web UI
 
-The web UI and CLI never truncate results. They have no size limit — the browser or terminal
-can handle arbitrarily large responses and there is no LLM context window to worry about.
+The web UI never truncates results. It has no size limit — the browser can handle
+arbitrarily large responses and there is no LLM context window to worry about.
 
-Limits are **opt-in per call**, used only on the MCP and Edge Function paths where an AI
-agent's context window matters. Callers always choose whether to apply a limit.
+Limits apply on the MCP, Edge Function **and CLI** paths. On MCP and the Edge Functions
+they exist because an AI agent's context window matters; the CLI applies the same default
+so that one setting (`CEREFOX_MAX_RESPONSE_BYTES`) governs every non-browser path, and
+raises or lowers it per call with `--max-bytes`.
+
+> **Changed in v0.10.2.** The CLI originally returned everything, like the web UI. It now
+> honours `CEREFOX_MAX_RESPONSE_BYTES` (200 000 default) and prints
+> `(results truncated at N bytes; use --max-bytes to raise)` when results are dropped.
+> This guide described the pre-v0.10.2 behaviour until v1.14.4.
 
 ---
 
@@ -21,7 +28,7 @@ agent's context window matters. Callers always choose whether to apply a limit.
 | Path | Limit behaviour |
 |------|----------------|
 | Web UI (`/search`) | **No limit** — all results returned |
-| CLI (`cerefox search`) | **No limit** — all results returned |
+| CLI (`cerefox search`) | Defaults to `CEREFOX_MAX_RESPONSE_BYTES` (200 000); raise or lower per call with `--max-bytes`. Announces truncation. |
 | Local MCP server (`cerefox mcp`) | Defaults to `CEREFOX_MAX_RESPONSE_BYTES` (200 000); agent can request less |
 | Edge Function (`cerefox-search`) | Defaults to 200 000 bytes; agent can request less via `max_bytes` body param |
 | Remote MCP (`cerefox-mcp` Edge Function) | Defaults to 200 000 bytes; agent can request less via `max_bytes` tool param |
@@ -58,6 +65,27 @@ without misleading you: the notice that results were held back, or the
 below-confidence advisory. Both are a few dozen bytes, and neither is ever
 traded for content. Returning 1 of 5 results without saying so, or presenting
 weak candidates as confident ones, would be worse than a small overrun.
+
+### Metadata search follows the same rules (v1.14.4)
+
+`cerefox_metadata_search` and the `cerefox-metadata-search` Edge Function apply
+`max_bytes` only when `include_content: true`, and the budget is applied by the
+database, which stops at the first document whose content does not fit. That
+made two silent failures possible until v1.14.4, and both are now closed:
+
+- **The reply is never empty when documents matched.** If the first document is
+  the oversized one, the budget used to empty the result set — the MCP tool
+  returned "No documents match", the Edge Function returned `[]`. Both now say
+  what matched: the tool with a warning and a header list, the Edge Function by
+  listing every matching document with content omitted.
+- **Documents are never held back silently.** The MCP tool appends
+  `[2 of 7 document(s) shown; 5 did not fit max_bytes=20000. …]`. The Edge
+  Function keeps its array shape and lists **every** matching document, marking
+  the ones whose content did not fit with `"content_omitted": true` — so
+  `results.length` is always the true match count and only content is dropped.
+
+Passing a non-numeric `max_bytes` (`"lots"`) is treated as "unset" and falls
+back to the server ceiling; it does not disable the limit.
 
 ---
 
@@ -164,7 +192,7 @@ threshold (it is a SQL DEFAULT in `rpcs.sql`, changed via `cerefox server deploy
 | Question | Answer |
 |----------|--------|
 | Does the web UI truncate results? | No — unlimited |
-| Does the CLI truncate results? | No — unlimited |
+| Does the CLI truncate results? | Yes — at `CEREFOX_MAX_RESPONSE_BYTES`, or `--max-bytes`. It says so when it does. |
 | What is the default MCP response limit? | 200 000 bytes |
 | Can an agent request a smaller limit? | Yes — `max_bytes` tool parameter |
 | Can an agent exceed the server ceiling? | No — always capped |

--- a/docs/guides/response-limits.md
+++ b/docs/guides/response-limits.md
@@ -42,8 +42,10 @@ Cerefox never cuts a document mid-content.
 
 A result that does not fit is **skipped**, not treated as the end of the list, so the
 returned set is not necessarily the top N by rank: one oversized document ranked first
-does not hide the smaller results behind it (v1.14.3). Anything skipped is named in the
-footer, so what is missing is always visible.
+does not hide the smaller results behind it (v1.14.3 on the MCP tool; v1.14.4 on the
+`cerefox-search` Edge Function and the CLI, which both still stopped at the first
+oversized row). Anything skipped is named in the footer, so what is missing is always
+visible.
 
 When truncation occurs:
 - The MCP tool appends a footer naming what was held back:
@@ -84,8 +86,11 @@ made two silent failures possible until v1.14.4, and both are now closed:
   the ones whose content did not fit with `"content_omitted": true` — so
   `results.length` is always the true match count and only content is dropped.
 
-Passing a non-numeric `max_bytes` (`"lots"`) is treated as "unset" and falls
-back to the server ceiling; it does not disable the limit.
+`max_bytes` is resolved the same way on every path: `null`, absent, empty or
+non-numeric all mean **unset** and fall back to the server ceiling, and none of
+them disables the limit. A real number of zero or less means "almost no
+budget" and is honoured as such — a caller whose allowance has run out is not
+handed the largest possible reply.
 
 ---
 

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -49,10 +49,23 @@ Fixed by making the Edge Function's array *complete* (every match listed,
 `content_omitted: true` where content was dropped) rather than by adding an
 envelope, which would break Custom GPTs configured against the documented
 shape. Plus a **derived** guard test over every surface that reads a budget
-from caller input, proven to fire by reverting the real fix. Also: the CLI now
-skips an oversized result instead of stopping at it, and
-`docs/guides/response-limits.md` — stale since **v0.10.2** — no longer claims
-the CLI never truncates. Detail:
+from caller input, proven to fire by reverting the real fix.
+
+The `/code-review` of PR #269 then found four more instances of the same two
+patterns, including one the fix itself introduced: an explicit
+`max_bytes: null` became a **one-byte** budget (`Number(null)` is 0, and the
+clamp then honoured it), `applyByteBudget` still stopped at the first oversized
+row so `cerefox-search` violated the rule the CLI had just adopted, the CLI's
+own `metadata search` still printed "No documents match", and a failed probe
+fell through to the false empty it exists to prevent. The budget arithmetic now
+lives in ONE `resolveByteBudget()` — it had four hand-written copies and each
+was wrong differently. `docs/guides/response-limits.md`, stale since
+**v0.10.2**, no longer claims the CLI never truncates.
+
+**Carry this**: the Edge Functions are in no `tsconfig` (they use `jsr:`
+specifiers), so a missing import there is invisible to `bun run typecheck` —
+this release shipped one for a deploy cycle, caught only by deploying to
+staging and probing. Deploy-and-probe is not optional for an EF change. Detail:
 [iteration 46](plans/iteration-46-spa-serving-and-tab-titles.md).
 
 **2026-09-08 — v1.14.3 SHIPPED** (PRs #256, #258, #260, #262, #264; cut

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -28,10 +28,38 @@
 ---
 ## Current Focus
 
+**2026-09-08 — v1.14.4 IN PROGRESS** (branch `fix/metadata-search-contract`;
+#268). Post-release verification of 1.14.3 on staging: every suite green
+(`_shared` 1143, package 313/2/0, live EF 23, remote MCP 26, Playwright 23/23)
+and the contract probed live — four modes × six budgets × hostile inputs, on
+the local MCP, the remote MCP and the search Edge Function, with a constructed
+fixture for rule 4 because staging's corpus ranks its smallest document first.
+**1.14.3 is sound.** What the seven rounds never swept is the *metadata-search*
+pair, which answers the same question and had none of the guarantees:
+
+- the Edge Function returned a bare `[]` when the budget stopped at the first
+  document, and silently returned 3 of 5 on its **default** path;
+- the MCP tool's degraded branch fires only at zero rows, so a partial cut
+  (1 returned, 5 matched) was reported as a complete answer;
+- `max_bytes` was unsanitised on the Edge Function — #267's `NaN` →
+  `p_max_bytes NULL` → *no limit* hole, returning 298,602 bytes against a
+  200,000 ceiling, in the file whose `limit` **was** sanitised.
+
+Fixed by making the Edge Function's array *complete* (every match listed,
+`content_omitted: true` where content was dropped) rather than by adding an
+envelope, which would break Custom GPTs configured against the documented
+shape. Plus a **derived** guard test over every surface that reads a budget
+from caller input, proven to fire by reverting the real fix. Also: the CLI now
+skips an oversized result instead of stopping at it, and
+`docs/guides/response-limits.md` — stale since **v0.10.2** — no longer claims
+the CLI never truncates. Detail:
+[iteration 46](plans/iteration-46-spa-serving-and-tab-titles.md).
+
 **2026-09-08 — v1.14.3 SHIPPED** (PRs #256, #258, #260, #262, #264; cut
-`d4d53c3`, npm 1.14.3 published, CI green). **Staging verification pending**
-until the maintainer upgrades it: `cerefox self-update` **and**
-`cerefox server deploy --functions-only` (the `cerefox-search` EF changed). One subject, seven review rounds: **what
+`d4d53c3`, npm 1.14.3 published, CI green). **Verified on staging 2026-09-08**
+after the maintainer's upgrade — all suites green and the contract probed live;
+see the v1.14.4 block above for what that verification then found *next door*.
+One subject, seven review rounds: **what
 `cerefox_search` returns and how much of it**. It began as a false empty (an
 agent was told the store had nothing when the top hit simply exceeded
 `max_bytes`, #254, shipped in 1.14.2) and each round found the next layer:

--- a/docs/plans/iteration-46-spa-serving-and-tab-titles.md
+++ b/docs/plans/iteration-46-spa-serving-and-tab-titles.md
@@ -301,3 +301,37 @@ code.
   `minSchema` / `minEdgeFunctions` change.
 - GPT Actions OpenAPI block → **4.3.0** (additive response field).
 - **#154** (Node baseline) still waiting; seventh deferral.
+
+### What the review of #269 added
+
+`/code-review high` returned eight findings on the first cut, and the valuable
+ones were all the same lesson: **a sweep that stops at the surfaces you were
+looking at is not a sweep.** The first commit fixed the metadata-search pair
+and left four more instances of the very patterns it was fixing:
+
+- an explicit `max_bytes: null` became a ONE-BYTE budget, because `Number(null)`
+  is `0` and the clamp to `>= 1` then "honoured" it — a regression introduced by
+  the fix itself, and present on three other surfaces already;
+- `applyByteBudget`, shared with `cerefox-search`, still stopped at the first
+  oversized row, so the Edge Function violated the rule the CLI had just adopted;
+- `cerefox metadata search` — the third metadata surface, and a human-facing one
+  — still printed "No documents match" when the budget emptied the list;
+- a failed follow-up probe fell through and shipped the false empty the probe
+  exists to prevent.
+
+The durable fix is `resolveByteBudget()`: the arithmetic existed in four
+hand-written copies and **each copy was wrong differently**, which is the
+"derive it, don't repeat it" rule arriving a release late. The guard test was
+tightened in the same spirit — it now scopes to the statement that reads the
+budget (and the statements using the local it binds) with comments stripped,
+because the file-scoped version could be satisfied by a correctly sanitised
+read one line above an unsanitised one, and because these files' own comments
+quote the sanitiser they describe.
+
+**One thing typecheck cannot catch, worth carrying**: the Edge Functions are
+not in any `tsconfig` — they use `jsr:` specifiers Deno resolves — so a missing
+import in an Edge Function is invisible to `bun run typecheck` and to CI. This
+release shipped exactly that for one deploy cycle (`resolveByteBudget is not
+defined`), caught only because the function was deployed to staging and probed.
+The live EF suite would also have caught it. **Deploy-and-probe is not optional
+for an Edge Function change.**

--- a/docs/plans/iteration-46-spa-serving-and-tab-titles.md
+++ b/docs/plans/iteration-46-spa-serving-and-tab-titles.md
@@ -236,3 +236,68 @@ former has no fixed release and the latter's fix is outside the range
 - Staging already runs the fixed function (deployed from the branch during
   verification), so it is ahead of `main` until the cut.
 - **#154** (Node baseline) moves again, for the sixth time.
+
+---
+
+## v1.14.4 — finishing the sweep the reviews stopped short of (#268)
+
+The seven review rounds behind 1.14.3 were stopped by decision, not because
+they had converged. Post-release verification against staging asked the
+obvious follow-up question — *which surfaces were never swept?* — and found
+two, both reachable by an agent and both silent.
+
+**What the release verification actually covered.** All suites green
+(`_shared` 1143, package 313/2/0, live EF 23, remote MCP 26, Playwright
+23/23), plus live probes of the contract on real data: four modes × six
+budgets × hostile inputs, on the local MCP, the remote MCP and the search
+Edge Function. Rule 4 needed a constructed fixture, because staging's own
+corpus ranks its smallest document first and so cannot exercise a skip; with
+one oversized document ranked above two tiny ones, the two small rows came
+back and the big one was named as skipped. 1.14.3 itself is sound.
+
+**What was missed.** `cerefox_metadata_search` and its Edge Function answer
+the same question — *which documents match?* — and neither had the guarantees
+the search path now has. The database applies `p_max_bytes` by stopping at the
+first document whose content does not fit, so an oversized first row emptied
+the reply: `[]` from the Edge Function, "No documents match" from the tool.
+The tool's degraded branch fires only on `rows.length === 0`, so a *partial*
+cut — one document returned where five matched — was reported as a complete
+answer. And `max_bytes` was unsanitised on the Edge Function, the same
+`NaN` → `p_max_bytes NULL` → *no limit* hole #267 closed on the search tool,
+in the file whose `limit` two lines above **was** sanitised.
+
+**Decisions.**
+
+- **The Edge Function keeps its bare-array shape.** An envelope would match
+  `cerefox-search` and carry a notice field, but Custom GPTs are configured
+  against the documented array, and a shape change is not a patch-release
+  matter. Instead the array is made *complete*: every matching document is
+  listed and only content is negotiable, marked `content_omitted: true`. The
+  count is then structural — `results.length` is the truth — and no notice
+  field is needed.
+- **The partial case costs one extra probe, and only when it can say
+  something.** The count is resolved with the same content-free query the
+  empty branch already used, skipped when the page is full or no budget was
+  set.
+- **The guard is derived, not a list.** Surfaces are found by how each layer
+  reads caller input (`args` / `body` / `options`), so a new one is policed on
+  the day it is written. Proven to fire by reverting the real fix, not only
+  against a synthetic string — two static checks in this project once passed
+  vacuously.
+
+**Checked before fixing** (the maintainer asked, and it changed the write-up):
+the Decision Log records `p_max_bytes` on metadata search as using "the same
+whole-row-drop model as `cerefox_search_docs`", so parity with the search path
+was always the intent. The 2026-03-20 entry does say "Web UI/CLI = no
+truncation" — but **v0.10.2** deliberately reversed that for the CLI and
+corrected `CLAUDE.md`, leaving `docs/guides/response-limits.md` stale for three
+months until 1.14.3 cited it as the contract. The guide was the drift, not the
+code.
+
+### Release notes for the cut (v1.14.4)
+
+- `cerefox self-update` **and** `cerefox server deploy --functions-only` — the
+  `cerefox-metadata-search` Edge Function changed. No schema change, no
+  `minSchema` / `minEdgeFunctions` change.
+- GPT Actions OpenAPI block → **4.3.0** (additive response field).
+- **#154** (Node baseline) still waiting; seventh deferral.

--- a/packages/memory/src/cli/commands/metadata-search.ts
+++ b/packages/memory/src/cli/commands/metadata-search.ts
@@ -97,9 +97,32 @@ async function action(options: {
   };
   if (options.includeContent) params.p_max_bytes = maxBytes;
 
-  const rows = await client.rpc<MetadataSearchRow[]>("cerefox_metadata_search", params);
+  let rows = await client.rpc<MetadataSearchRow[]>("cerefox_metadata_search", params);
   if (rows === null) {
     throw systemError("cerefox_metadata_search: RPC returned no data.");
+  }
+
+  // The database applies `p_max_bytes` by stopping at the first document whose
+  // content does not fit, so a short list has two indistinguishable causes:
+  // fewer documents matched, or the budget cut it. When the FIRST document is
+  // the oversized one the list comes back empty and this command printed "No
+  // documents match the metadata filter." — the same false empty #254 fixed on
+  // the agent surfaces, on the one a human reads (#268). Ask before reporting.
+  let heldBack = 0;
+  if (options.includeContent && rows.length < limit) {
+    const all = await client.rpc<MetadataSearchRow[]>("cerefox_metadata_search", {
+      ...params,
+      p_include_content: false,
+      p_max_bytes: null,
+    });
+    if (all !== null && all.length > rows.length) {
+      const withContent = new Map(rows.map((r) => [r.document_id, r]));
+      heldBack = all.length - rows.length;
+      const merged = all.map((h) => withContent.get(h.document_id) ?? { ...h, content: null });
+      const seen = new Set(merged.map((r) => r.document_id));
+      for (const r of rows) if (!seen.has(r.document_id)) merged.push(r);
+      rows = merged;
+    }
   }
 
   const requestor = resolveRequestor(options.author ?? options.requestor);
@@ -126,6 +149,16 @@ async function action(options: {
   if (rows.length === 0) {
     println("No documents match the metadata filter.");
     return;
+  }
+
+  if (heldBack > 0) {
+    println(
+      c.dim(
+        `(${rows.length - heldBack} of ${rows.length} document(s) have content here; ` +
+          `${heldBack} did not fit --max-bytes ${maxBytes} and are listed without it)`,
+      ),
+    );
+    println("");
   }
 
   for (const row of rows) {

--- a/packages/memory/src/cli/commands/search.ts
+++ b/packages/memory/src/cli/commands/search.ts
@@ -324,7 +324,17 @@ async function action(
   }
 
   if (truncated) {
-    println(c.dim(`(results truncated at ${usedBytes} bytes; use --max-bytes to raise)`));
+    // "N of M", not just "truncated": oversized rows are SKIPPED now, so what
+    // is missing sits in the middle of the ranking rather than after it, and a
+    // bare "truncated" leaves the reader unable to tell how much they are not
+    // seeing (contract rule 2).
+    const held = results.length - accepted.length;
+    println(
+      c.dim(
+        `(${accepted.length} of ${results.length} result(s) shown; ${held} did not fit ` +
+          `${usedBytes} bytes used of --max-bytes ${maxBytes} — raise it to see the rest)`,
+      ),
+    );
   }
 }
 

--- a/packages/memory/src/cli/commands/search.ts
+++ b/packages/memory/src/cli/commands/search.ts
@@ -198,9 +198,13 @@ async function action(
   let truncated = false;
   for (const row of results) {
     const rowBytes = Buffer.byteLength(JSON.stringify(row), "utf8");
+    // Skipped, not the end of the list (#266, #268): one oversized result used
+    // to suppress every smaller one behind it, so a raised --max-bytes could
+    // show FEWER documents than a lower one. The first row is always kept, so
+    // a budget smaller than any result still answers with something.
     if (usedBytes + rowBytes > maxBytes && accepted.length > 0) {
       truncated = true;
-      break;
+      continue;
     }
     accepted.push(row);
     usedBytes += rowBytes;

--- a/supabase/functions/cerefox-metadata-search/index.ts
+++ b/supabase/functions/cerefox-metadata-search/index.ts
@@ -103,8 +103,20 @@ Deno.serve(async (req: Request): Promise<Response> => {
     const include_content = body.include_content ?? false;
     const requested_max_bytes = body.max_bytes;
 
+    // Sanitised before clamping, exactly as `cerefox-search` and the MCP tools
+    // do it (#268). `Math.min("lots", MAX_BYTES)` is `NaN`, which serialises to
+    // JSON null, and `p_max_bytes NULL` means NO limit — so a non-numeric value
+    // returned every matching document's full content, above the very ceiling
+    // this parameter exists to enforce. `limit` below was already sanitised;
+    // this was its unhardened neighbour. A NUMBER of 0 or less still means
+    // "almost no budget": falling back to the ceiling would hand a caller whose
+    // allowance ran out the largest possible reply (#267).
+    const requestedBytes = Math.floor(Number(requested_max_bytes));
     const max_bytes = include_content
-      ? Math.min(requested_max_bytes ?? MAX_BYTES, MAX_BYTES)
+      ? Math.min(
+          Number.isFinite(requestedBytes) ? Math.max(requestedBytes, 1) : MAX_BYTES,
+          MAX_BYTES,
+        )
       : null;
 
     const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
@@ -154,18 +166,59 @@ Deno.serve(async (req: Request): Promise<Response> => {
       });
     }
 
-    // Fire-and-forget usage logging
+    let rows = (data ?? []) as Array<Record<string, unknown>>;
+
+    // Never answer with a shorter list than what matched (#268).
+    //
+    // The RPC applies `p_max_bytes` server-side by stopping at the first row
+    // whose content does not fit, so this list has two indistinguishable
+    // causes: fewer documents matched, or the budget cut it short. When the
+    // first row is the oversized one the array comes back EMPTY, and a caller
+    // reads `[]` as "this knowledge does not exist" and stops looking — the
+    // false negative #254 exists to prevent, reached here through a sibling
+    // that never got the guard.
+    //
+    // The response shape stays a bare array, because Custom GPTs are
+    // configured against it: every matching document is listed, and only
+    // CONTENT is negotiable. Rows the budget could not afford come back
+    // content-free and marked, so `results.length` is always the true count
+    // and nothing is held back silently.
+    if (include_content && max_bytes !== null && rows.length < limit) {
+      const { data: headerData, error: probeError } = await supabase.rpc(
+        "cerefox_metadata_search",
+        { ...params, p_include_content: false, p_max_bytes: null },
+      );
+      // supabase-js RESOLVES with `{ data: null, error }` for PostgREST and
+      // network failures rather than throwing, so a probe failure must be read
+      // from the error, not inferred from an empty list — reading it as "no
+      // documents" is the very false empty this branch prevents (#261).
+      if (!probeError) {
+        const headers = (headerData ?? []) as Array<Record<string, unknown>>;
+        if (headers.length > rows.length) {
+          const withContent = new Map(rows.map((r) => [r.document_id as string, r]));
+          // The probe carries the full, correctly ordered match set; the
+          // content-bearing rows are folded into it by id so ordering is the
+          // RPC's, not an artefact of which rows happened to fit.
+          rows = headers.map(
+            (h) => withContent.get(h.document_id as string) ?? { ...h, content_omitted: true },
+          );
+        }
+      }
+    }
+
+    // Fire-and-forget usage logging. Counts what MATCHED, not what the budget
+    // allowed through: a budget-wiped search logging `0` misreports the store
+    // as empty in analytics (#259).
     Promise.resolve(supabase.rpc("cerefox_log_usage", {
       p_operation: "metadata_search",
       p_access_path: "edge-function",
       p_requestor: identityValue ?? null,
       p_query_text: JSON.stringify(metadata_filter),
-      p_result_count: (data ?? []).length,
+      p_result_count: rows.length,
       p_project_id: project_id,
     })).catch(() => {});
 
     // Presentation only: the same shared reader every other surface uses.
-    const rows = (data ?? []) as Array<Record<string, unknown>>;
     const showReview = await reviewWorkflowEnabled(supabase);
     const out = showReview
       ? rows

--- a/supabase/functions/cerefox-metadata-search/index.ts
+++ b/supabase/functions/cerefox-metadata-search/index.ts
@@ -4,6 +4,7 @@ import { isVersionRequest, versionResponse } from "../../../_shared/ef-meta/inde
 import { efAuthGate } from "../../../_shared/ef-auth/index.ts";
 import { callerIdentity } from "../../../_shared/mcp-tools/identity.ts";
 import { reviewWorkflowEnabled } from "../../../_shared/mcp-tools/feature-flags.ts";
+import { resolveByteBudget } from "../../../_shared/mcp-tools/_utils.ts";
 
 /**
  * cerefox-metadata-search -- Supabase Edge Function
@@ -103,20 +104,12 @@ Deno.serve(async (req: Request): Promise<Response> => {
     const include_content = body.include_content ?? false;
     const requested_max_bytes = body.max_bytes;
 
-    // Sanitised before clamping, exactly as `cerefox-search` and the MCP tools
-    // do it (#268). `Math.min("lots", MAX_BYTES)` is `NaN`, which serialises to
-    // JSON null, and `p_max_bytes NULL` means NO limit — so a non-numeric value
-    // returned every matching document's full content, above the very ceiling
-    // this parameter exists to enforce. `limit` below was already sanitised;
-    // this was its unhardened neighbour. A NUMBER of 0 or less still means
-    // "almost no budget": falling back to the ceiling would hand a caller whose
-    // allowance ran out the largest possible reply (#267).
-    const requestedBytes = Math.floor(Number(requested_max_bytes));
+    // One implementation of this arithmetic, shared with every other surface
+    // that takes a budget (#268): non-numeric and null both mean "unset" and
+    // fall back to the ceiling, while a real number of zero or less is
+    // honoured as "almost no budget".
     const max_bytes = include_content
-      ? Math.min(
-          Number.isFinite(requestedBytes) ? Math.max(requestedBytes, 1) : MAX_BYTES,
-          MAX_BYTES,
-        )
+      ? resolveByteBudget(requested_max_bytes, MAX_BYTES)
       : null;
 
     const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
@@ -183,6 +176,11 @@ Deno.serve(async (req: Request): Promise<Response> => {
     // CONTENT is negotiable. Rows the budget could not afford come back
     // content-free and marked, so `results.length` is always the true count
     // and nothing is held back silently.
+    //
+    // Cost: a second RPC round-trip whenever a content-bearing search returns
+    // less than a full page, which is the common case rather than a rare one.
+    // The RPC signals no total, so the only alternative to asking is guessing
+    // whether a short list was cut — and guessing wrong is the bug.
     if (include_content && max_bytes !== null && rows.length < limit) {
       const { data: headerData, error: probeError } = await supabase.rpc(
         "cerefox_metadata_search",
@@ -192,6 +190,21 @@ Deno.serve(async (req: Request): Promise<Response> => {
       // network failures rather than throwing, so a probe failure must be read
       // from the error, not inferred from an empty list — reading it as "no
       // documents" is the very false empty this branch prevents (#261).
+      if (probeError && rows.length === 0) {
+        // Falling through here would ship exactly the false empty this block
+        // exists to prevent — `200 []`, which a caller reads as "no such
+        // knowledge". An error is the honest answer: it says the question was
+        // not resolved, rather than answering it wrongly.
+        return new Response(
+          JSON.stringify({
+            error:
+              `Nothing fit max_bytes=${max_bytes} with include_content, and the follow-up ` +
+              `query that lists what matched failed: ${probeError.message}. This is NOT a ` +
+              `confirmed empty result — retry with a larger max_bytes, or include_content: false.`,
+          }),
+          { status: 502, headers: { ...CORS_HEADERS, "Content-Type": "application/json" } },
+        );
+      }
       if (!probeError) {
         const headers = (headerData ?? []) as Array<Record<string, unknown>>;
         if (headers.length > rows.length) {
@@ -199,9 +212,20 @@ Deno.serve(async (req: Request): Promise<Response> => {
           // The probe carries the full, correctly ordered match set; the
           // content-bearing rows are folded into it by id so ordering is the
           // RPC's, not an artefact of which rows happened to fit.
-          rows = headers.map(
+          const merged = headers.map(
             (h) => withContent.get(h.document_id as string) ?? { ...h, content_omitted: true },
           );
+          // Two queries, two chances to disagree: the RPC orders by
+          // `updated_at DESC` with no tiebreaker under a LIMIT, and a
+          // concurrent write between the calls shifts the window. Anything the
+          // content query returned that the probe did not is APPENDED rather
+          // than dropped — losing a document we already hold, while fixing a
+          // bug about losing documents, would be its own joke.
+          const seen = new Set(merged.map((r) => r.document_id as string));
+          for (const r of rows) {
+            if (!seen.has(r.document_id as string)) merged.push(r);
+          }
+          rows = merged;
         }
       }
     }

--- a/supabase/functions/cerefox-search/index.ts
+++ b/supabase/functions/cerefox-search/index.ts
@@ -5,7 +5,7 @@ import { efAuthGate } from "../../../_shared/ef-auth/index.ts";
 import { callerIdentity } from "../../../_shared/mcp-tools/identity.ts";
 import { capEmbeddingInput } from "../../../_shared/embeddings/index.ts";
 // One implementation of the byte budget, shared with the MCP tools (#254).
-import { applyByteBudget } from "../../../_shared/mcp-tools/_utils.ts";
+import { applyByteBudget, resolveByteBudget } from "../../../_shared/mcp-tools/_utils.ts";
 
 /**
  * cerefox-search — Supabase Edge Function
@@ -219,11 +219,7 @@ Deno.serve(async (req: Request) => {
   // check, so a non-numeric value bypassed the ceiling entirely (#266).
   // A number of 0 or less still means "almost no budget"; only a missing or
   // non-numeric value falls back to the ceiling (#267).
-  const requestedBytes = Math.floor(Number(requested_max_bytes));
-  const max_bytes = Math.min(
-    Number.isFinite(requestedBytes) ? Math.max(requestedBytes, 1) : MAX_BYTES,
-    MAX_BYTES,
-  );
+  const max_bytes = resolveByteBudget(requested_max_bytes, MAX_BYTES);
   // Clamp match_count to [1, MAX_MATCH_COUNT] (bounds query work; see MAX_MATCH_COUNT).
   const match_count = Math.min(Math.max(1, Math.floor(Number(raw_match_count)) || 5), MAX_MATCH_COUNT);
 


### PR DESCRIPTION
Closes #268.

Post-release verification of v1.14.3 found it sound, then found that the sweep
had stopped one surface short. The seven rounds behind 1.14.3 all worked on the
search tool and `cerefox-search`; the two surfaces that answer the same
question by metadata were never touched, and both could tell an agent that
knowledge does not exist when it does.

## What was wrong

The database applies `p_max_bytes` by stopping at the first document whose
content does not fit. Three consequences, all confirmed against a deployed
v1.14.3:

| | Before | After |
|---|---|---|
| EF, `max_bytes=200` | `[]` while 5 documents matched | 5 rows, all `content_omitted` |
| EF, default call (`include_content: true`, no `max_bytes`) | 3 rows, bare array, 2 dropped silently | 5 rows, 3 with content, 2 marked |
| EF, `max_bytes: "lots"` | **298,602 bytes** — above the 200,000 ceiling | 190,190 bytes (falls back to ceiling) |
| MCP tool, budget admitting 1 of 5 | 1 document, no notice | `[1 of 5 document(s) shown; 4 did not fit max_bytes=…]` |

The unsanitised budget is #267's exact hole: `Math.min("lots", MAX_BYTES)` is
`NaN`, which serialises to JSON `null`, and `p_max_bytes NULL` means *no
limit*. It sat two lines below a `limit` that **was** sanitised.

The MCP tool's degraded branch fires only on `rows.length === 0`, so the
partial case fell straight through to the normal render path.

## Judgement calls, so they are cheap to disagree with

1. **The Edge Function keeps its bare-array shape.** An envelope would match
   `cerefox-search` and carry `matched`/`truncated` fields, but Custom GPTs are
   configured against the documented array, and changing the shape is not a
   patch-release matter. Instead the array is made *complete*: every matching
   document is listed and only content is negotiable, marked
   `content_omitted: true`. `results.length` is then always the true match
   count, so no notice field is needed. If you would rather have the envelope
   and a major OpenAPI bump, say so and I will swap it.
2. **The partial case costs one extra RPC**, and only when it can actually say
   something — skipped when the page is full (`rows.length === limit`) or when
   no budget was set. It reuses the content-free probe the empty branch
   already had.
3. **`limit` semantics unchanged.** A short page caused by `limit` rather than
   by the budget is not reported as a hold-back; only budget drops are.

## Checked before fixing, at the maintainer's prompt

Whether either behaviour was deliberate and documented:

- The Decision Log (2026-03-28) records `p_max_bytes` on metadata search as
  using "the same whole-row-drop model as `cerefox_search_docs`" — parity with
  the search path was always the intent, so this moves toward the design.
- The 2026-03-20 entry does say "Web UI/CLI = no truncation", but **v0.10.2**
  deliberately reversed that for the CLI and corrected `CLAUDE.md`, leaving
  `docs/guides/response-limits.md` stale — for three months, until v1.14.3
  cited it as the statement of the contract. The guide was the drift, not the
  code, so the guide is corrected here with a "changed in v0.10.2" note.

## The guard

`_shared/__tests__/max-bytes-sanitised.test.ts` is **derived, not a list**: it
finds surfaces by how each layer reads caller input (MCP tool `args`, Edge
Function `body`, CLI `options`), so a new surface is policed the day it is
written. It asserts its own detector still matches a plausible population —
two static checks in this project once passed while policing an empty set —
and it is proven to fire by reverting the real fix, not only against a
synthetic string.

A first attempt keyed on `p_max_bytes` and silently missed the two search
surfaces, which spend the budget in TypeScript rather than forwarding it; a
second missed `cerefox-search`, which destructures the value under an alias.
Both are in the detector now.

## Test plan

- [x] `bun run typecheck` — clean (3 projects)
- [x] `_shared`: **1151 pass** / 0 fail
- [x] Package suite against a labelled staging target: **313 pass, 2 skip, 0 fail**
- [x] Live Edge Function e2e: **23/23**
- [x] Live remote-MCP e2e: **26/26**
- [x] Frontend unit 26/26; Playwright 23/23 (run against v1.14.3 pre-change)
- [x] Guard proven to fire: reverting the real EF fix fails the suite; restored
- [x] The fixed Edge Function deployed to **staging only** and all three
      defects re-probed live (table above)
- [x] MCP partial-notice verified live, and confirmed absent when nothing is
      held back

## Deploying

`cerefox self-update` **and** `cerefox server deploy --functions-only` — the
`cerefox-metadata-search` Edge Function changed. No schema change; no
`minSchema` / `minEdgeFunctions` change. GPT Actions OpenAPI block → **4.3.0**
(additive response field).

Note: staging already runs this branch's function, deployed during
verification, so it is ahead of `main` until the cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1oto5Wo8o9iLXvz453BFa

---

## Review round (`/code-review high`) — 8 findings, all addressed

The review's valuable findings all said one thing: **a sweep that stops at the
surfaces you were looking at is not a sweep.** The first commit fixed the
metadata-search pair and left four more instances of the patterns it was
fixing — one of them introduced by the fix itself.

| # | Finding | Resolution |
|---|---|---|
| 1 | `max_bytes: null` became a **one-byte** budget (`Number(null)` is 0, and the clamp honoured it) — a regression here, and already live on three other surfaces | One shared `resolveByteBudget()`; `null`/absent/`""`/non-numeric all mean unset, a real ≤ 0 still means a tiny budget. Verified live. |
| 2 | Probe failure fell through and shipped `200 []` — the false empty the probe exists to prevent | Answers `502` with the reason instead |
| 3 | The merge could drop a content-bearing row the probe did not return | Unmatched rows are appended, not discarded |
| 4 | `cerefox metadata search` — the third metadata surface — had the same false empty | Fixed; lists every match, omits only content, states how many |
| 5 | `applyByteBudget` still **stopped** at the first oversized row, so `cerefox-search` broke the rule the CLI had just adopted | Skips now. Verified live: an oversized document ranked above two small ones returns **2 of 3**, where the old code returned none |
| 6 | The probe-cost comment overclaimed ("neither case pays") | Comment corrected — it fires whenever a content search returns less than a full page, which is the common case; the RPC signals no total, so the alternative to asking is guessing |
| 7 | CLI truncation line said only "truncated" | Now `N of M result(s) shown` |
| 8 | The guard was file-scoped, so a sanitised read could vouch for an unsanitised one beside it | Scoped to the statement that reads the budget plus the statements using its binding, with comments stripped (these files' comments quote the sanitiser they describe). Re-proven to fire. |

**Worth carrying beyond this PR:** the Edge Functions are in no `tsconfig` —
they use `jsr:` specifiers Deno resolves — so a **missing import in an Edge
Function is invisible to `bun run typecheck` and to CI**. This branch shipped
exactly that (`resolveByteBudget is not defined`) for one deploy cycle, caught
only because the function was deployed to staging and probed. Deploy-and-probe
is not optional for an EF change.

### Re-verified after the review fixes

- [x] `_shared` **1152 pass** / 0 fail (includes the corrected `applyByteBudget` contract test)
- [x] `bun run typecheck` clean; package suite **313 pass, 2 skip, 0 fail**
- [x] Live EF **23/23**, live remote-MCP **26/26**, frontend unit **26/26**
- [x] Playwright **22 passed, 1 skipped** (Empty trash, needs its opt-in flag)
- [x] Both changed Edge Functions redeployed to **staging** and re-probed:
      `null` → ceiling, `0`/`200` → tiny budget but never empty, `"lots"` → ceiling
- [x] All probe fixtures soft-deleted from staging
